### PR TITLE
Rename usage tool to list_api_usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,20 @@ pip install yutori-mcp
 
 #### list_scouts
 
-List all scouts for the authenticated user.
+List all scouts for the user (basic metadata only). 
 
 ```json
 {}
+```
+
+#### get_scout_detail
+
+Get detailed information for a specific scout.
+
+```json
+{
+  "scout_id": "abc123-..."
+}
 ```
 
 #### create_scout
@@ -250,7 +260,7 @@ Returns:
 
 ### Account Operations
 
-#### get_usage
+#### list_api_usage
 
 Get usage statistics.
 
@@ -264,7 +274,7 @@ Tools include hints for client behavior:
 
 | Tool | Annotation |
 |------|------------|
-| `list_scouts`, `get_scout_updates`, `get_usage`, `get_browsing_task_result` | `readOnlyHint: true` |
+| `list_scouts`, `get_scout_detail`, `get_scout_updates`, `list_api_usage`, `get_browsing_task_result` | `readOnlyHint: true` |
 | `pause_scout`, `resume_scout`, `complete_scout` | `idempotentHint: true` |
 | `delete_scout` | `destructiveHint: true` |
 

--- a/src/yutori_mcp/client.py
+++ b/src/yutori_mcp/client.py
@@ -53,7 +53,7 @@ class YutoriClient:
     # -------------------------------------------------------------------------
 
     def list_scouts(self) -> dict[str, Any]:
-        """List all scouts for the authenticated user."""
+        """List all scouts for the authenticated user (basic metadata only)."""
         return self._request("GET", "/scouting/tasks")
 
     def create_scout(
@@ -123,6 +123,10 @@ class YutoriClient:
     def delete_scout(self, scout_id: str) -> dict[str, Any]:
         """Permanently delete a scout."""
         return self._request("DELETE", f"/scouting/tasks/{scout_id}")
+
+    def get_scout_detail(self, scout_id: str) -> dict[str, Any]:
+        """Get detailed information for a specific scout."""
+        return self._request("GET", f"/scouting/tasks/{scout_id}")
 
     def get_scout_updates(
         self,

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -26,8 +26,17 @@ TOOLS = [
     # Read operations
     Tool(
         name="list_scouts",
-        description="List all scouts for the authenticated user. Returns scout IDs, queries, and status.",
+        description=(
+            "List all scouts for the authenticated user. "
+            "Returns basic metadata; use get_scout_detail for full fields."
+        ),
         inputSchema={"type": "object", "properties": {}, "required": []},
+        annotations={"readOnlyHint": True},
+    ),
+    Tool(
+        name="get_scout_detail",
+        description="Get detailed information about a specific scout.",
+        inputSchema=ScoutIdInput.model_json_schema(),
         annotations={"readOnlyHint": True},
     ),
     Tool(
@@ -37,8 +46,8 @@ TOOLS = [
         annotations={"readOnlyHint": True},
     ),
     Tool(
-        name="get_usage",
-        description="Get usage statistics for the authenticated API key, including number of active scouts.",
+        name="list_api_usage",
+        description="Get usage statistics for the authenticated API key.",
         inputSchema={"type": "object", "properties": {}, "required": []},
         annotations={"readOnlyHint": True},
     ),
@@ -127,6 +136,9 @@ def _handle_tool(client: YutoriClient, name: str, arguments: dict) -> dict:
         # Read operations
         case "list_scouts":
             return client.list_scouts()
+        case "get_scout_detail":
+            params = ScoutIdInput(**arguments)
+            return client.get_scout_detail(params.scout_id)
         case "get_scout_updates":
             params = GetUpdatesInput(**arguments)
             return client.get_scout_updates(
@@ -134,7 +146,7 @@ def _handle_tool(client: YutoriClient, name: str, arguments: dict) -> dict:
                 cursor=params.cursor,
                 limit=params.limit,
             )
-        case "get_usage":
+        case "list_api_usage":
             return client.get_usage()
 
         # Scout lifecycle


### PR DESCRIPTION
## Summary
- rename the MCP usage tool to `list_api_usage` and adjust descriptions
- document the new tool name and read-only annotation in README

## Testing
- pytest

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a dedicated detail endpoint and aligns usage tooling/naming across server and docs.
> 
> - Add `get_scout_detail` tool (server) and `get_scout_detail` client method; reference from README
> - Rename usage tool from `get_usage` to `list_api_usage` in server and README; update tool annotations table
> - Clarify `list_scouts` as returning basic metadata only (client/server/README)
> - Update tool routing to handle `get_scout_detail` and `list_api_usage` while mapping to existing client `get_usage`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7d7a88f8f42f7caa78b13a3ab5db66a30879949. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->