### PR TITLE
Add manual trigger for PyPI publishing workflow

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,8 +1,9 @@
-name: Publish to PyPI
+name: Publish yutori-mcp to PyPI
 
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary
- rename the publish workflow to clarify it targets yutori-mcp
- add a workflow_dispatch trigger for manual PyPI releases

## Testing
- not run (workflow-only change)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates the GitHub Actions workflow for PyPI publishing.
> 
> - **Rename** workflow to `Publish yutori-mcp to PyPI` for clarity
> - **Add** `workflow_dispatch` trigger to allow manual publishes (in addition to `release: published`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e7040f41a19e79dd193e5c755a90f2a0e1cb7cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->