### PR TITLE
feat: simplify structured output with output_fields parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,29 +278,7 @@ Create a new monitoring scout for continuous web monitoring. Scouts track change
   "user_timezone": "America/Los_Angeles",
   "skip_email": true,
   "webhook_url": "https://example.com/webhook",
-  "task_spec": {
-    "output_schema": {
-      "type": "json",
-      "json_schema": {
-        "type": "object",
-        "properties": {
-          "stories": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "headline": { "type": "string" },
-                "summary": { "type": "string" },
-                "source_url": { "type": "string" }
-              },
-              "required": ["headline", "source_url"]
-            }
-          }
-        },
-        "required": ["stories"]
-      }
-    }
-  }
+  "output_fields": ["headline", "summary", "source_url"]
 }
 ```
 
@@ -324,7 +302,7 @@ First run: 2026-01-07 03:10 UTC
 | `output_interval` | No | Seconds between runs (min: 1800). Default: 86400 |
 | `webhook_url` | No | URL for webhook notifications |
 | `webhook_format` | No | `scout` (default), `slack`, or `zapier` |
-| `task_spec` | No | JSON Schema for structured output |
+| `output_fields` | No | List of field names for structured output as array of objects |
 | `user_timezone` | No | Timezone for scheduling |
 | `skip_email` | No | Skip email notifications |
 | `start_timestamp` | No | ISO timestamp for when monitoring should start |
@@ -385,11 +363,11 @@ Changes applied:
 | `output_interval` | No | Seconds between runs (min 1800) |
 | `webhook_url` | No | Webhook notification URL |
 | `webhook_format` | No | `scout`, `slack`, or `zapier` |
+| `output_fields` | No | List of field names for structured output |
 | `user_timezone` | No | Timezone for scheduling |
 | `user_location` | No | Location for geo-relevant searches |
 | `is_public` | No | Whether results are public |
 | `skip_email` | No | Skip email notifications |
-| `task_spec` | No | JSON Schema for structured output |
 
 #### delete_scout
 
@@ -461,30 +439,7 @@ Execute a one-time deep web research task. The research agent searches, reads, a
   "query": "What are the latest developments in quantum computing from the past week? Include company announcements, research papers, and product releases.",
   "user_timezone": "America/Los_Angeles",
   "webhook_url": "https://example.com/webhook",
-  "task_spec": {
-    "output_schema": {
-      "type": "json",
-      "json_schema": {
-        "type": "object",
-        "properties": {
-          "developments": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "title": { "type": "string" },
-                "summary": { "type": "string" },
-                "source_url": { "type": "string" },
-                "category": { "type": "string", "enum": ["company", "research", "product"] }
-              },
-              "required": ["title", "summary", "source_url"]
-            }
-          }
-        },
-        "required": ["developments"]
-      }
-    }
-  }
+  "output_fields": ["title", "summary", "source_url", "category"]
 }
 ```
 
@@ -505,7 +460,7 @@ Poll with get_research_task_result(task_id="ae27a17c-a4ed-4c69-8b2a-4bec330fc935
 | `query` | Yes | Natural language description of what to research |
 | `user_timezone` | No | Timezone for context. Default: 'America/Los_Angeles' |
 | `user_location` | No | Location for context. Default: 'San Francisco, CA, US' |
-| `task_spec` | No | JSON Schema for structured output |
+| `output_fields` | No | List of field names for structured output as array of objects |
 | `webhook_url` | No | URL for completion notification |
 | `webhook_format` | No | `scout` (default), `slack`, or `zapier` |
 
@@ -573,28 +528,7 @@ Execute a one-time web browsing task using the navigator agent. The agent runs a
   "start_url": "https://yutori.com",
   "max_steps": 75,
   "webhook_url": "https://example.com/webhook",
-  "task_spec": {
-    "output_schema": {
-      "type": "json",
-      "json_schema": {
-        "type": "object",
-        "properties": {
-          "employees": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "properties": {
-                "name": { "type": "string" },
-                "title": { "type": "string" }
-              },
-              "required": ["name", "title"]
-            }
-          }
-        },
-        "required": ["employees"]
-      }
-    }
-  }
+  "output_fields": ["name", "title"]
 }
 ```
 
@@ -615,7 +549,7 @@ Poll with get_browsing_task_result(task_id="54fb19fd-277e-4098-ab72-5a9f8a4347fc
 | `task` | Yes | Natural language instruction for the navigator |
 | `start_url` | Yes | URL where browsing begins |
 | `max_steps` | No | Max browser actions (1-100). Default: 25 |
-| `task_spec` | No | JSON Schema for structured output |
+| `output_fields` | No | List of field names for structured output as array of objects |
 | `webhook_url` | No | URL for completion notification |
 | `webhook_format` | No | `scout` (default) or `slack` |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.1.4"
+version = "0.1.5"
 description = "MCP server for Yutori - web monitoring and browsing automation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -39,9 +39,15 @@ class CreateScoutInput(BaseModel):
         default=None,
         description="Webhook payload format: 'scout' (default), 'slack', or 'zapier'",
     )
-    task_spec: dict[str, Any] | None = Field(
+    output_fields: list[str] | None = Field(
         default=None,
-        description="JSON Schema for structured output format",
+        description=(
+            "Optional: Extract structured data as an array of objects with these field names. "
+            "Example: ['headline', 'summary', 'url']. "
+            "If omitted, returns human-readable text. "
+            "For complex schemas, call the Yutori REST API directly (see example at: "
+            "https://docs.yutori.com/reference/scouts-create#using-scheduling-webhooks-and-a-structured-output-schema)."
+        ),
     )
     user_timezone: str | None = Field(
         default=None,
@@ -93,9 +99,14 @@ class EditScoutInput(BaseModel):
         default=None,
         description="Updated webhook format: 'scout', 'slack', or 'zapier'",
     )
-    task_spec: dict[str, Any] | None = Field(
+    output_fields: list[str] | None = Field(
         default=None,
-        description="Updated JSON Schema for structured output",
+        description=(
+            "Optional: Extract structured data as an array of objects with these field names. "
+            "Example: ['headline', 'summary', 'url']. "
+            "If omitted, returns human-readable text. "
+            "For complex schemas, call the Yutori REST API directly"
+        ),
     )
     skip_email: bool | None = Field(
         default=None,
@@ -123,7 +134,7 @@ class EditScoutInput(BaseModel):
             self.output_interval,
             self.webhook_url,
             self.webhook_format,
-            self.task_spec,
+            self.output_fields,
             self.skip_email,
             self.user_timezone,
             self.user_location,
@@ -201,9 +212,15 @@ class BrowsingTaskInput(BaseModel):
         le=100,
         description="Maximum number of browser actions (1-100). Default: 25",
     )
-    task_spec: dict[str, Any] | None = Field(
+    output_fields: list[str] | None = Field(
         default=None,
-        description="JSON Schema for structured output format",
+        description=(
+            "Optional: Extract structured data as an array of objects with these field names. "
+            "Example: ['name', 'title', 'email']. "
+            "If omitted, returns human-readable text. "
+            "For complex schemas, call the Yutori REST API directly (see example at: "
+            "https://docs.yutori.com/reference/browsing-create#using-webhooks-and-a-structured-output-schema)."
+        ),
     )
     webhook_url: str | None = Field(
         default=None,
@@ -249,9 +266,15 @@ class ResearchTaskInput(BaseModel):
         default=None,
         description="Location for contextual awareness. Format: 'city, region, country'. Default: 'San Francisco, CA, US'",
     )
-    task_spec: dict[str, Any] | None = Field(
+    output_fields: list[str] | None = Field(
         default=None,
-        description="JSON Schema for structured output format",
+        description=(
+            "Optional: Extract structured data as an array of objects with these field names. "
+            "Example: ['title', 'summary', 'source_url']. "
+            "If omitted, returns human-readable text. "
+            "For complex schemas, call the Yutori REST API directly (see example at: "
+            "https://docs.yutori.com/reference/research-create#using-webhooks-and-a-structured-output-schema)."
+        ),
     )
     webhook_url: str | None = Field(
         default=None,

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
@@ -22,6 +23,34 @@ from .schemas import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _output_fields_to_task_spec(output_fields: list[str] | None) -> dict[str, Any] | None:
+    """Convert simple output_fields list to full task_spec JSON Schema.
+
+    Args:
+        output_fields: List of field names, e.g. ['headline', 'summary', 'url']
+
+    Returns:
+        Full task_spec dict for API, or None if output_fields is None.
+    """
+    if output_fields is None:
+        return None
+
+    properties = {field: {"type": "string"} for field in output_fields}
+
+    return {
+        "output_schema": {
+            "type": "json",
+            "json_schema": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": properties,
+                },
+            },
+        },
+    }
 
 # Tool definitions with annotations
 TOOLS = [
@@ -161,7 +190,7 @@ def _handle_tool(client: YutoriClient, name: str, arguments: dict) -> tuple[dict
                 output_interval=params.output_interval,
                 webhook_url=params.webhook_url,
                 webhook_format=params.webhook_format,
-                task_spec=params.task_spec,
+                task_spec=_output_fields_to_task_spec(params.output_fields),
                 user_timezone=params.user_timezone,
                 skip_email=params.skip_email,
                 start_timestamp=params.start_timestamp,
@@ -181,7 +210,7 @@ def _handle_tool(client: YutoriClient, name: str, arguments: dict) -> tuple[dict
                 params.output_interval,
                 params.webhook_url,
                 params.webhook_format,
-                params.task_spec,
+                params.output_fields,
                 params.skip_email,
                 params.user_timezone,
                 params.user_location,
@@ -195,7 +224,7 @@ def _handle_tool(client: YutoriClient, name: str, arguments: dict) -> tuple[dict
                     output_interval=params.output_interval,
                     webhook_url=params.webhook_url,
                     webhook_format=params.webhook_format,
-                    task_spec=params.task_spec,
+                    task_spec=_output_fields_to_task_spec(params.output_fields),
                     skip_email=params.skip_email,
                     user_timezone=params.user_timezone,
                     user_location=params.user_location,
@@ -225,7 +254,7 @@ def _handle_tool(client: YutoriClient, name: str, arguments: dict) -> tuple[dict
                 task=params.task,
                 start_url=params.start_url,
                 max_steps=params.max_steps,
-                task_spec=params.task_spec,
+                task_spec=_output_fields_to_task_spec(params.output_fields),
                 webhook_url=params.webhook_url,
                 webhook_format=params.webhook_format,
             )
@@ -241,7 +270,7 @@ def _handle_tool(client: YutoriClient, name: str, arguments: dict) -> tuple[dict
                 query=params.query,
                 user_timezone=params.user_timezone,
                 user_location=params.user_location,
-                task_spec=params.task_spec,
+                task_spec=_output_fields_to_task_spec(params.output_fields),
                 webhook_url=params.webhook_url,
                 webhook_format=params.webhook_format,
             )

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -52,6 +52,19 @@ class TestCreateScoutInput:
         assert data.user_location == "New York, NY, US"
         assert data.is_public is False
 
+    def test_output_fields(self):
+        """output_fields accepts a list of field names."""
+        data = CreateScoutInput(
+            query="Track AI news",
+            output_fields=["headline", "summary", "url"],
+        )
+        assert data.output_fields == ["headline", "summary", "url"]
+
+    def test_output_fields_optional(self):
+        """output_fields is optional and defaults to None."""
+        data = CreateScoutInput(query="Track AI news")
+        assert data.output_fields is None
+
 
 class TestEditScoutInput:
     def test_scout_id_required(self):
@@ -109,6 +122,14 @@ class TestEditScoutInput:
         assert data.user_location == "San Francisco, CA"
         assert data.is_public is True
 
+    def test_output_fields(self):
+        """output_fields can be updated."""
+        data = EditScoutInput(
+            scout_id="abc-123",
+            output_fields=["title", "description"],
+        )
+        assert data.output_fields == ["title", "description"]
+
 
 class TestBrowsingTaskInput:
     def test_required_fields(self):
@@ -140,6 +161,20 @@ class TestBrowsingTaskInput:
                 start_url="https://example.com",
                 max_steps=150,
             )
+
+    def test_output_fields(self):
+        """output_fields accepts a list of field names."""
+        data = BrowsingTaskInput(
+            task="Extract employee data",
+            start_url="https://example.com/team",
+            output_fields=["name", "title", "email"],
+        )
+        assert data.output_fields == ["name", "title", "email"]
+
+    def test_output_fields_optional(self):
+        """output_fields is optional."""
+        data = BrowsingTaskInput(task="Test", start_url="https://example.com")
+        assert data.output_fields is None
 
 
 class TestScoutIdInput:
@@ -236,15 +271,21 @@ class TestResearchTaskInput:
             query="Research quantum computing developments",
             user_timezone="America/New_York",
             user_location="New York, NY, US",
-            task_spec={"output_schema": {"type": "json", "json_schema": {"type": "object"}}},
+            output_fields=["title", "summary", "source_url"],
             webhook_url="https://example.com/webhook",
             webhook_format="slack",
         )
         assert data.user_timezone == "America/New_York"
         assert data.user_location == "New York, NY, US"
         assert data.webhook_format == "slack"
+        assert data.output_fields == ["title", "summary", "source_url"]
 
     def test_query_required(self):
         """query is required."""
         with pytest.raises(ValidationError):
             ResearchTaskInput()
+
+    def test_output_fields_optional(self):
+        """output_fields is optional."""
+        data = ResearchTaskInput(query="Research AI")
+        assert data.output_fields is None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,63 @@
+"""Tests for server helper functions."""
+
+from yutori_mcp.server import _output_fields_to_task_spec
+
+
+class TestOutputFieldsToTaskSpec:
+    def test_none_returns_none(self):
+        """None input returns None."""
+        assert _output_fields_to_task_spec(None) is None
+
+    def test_empty_list(self):
+        """Empty list produces empty properties."""
+        result = _output_fields_to_task_spec([])
+        assert result == {
+            "output_schema": {
+                "type": "json",
+                "json_schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {},
+                    },
+                },
+            },
+        }
+
+    def test_single_field(self):
+        """Single field is converted correctly."""
+        result = _output_fields_to_task_spec(["headline"])
+        assert result == {
+            "output_schema": {
+                "type": "json",
+                "json_schema": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "headline": {"type": "string"},
+                        },
+                    },
+                },
+            },
+        }
+
+    def test_multiple_fields(self):
+        """Multiple fields are all converted to string properties."""
+        result = _output_fields_to_task_spec(["headline", "summary", "url"])
+        expected_properties = {
+            "headline": {"type": "string"},
+            "summary": {"type": "string"},
+            "url": {"type": "string"},
+        }
+        assert result["output_schema"]["json_schema"]["items"]["properties"] == expected_properties
+
+    def test_output_is_array_type(self):
+        """Output schema is always array type."""
+        result = _output_fields_to_task_spec(["field1"])
+        assert result["output_schema"]["json_schema"]["type"] == "array"
+
+    def test_items_are_objects(self):
+        """Array items are always objects."""
+        result = _output_fields_to_task_spec(["field1"])
+        assert result["output_schema"]["json_schema"]["items"]["type"] == "object"


### PR DESCRIPTION
## Summary

- Replace complex `task_spec` JSON Schema with simple `output_fields` list for LLM-friendly structured output
- MCP layer converts `output_fields` to full JSON Schema before calling the REST API
- Users needing complex schemas can call the API directly

**Before:**
```json
{
  "query": "Track AI news",
  "task_spec": {
    "output_schema": {
      "type": "json",
      "json_schema": {
        "type": "array",
        "items": {
          "type": "object",
          "properties": {
            "headline": {"type": "string"},
            "summary": {"type": "string"}
          }
        }
      }
    }
  }
}
```

**After:**
```json
{
  "query": "Track AI news",
  "output_fields": ["headline", "summary"]
}
```

## Test plan

- [x] All 62 tests pass
- [ ] Verify `output_fields` works with `create_scout`
- [ ] Verify `output_fields` works with `run_research_task`
- [ ] Verify `output_fields` works with `run_browsing_task`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Simplifies structured output across MCP tools by replacing `task_spec` JSON Schema inputs with a simple `output_fields` list, and auto-converting it server-side.
> 
> - Adds `output_fields` to `CreateScoutInput`, `EditScoutInput`, `BrowsingTaskInput`, and `ResearchTaskInput`; removes `task_spec`
> - Implements `_output_fields_to_task_spec` in `server.py` and uses it for `create_scout`, `edit_scout`, `run_browsing_task`, and `run_research_task`
> - Updates README examples and parameter tables to document `output_fields`
> - Adds tests for `output_fields` and new helper (`tests/test_server.py`); updates schema tests; bumps version to `0.1.5`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9042352920d6610028a8714bb780f0f1fc556a58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->