### PR TITLE
feat: simplify JSON Schema types for MCP clients

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.1.5"
+version = "0.1.6"
 description = "MCP server for Yutori - web monitoring and browsing automation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,137 @@
 """Tests for server helper functions."""
 
-from yutori_mcp.server import _output_fields_to_task_spec
+from yutori_mcp.server import _output_fields_to_task_spec, _simplify_schema, _get_simplified_schema
+from yutori_mcp.schemas import ListScoutsInput, CreateScoutInput
+
+
+class TestSimplifySchema:
+    def test_flattens_anyof_with_null(self):
+        """anyOf with null type is flattened to just the non-null type."""
+        schema = {
+            "properties": {
+                "limit": {
+                    "anyOf": [
+                        {"type": "integer", "minimum": 1, "maximum": 100},
+                        {"type": "null"},
+                    ],
+                    "default": 10,
+                    "description": "Max results",
+                }
+            }
+        }
+        result = _simplify_schema(schema)
+        assert result["properties"]["limit"] == {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 100,
+            "default": 10,
+            "description": "Max results",
+        }
+
+    def test_flattens_anyof_with_enum(self):
+        """anyOf with enum and null is flattened correctly."""
+        schema = {
+            "properties": {
+                "status": {
+                    "anyOf": [
+                        {"type": "string", "enum": ["active", "paused", "done"]},
+                        {"type": "null"},
+                    ],
+                    "default": None,
+                }
+            }
+        }
+        result = _simplify_schema(schema)
+        assert result["properties"]["status"] == {
+            "type": "string",
+            "enum": ["active", "paused", "done"],
+            "default": None,
+        }
+
+    def test_preserves_non_anyof_properties(self):
+        """Properties without anyOf are preserved as-is."""
+        schema = {
+            "properties": {
+                "query": {"type": "string", "description": "Search query"},
+            },
+            "required": ["query"],
+        }
+        result = _simplify_schema(schema)
+        assert result == schema
+
+    def test_handles_nested_objects(self):
+        """Recursively simplifies nested objects."""
+        schema = {
+            "properties": {
+                "config": {
+                    "type": "object",
+                    "properties": {
+                        "timeout": {
+                            "anyOf": [{"type": "integer"}, {"type": "null"}],
+                            "default": 30,
+                        }
+                    },
+                }
+            }
+        }
+        result = _simplify_schema(schema)
+        assert result["properties"]["config"]["properties"]["timeout"] == {
+            "type": "integer",
+            "default": 30,
+        }
+
+    def test_handles_arrays(self):
+        """Handles arrays of schemas."""
+        schema = {
+            "items": [
+                {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                {"type": "integer"},
+            ]
+        }
+        result = _simplify_schema(schema)
+        assert result["items"][0] == {"type": "string"}
+        assert result["items"][1] == {"type": "integer"}
+
+    def test_preserves_anyof_without_null(self):
+        """anyOf without null type is preserved."""
+        schema = {
+            "properties": {
+                "value": {
+                    "anyOf": [{"type": "string"}, {"type": "integer"}],
+                }
+            }
+        }
+        result = _simplify_schema(schema)
+        # Should be unchanged since it's not the [type, null] pattern
+        assert result["properties"]["value"]["anyOf"] == [
+            {"type": "string"},
+            {"type": "integer"},
+        ]
+
+
+class TestGetSimplifiedSchema:
+    def test_list_scouts_schema_has_integer_limit(self):
+        """ListScoutsInput.limit should be integer, not anyOf."""
+        schema = _get_simplified_schema(ListScoutsInput)
+        limit_schema = schema["properties"]["limit"]
+        assert limit_schema["type"] == "integer"
+        assert "anyOf" not in limit_schema
+
+    def test_list_scouts_schema_has_string_status(self):
+        """ListScoutsInput.status should be string with enum, not anyOf."""
+        schema = _get_simplified_schema(ListScoutsInput)
+        status_schema = schema["properties"]["status"]
+        assert status_schema["type"] == "string"
+        assert status_schema["enum"] == ["active", "paused", "done"]
+        assert "anyOf" not in status_schema
+
+    def test_create_scout_schema_has_integer_output_interval(self):
+        """CreateScoutInput.output_interval should be integer, not anyOf."""
+        schema = _get_simplified_schema(CreateScoutInput)
+        interval_schema = schema["properties"]["output_interval"]
+        assert interval_schema["type"] == "integer"
+        assert interval_schema["minimum"] == 1800
+        assert "anyOf" not in interval_schema
 
 
 class TestOutputFieldsToTaskSpec:


### PR DESCRIPTION
## Summary

- Add schema simplifier to flatten `anyOf` patterns with null types
- MCP clients now see proper types instead of "unknown"

**Before:**
```
limit: unknown - Maximum number of scouts to return (1-100). Default: 10
status: unknown - Filter by status: 'active', 'paused', or 'done'
```

**After:**
```
limit: integer - Maximum number of scouts to return (1-100). Default: 10
status: string - Filter by status: 'active', 'paused', or 'done'
```

## Technical Details

Pydantic generates `anyOf: [{type: X}, {type: null}]` for optional fields (`int | None`). MCP clients don't always understand this pattern.

The `_simplify_schema()` function:
- Flattens `anyOf: [{actual_type}, {type: null}]` → `{actual_type}`
- Preserves all properties (default, description, minimum, maximum, enum)
- Recursively handles nested objects and arrays
- Preserves non-null `anyOf` patterns (e.g., `string | integer`)

## Test plan

- [x] All 71 tests pass (9 new tests for schema simplifier)
- [ ] Verify MCP clients show proper types after update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves MCP tool input schemas by flattening optional field `anyOf` patterns to concrete types for better client compatibility.
> 
> - Adds `_simplify_schema` and `_get_simplified_schema` to convert Pydantic `anyOf: [type, null]` into a single non-null `type`, preserving metadata
> - Switches all Tool `inputSchema` definitions to use simplified schemas
> - Adds focused tests for schema simplification and model schemas; extends server tests
> - Bumps package version to `0.1.6`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 586b8f909481b9dc98d86f6a4f5d16921603ec17. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->