### PR TITLE
feat: update to simplified output_schema API parameter

### DIFF
--- a/src/yutori_mcp/client.py
+++ b/src/yutori_mcp/client.py
@@ -71,7 +71,7 @@ class YutoriClient:
         output_interval: int | None = None,
         webhook_url: str | None = None,
         webhook_format: str | None = None,
-        task_spec: dict[str, Any] | None = None,
+        output_schema: dict[str, Any] | None = None,
         user_timezone: str | None = None,
         skip_email: bool | None = None,
         start_timestamp: str | None = None,
@@ -86,8 +86,8 @@ class YutoriClient:
             payload["webhook_url"] = webhook_url
         if webhook_format is not None:
             payload["webhook_format"] = webhook_format
-        if task_spec is not None:
-            payload["task_spec"] = task_spec
+        if output_schema is not None:
+            payload["output_schema"] = output_schema
         if user_timezone is not None:
             payload["user_timezone"] = user_timezone
         if skip_email is not None:
@@ -107,7 +107,7 @@ class YutoriClient:
         output_interval: int | None = None,
         webhook_url: str | None = None,
         webhook_format: str | None = None,
-        task_spec: dict[str, Any] | None = None,
+        output_schema: dict[str, Any] | None = None,
         skip_email: bool | None = None,
         user_timezone: str | None = None,
         user_location: str | None = None,
@@ -123,8 +123,8 @@ class YutoriClient:
             payload["webhook_url"] = webhook_url
         if webhook_format is not None:
             payload["webhook_format"] = webhook_format
-        if task_spec is not None:
-            payload["task_spec"] = task_spec
+        if output_schema is not None:
+            payload["output_schema"] = output_schema
         if skip_email is not None:
             payload["skip_email"] = skip_email
         if user_timezone is not None:
@@ -178,7 +178,7 @@ class YutoriClient:
         task: str,
         start_url: str,
         max_steps: int | None = None,
-        task_spec: dict[str, Any] | None = None,
+        output_schema: dict[str, Any] | None = None,
         webhook_url: str | None = None,
         webhook_format: str | None = None,
     ) -> dict[str, Any]:
@@ -186,8 +186,8 @@ class YutoriClient:
         payload: dict[str, Any] = {"task": task, "start_url": start_url}
         if max_steps is not None:
             payload["max_steps"] = max_steps
-        if task_spec is not None:
-            payload["task_spec"] = task_spec
+        if output_schema is not None:
+            payload["output_schema"] = output_schema
         if webhook_url is not None:
             payload["webhook_url"] = webhook_url
         if webhook_format is not None:
@@ -207,7 +207,7 @@ class YutoriClient:
         query: str,
         user_timezone: str | None = None,
         user_location: str | None = None,
-        task_spec: dict[str, Any] | None = None,
+        output_schema: dict[str, Any] | None = None,
         webhook_url: str | None = None,
         webhook_format: str | None = None,
     ) -> dict[str, Any]:
@@ -217,8 +217,8 @@ class YutoriClient:
             payload["user_timezone"] = user_timezone
         if user_location is not None:
             payload["user_location"] = user_location
-        if task_spec is not None:
-            payload["task_spec"] = task_spec
+        if output_schema is not None:
+            payload["output_schema"] = output_schema
         if webhook_url is not None:
             payload["webhook_url"] = webhook_url
         if webhook_format is not None:

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -65,14 +65,14 @@ def _get_simplified_schema(model: type) -> dict[str, Any]:
     return _simplify_schema(model.model_json_schema())
 
 
-def _output_fields_to_task_spec(output_fields: list[str] | None) -> dict[str, Any] | None:
-    """Convert simple output_fields list to full task_spec JSON Schema.
+def _output_fields_to_output_schema(output_fields: list[str] | None) -> dict[str, Any] | None:
+    """Convert simple output_fields list to JSON Schema for output_schema parameter.
 
     Args:
         output_fields: List of field names, e.g. ['headline', 'summary', 'url']
 
     Returns:
-        Full task_spec dict for API, or None if output_fields is None.
+        JSON Schema dict for API output_schema parameter, or None if output_fields is None.
     """
     if output_fields is None:
         return None
@@ -80,15 +80,10 @@ def _output_fields_to_task_spec(output_fields: list[str] | None) -> dict[str, An
     properties = {field: {"type": "string"} for field in output_fields}
 
     return {
-        "output_schema": {
-            "type": "json",
-            "json_schema": {
-                "type": "array",
-                "items": {
-                    "type": "object",
-                    "properties": properties,
-                },
-            },
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": properties,
         },
     }
 
@@ -230,7 +225,7 @@ def _handle_tool(client: YutoriClient, name: str, arguments: dict) -> tuple[dict
                 output_interval=params.output_interval,
                 webhook_url=params.webhook_url,
                 webhook_format=params.webhook_format,
-                task_spec=_output_fields_to_task_spec(params.output_fields),
+                output_schema=_output_fields_to_output_schema(params.output_fields),
                 user_timezone=params.user_timezone,
                 skip_email=params.skip_email,
                 start_timestamp=params.start_timestamp,
@@ -264,7 +259,7 @@ def _handle_tool(client: YutoriClient, name: str, arguments: dict) -> tuple[dict
                     output_interval=params.output_interval,
                     webhook_url=params.webhook_url,
                     webhook_format=params.webhook_format,
-                    task_spec=_output_fields_to_task_spec(params.output_fields),
+                    output_schema=_output_fields_to_output_schema(params.output_fields),
                     skip_email=params.skip_email,
                     user_timezone=params.user_timezone,
                     user_location=params.user_location,
@@ -294,7 +289,7 @@ def _handle_tool(client: YutoriClient, name: str, arguments: dict) -> tuple[dict
                 task=params.task,
                 start_url=params.start_url,
                 max_steps=params.max_steps,
-                task_spec=_output_fields_to_task_spec(params.output_fields),
+                output_schema=_output_fields_to_output_schema(params.output_fields),
                 webhook_url=params.webhook_url,
                 webhook_format=params.webhook_format,
             )
@@ -310,7 +305,7 @@ def _handle_tool(client: YutoriClient, name: str, arguments: dict) -> tuple[dict
                 query=params.query,
                 user_timezone=params.user_timezone,
                 user_location=params.user_location,
-                task_spec=_output_fields_to_task_spec(params.output_fields),
+                output_schema=_output_fields_to_output_schema(params.output_fields),
                 webhook_url=params.webhook_url,
                 webhook_format=params.webhook_format,
             )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,6 +1,6 @@
 """Tests for server helper functions."""
 
-from yutori_mcp.server import _output_fields_to_task_spec, _simplify_schema, _get_simplified_schema
+from yutori_mcp.server import _output_fields_to_output_schema, _simplify_schema, _get_simplified_schema
 from yutori_mcp.schemas import ListScoutsInput, CreateScoutInput
 
 
@@ -134,61 +134,51 @@ class TestGetSimplifiedSchema:
         assert "anyOf" not in interval_schema
 
 
-class TestOutputFieldsToTaskSpec:
+class TestOutputFieldsToOutputSchema:
     def test_none_returns_none(self):
         """None input returns None."""
-        assert _output_fields_to_task_spec(None) is None
+        assert _output_fields_to_output_schema(None) is None
 
     def test_empty_list(self):
         """Empty list produces empty properties."""
-        result = _output_fields_to_task_spec([])
+        result = _output_fields_to_output_schema([])
         assert result == {
-            "output_schema": {
-                "type": "json",
-                "json_schema": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {},
-                    },
-                },
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {},
             },
         }
 
     def test_single_field(self):
         """Single field is converted correctly."""
-        result = _output_fields_to_task_spec(["headline"])
+        result = _output_fields_to_output_schema(["headline"])
         assert result == {
-            "output_schema": {
-                "type": "json",
-                "json_schema": {
-                    "type": "array",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "headline": {"type": "string"},
-                        },
-                    },
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "headline": {"type": "string"},
                 },
             },
         }
 
     def test_multiple_fields(self):
         """Multiple fields are all converted to string properties."""
-        result = _output_fields_to_task_spec(["headline", "summary", "url"])
+        result = _output_fields_to_output_schema(["headline", "summary", "url"])
         expected_properties = {
             "headline": {"type": "string"},
             "summary": {"type": "string"},
             "url": {"type": "string"},
         }
-        assert result["output_schema"]["json_schema"]["items"]["properties"] == expected_properties
+        assert result["items"]["properties"] == expected_properties
 
     def test_output_is_array_type(self):
         """Output schema is always array type."""
-        result = _output_fields_to_task_spec(["field1"])
-        assert result["output_schema"]["json_schema"]["type"] == "array"
+        result = _output_fields_to_output_schema(["field1"])
+        assert result["type"] == "array"
 
     def test_items_are_objects(self):
         """Array items are always objects."""
-        result = _output_fields_to_task_spec(["field1"])
-        assert result["output_schema"]["json_schema"]["items"]["type"] == "object"
+        result = _output_fields_to_output_schema(["field1"])
+        assert result["items"]["type"] == "object"


### PR DESCRIPTION
## Summary

- Updates the MCP client to use the Yutori REST API's simplified `output_schema` parameter
- The API now accepts `output_schema` as a direct JSON Schema instead of the previous nested structure

## Motivation

The Yutori REST API simplified its structured output parameter from a deeply nested format to a direct JSON Schema. This change aligns the MCP server with the current API contract.

**Before (old API):**
```json
{
  "task_spec": {
    "output_schema": {
      "type": "json",
      "json_schema": {
        "type": "array",
        "items": { "type": "object", "properties": {...} }
      }
    }
  }
}
```

**After (new API):**
```json
{
  "output_schema": {
    "type": "array",
    "items": { "type": "object", "properties": {...} }
  }
}
```

## Changes

- Rename `_output_fields_to_task_spec()` → `_output_fields_to_output_schema()`
- Simplify returned schema structure (remove nested wrappers)
- Update client methods to use `output_schema` parameter instead of `task_spec`
- Update tests to match new structure

## Notes

- The MCP tool interface remains unchanged — users still provide the simple `output_fields` list (e.g., `["headline", "summary", "url"]`)
- The MCP server internally converts this to the proper `output_schema` JSON Schema for the API
- This maintains the ergonomic benefit for LLMs calling the tools while aligning with the API

## API Documentation

See the Yutori REST API docs for the current `output_schema` format:
- [Scouts API](https://docs.yutori.com/reference/scouts-create)
- [Browsing API](https://docs.yutori.com/reference/browsing-create)
- [Research API](https://docs.yutori.com/reference/research-create)

## Test plan

- [x] All 71 existing tests pass
- [x] Verified syntax with py_compile

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the request payload contract sent to the Yutori REST API across scouts, browsing, and research; incorrect schema shape/name would break task creation or structured outputs.
> 
> **Overview**
> Updates all task-creation flows to use the REST API’s simplified structured output parameter: replaces the nested `task_spec` wrapper with a direct `output_schema` JSON Schema in `YutoriClient` requests.
> 
> Renames and rewrites the server helper from `_output_fields_to_task_spec` to `_output_fields_to_output_schema`, and wires it through `create_scout`, `edit_scout`, `run_browsing_task`, and `run_research_task`; tests are updated to assert the new schema shape.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 48462299d4923a9c270ddc3b6a3402af064f9bea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->