### PR TITLE
feat: add Claude Code plugin with workflow skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "yutori-plugins",
+  "owner": {
+    "name": "Yutori",
+    "email": "support@yutori.com"
+  },
+  "metadata": {
+    "description": "Official Yutori plugin marketplace for Claude Code",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "yutori",
+      "source": "./",
+      "description": "Web monitoring (Scouts), deep research, and browser automation with workflow skills"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "yutori",
+  "version": "1.0.0",
+  "description": "Web monitoring (Scouts), deep research, and browser automation with workflow skills",
+  "author": {
+    "name": "Yutori",
+    "email": "support@yutori.com",
+    "url": "https://yutori.com"
+  },
+  "homepage": "https://docs.yutori.com",
+  "repository": "https://github.com/yutori-ai/yutori-mcp",
+  "license": "Apache-2.0",
+  "keywords": ["web-monitoring", "scouts", "research", "browser-automation", "mcp"]
+}

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "yutori": {
+      "command": "uvx",
+      "args": ["yutori-mcp"],
+      "env": {
+        "YUTORI_API_KEY": "${YUTORI_API_KEY}"
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -27,6 +27,31 @@ Get your API key from [yutori.com/api](https://yutori.com/api).
 <details open>
 <summary>Claude Code</summary>
 
+**Option 1: Plugin (Recommended)** - Includes MCP tools + workflow skills
+
+```bash
+# Add the Yutori marketplace
+/plugin marketplace add yutori-ai/yutori-mcp
+
+# Install the plugin
+/plugin install yutori@yutori-plugins
+
+# Set your API key
+export YUTORI_API_KEY=yt-your-api-key
+```
+
+This installs both the MCP tools and workflow skills:
+
+| Skill | Description |
+|-------|-------------|
+| `/yutori:scout` | Set up continuous web monitoring with comprehensive queries |
+| `/yutori:research` | Deep web research workflow (async, 5-10 min) |
+| `/yutori:browse` | Browser automation tasks |
+| `/yutori:competitor-watch` | Quick competitor monitoring template |
+| `/yutori:api-monitor` | API/changelog monitoring template |
+
+**Option 2: MCP Only**
+
 ```bash
 claude mcp add --scope user yutori --env YUTORI_API_KEY=yt-your-api-key -- uvx yutori-mcp
 ```

--- a/skills/api-monitor/SKILL.md
+++ b/skills/api-monitor/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: api-monitor
+description: Set up monitoring for API changes, changelogs, or documentation updates. Useful for tracking breaking changes in services you depend on.
+argument-hint: "[service or API name]"
+disable-model-invocation: true
+---
+
+# API & Changelog Monitoring
+
+Set up monitoring for API or service changes.
+
+Create a scout with this query structure:
+
+```
+**Context:** Monitoring API stability and changes for $ARGUMENTS to ensure our integration stays up-to-date.
+
+## What to Monitor
+- **Breaking Changes:** API version changes, deprecated endpoints, removed features
+- **New Features:** New endpoints, parameters, capabilities
+- **Rate Limits & Quotas:** Changes to limits, pricing tier updates
+- **Deprecation Notices:** Sunset timelines, migration guides
+- **Security Updates:** Authentication changes, security advisories
+
+**Sources to check:** Official changelog, documentation, developer blog, GitHub releases, status page, developer Twitter/X account
+
+**Exclusions:** Minor bug fixes, internal refactoring, documentation typos
+
+## Deliverables
+**Frequency:** Every 12 hours
+
+**Output format:**
+1. **URGENT** section for breaking changes (if any)
+2. Table of changes: Date, Type (breaking/feature/deprecation), Description, Migration Required (yes/no), Source Link
+3. Recommended actions for each change
+```
+
+Use `create_scout` with:
+- `query`: The above structured query with $ARGUMENTS replaced
+- `output_interval`: 43200 (every 12 hours)
+
+After creation, explain:
+- Scout will check twice daily for changes
+- Critical for staying ahead of breaking changes
+- Can set up webhook for immediate notifications

--- a/skills/browse/SKILL.md
+++ b/skills/browse/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: browse
+description: Automate browser tasks like form filling, data extraction, or multi-step web workflows. Use when the user needs to interact with websites that require clicking, typing, or navigation.
+argument-hint: "[task description] [starting URL]"
+---
+
+# Browser Automation
+
+Help the user automate browser-based tasks using Yutori's Navigator agent.
+
+## Process
+
+1. **Understand the task**
+   - What website needs to be automated?
+   - What actions are required? (clicking, typing, extracting data)
+   - Does it require login or authentication?
+
+2. **Define the task clearly**
+   - Break complex workflows into clear steps
+   - Specify what data to extract if applicable
+   - Note any buttons or elements to interact with
+
+3. **Start the browsing task**
+   Use `run_browsing_task` with:
+   - `task`: Clear natural language instructions
+   - `start_url`: The URL to begin browsing
+   - `max_steps`: 25 (default) to 100 for complex flows
+   - `output_fields`: For structured data extraction (e.g., ["name", "price", "url"])
+
+4. **Poll for results**
+   - Browsing typically takes 30-120 seconds depending on complexity
+   - Use `get_browsing_task_result` to check status
+   - Poll every 10-15 seconds until complete
+
+5. **Review and validate**
+   - Check the extracted data or confirmation
+   - Verify the task completed as expected
+
+## Task Writing Tips
+
+- Be specific about UI elements: "Click the blue 'Submit' button"
+- Reference visible text when possible
+- For forms, specify which fields get which values
+
+$ARGUMENTS

--- a/skills/competitor-watch/SKILL.md
+++ b/skills/competitor-watch/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: competitor-watch
+description: Quickly set up monitoring for a competitor company. Tracks news, product updates, funding, and public announcements.
+argument-hint: "[competitor name]"
+disable-model-invocation: true
+---
+
+# Competitor Monitoring Setup
+
+Set up comprehensive monitoring for a competitor.
+
+Create a scout with this query structure:
+
+```
+**Context:** Monitoring competitive intelligence for $ARGUMENTS
+
+## What to Monitor
+- **News & Announcements:** Press releases, media coverage, blog posts
+- **Product Updates:** New features, pricing changes, product launches
+- **Funding & Business:** Funding rounds, acquisitions, partnerships, executive changes
+- **Public Communications:** Social media announcements, conference talks, webinars
+
+**Sources to check:** TechCrunch, company blog, LinkedIn, Twitter/X, Crunchbase, press releases
+
+**Exclusions:** Job postings (unless executive level), routine social media, unverified rumors
+
+## Deliverables
+**Frequency:** Daily
+
+**Output format:**
+1. Summary of significant developments (if any)
+2. Table of news items with: Date, Headline, Category, Source Link
+3. Analysis of competitive implications
+```
+
+Use `create_scout` with:
+- `query`: The above structured query with $ARGUMENTS replaced
+- `output_interval`: 86400 (daily)
+
+After creation, inform the user:
+- Scout will run daily and email results
+- They can check updates anytime with `get_scout_updates`
+- They can pause/resume with `edit_scout`

--- a/skills/research/SKILL.md
+++ b/skills/research/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: research
+description: Execute deep web research on any topic using Yutori's research agents. Use for competitive analysis, market research, finding documentation, or answering complex questions that require synthesizing information from multiple sources.
+argument-hint: "[research question]"
+---
+
+# Deep Web Research
+
+Help the user conduct thorough web research using Yutori's Research API.
+
+## Process
+
+1. **Understand the research goal**
+   - What question needs answering?
+   - What type of sources matter? (news, academic, documentation, social, financial filings)
+   - Any time constraints? (recent only, historical)
+   - What format should the output be in?
+
+2. **Craft the research query**
+   Similar to scout queries, comprehensive research queries include:
+   - Context on why this research matters
+   - Specific questions to answer
+   - Sources to prioritize
+   - Output format expectations
+
+3. **Start the research task**
+   Use `run_research_task` with:
+   - `query`: The research question with context
+   - `user_timezone`: For time-relevant searches
+   - `output_fields`: If structured output is needed (e.g., ["title", "summary", "source_url", "date"])
+
+4. **Poll for results**
+   - **Important:** Research typically takes 5-10 minutes (300-600 seconds)
+   - Use `get_research_task_result` to check status
+   - Poll every 30 seconds until `succeeded` or `failed`
+   - The task runs asynchronously - you can inform the user to wait
+
+5. **Synthesize and present findings**
+   - Organize results by relevance
+   - Highlight key insights
+   - Note sources for verification
+
+$ARGUMENTS

--- a/skills/scout/SKILL.md
+++ b/skills/scout/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: scout
+description: Set up continuous web monitoring with Yutori Scouts. Use when the user wants to track news, competitors, product updates, funding rounds, price changes, or any recurring web information.
+argument-hint: "[topic or monitoring goal]"
+---
+
+# Scout Setup
+
+Help the user set up a Yutori Scout for continuous web monitoring.
+
+## Process
+
+1. **Understand the monitoring context**
+   Ask about:
+   - Who is monitoring and why? (e.g., "We're a fintech looking for recently funded startups")
+   - What specific information matters? (funding events, product launches, pricing changes)
+   - What geography or market segments?
+   - How often should it run? (daily, twice daily)
+   - Notification preference: email, webhook, or both?
+
+2. **Craft a comprehensive query**
+
+   A well-structured scout query includes:
+
+   **Context on the monitoring goal:**
+   - Who is doing the monitoring and what's the use case
+   - What decisions this information supports
+
+   **What to Monitor:**
+   - Specific events/triggers to track
+   - Data sources to check (news sites, SEC filings, social media, etc.)
+   - Geographic or segment focus
+   - Exclusion criteria (what NOT to report)
+
+   **Deliverables:**
+   - Frequency of reports
+   - Output format (tables, narrative, both)
+   - Required fields and citations
+
+   **Example structure:**
+   ```
+   **Context:** [Who is monitoring and why]
+
+   ## What to Monitor
+   - [Specific events to track]
+   - [Sources to check]
+   - [Exclusions]
+
+   ## Deliverables
+   - [Output format]
+   - [Required fields]
+   ```
+
+3. **Create the scout**
+   Use the `create_scout` tool with:
+   - `query`: The comprehensive monitoring query
+   - `output_interval`: 86400 (daily), 43200 (twice daily), or 1800 (minimum, every 30 min)
+   - `webhook_url` and `webhook_format` if they want webhook notifications
+   - `skip_email: true` if they only want webhooks
+   - `output_fields`: For structured data extraction (e.g., ["company", "amount", "round_type", "source_url"])
+
+4. **Provide next steps**
+   - Share the scout ID for future management
+   - Explain how to pause/resume with `edit_scout`
+   - Mention they can get updates with `get_scout_updates`
+
+## Query Quality Tips
+
+**Good queries:**
+- Provide context on who is monitoring and why
+- Specify exact events/triggers (not just "news about X")
+- List data sources to check
+- Include exclusion criteria
+- Define output format expectations
+- Request citations and source links
+
+**Avoid:**
+- Vague queries like "monitor competitor X"
+- Missing context about the monitoring goal
+- No output format specification
+
+$ARGUMENTS


### PR DESCRIPTION
## Summary

Transform `yutori-mcp` into a Claude Code plugin that bundles both the existing MCP server **and** new workflow skills. This provides a unified installation experience where users get the MCP tools AND workflow guidance in one command.

**Target Developer Experience:**
```bash
# Add the marketplace
/plugin marketplace add yutori-ai/yutori-mcp

# Install the plugin (includes MCP server + skills)
/plugin install yutori@yutori-plugins
```

## Understanding: Skills vs MCP Tools

| Aspect | MCP Tools (existing) | Skills (new) |
|--------|---------------------|--------------|
| **What they do** | Provide API capabilities (create scout, run research, etc.) | Guide how to use those capabilities effectively |
| **Invocation** | Claude calls them like function calls | User invokes with `/skill-name` or Claude invokes contextually |
| **Value** | Raw functionality | Workflow patterns, best practices, templates |

**Key insight:** Skills don't duplicate MCP tools—they orchestrate them. A `/yutori:scout` skill teaches Claude the best workflow for setting up monitoring, using the existing `create_scout` MCP tool under the hood.

## Files Added

### Plugin Configuration
- **`.claude-plugin/plugin.json`** - Plugin manifest (name: `yutori`)
- **`.claude-plugin/marketplace.json`** - Self-contained marketplace (name: `yutori-plugins`)
- **`.mcp.json`** - Bundled MCP server configuration

### Skills (5 total)
| Skill | File | Description |
|-------|------|-------------|
| `/yutori:scout` | `skills/scout/SKILL.md` | Guide for setting up continuous monitoring with comprehensive queries |
| `/yutori:research` | `skills/research/SKILL.md` | Deep web research workflow (async, 5-10 min polling) |
| `/yutori:browse` | `skills/browse/SKILL.md` | Browser automation workflow |
| `/yutori:competitor-watch` | `skills/competitor-watch/SKILL.md` | Quick competitor monitoring template |
| `/yutori:api-monitor` | `skills/api-monitor/SKILL.md` | API/changelog monitoring template |

### README Updates
- Added plugin installation as Option 1 (Recommended) in the Claude Code section
- Kept existing MCP-only installation as Option 2
- Documented available skills

## Why Skills Add Value

Skills complement MCP tools by:
1. **Teaching best practices for query writing** - The scout skill guides users to write comprehensive queries with context, monitoring criteria, and deliverables
2. **Providing templates** - competitor-watch and api-monitor give users ready-to-use query structures
3. **Guiding async workflows** - Research takes 5-10 min; the skill sets expectations and guides polling intervals

## Backward Compatibility

Existing installation methods (uvx, pip, manual MCP config) continue to work unchanged. The plugin is an additional, improved installation path for Claude Code users.

## Test Plan

- [x] All 71 existing tests pass (`pytest -v`)
- [x] JSON files validated (plugin.json, marketplace.json, .mcp.json)
- [x] SKILL.md YAML frontmatter validated for all 5 skills
- [ ] Manual test: `claude --plugin-dir ./` to verify skills appear
- [ ] Manual test: Invoke `/yutori:scout` and verify workflow guidance
- [ ] Manual test: Verify MCP tools still function after plugin load

## Linear

Closes ENG-3412

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds Claude Code plugin/marketplace metadata, an MCP config file, and documentation/workflow skill guides; it does not change runtime server/tooling code paths.
> 
> **Overview**
> Adds a Claude Code **plugin distribution** for `yutori-mcp`, including `.claude-plugin/plugin.json`, a self-contained `.claude-plugin/marketplace.json`, and a bundled `.mcp.json` pointing to `uvx yutori-mcp` with `YUTORI_API_KEY` passthrough.
> 
> Introduces five new **workflow skills** (`scout`, `research`, `browse`, `competitor-watch`, `api-monitor`) as `SKILL.md` templates that guide how to invoke existing MCP tools, and updates the `README.md` to document plugin install steps and list the available skills alongside the existing MCP-only setup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9daed2cddd9fd3bd12679564f0f5bebec51aa16. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->