### PR TITLE
Update README and add TOOLS documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,19 @@
-# Yutori MCP Server & Plugin
+# Yutori MCP Server / Plugin / Skills
 
-An MCP server and Claude Code plugin for [Yutori](https://yutori.com) - web monitoring and browsing automation.
+An MCP server and skills for [Yutori](https://yutori.com/api) — web monitoring and browsing automation.
 
+You can use it with Claude Code, Cursor, VS Code, ChatGPT, Codex, OpenClaw, and other MCP hosts.
 
 ## Features
 
-- **Scouts**: Create agents that that monitor the web for anything you care about at a desired frequency
+- **Scouts**: Create agents that monitor the web for anything you care about at a desired frequency
 - **Research**: Execute one-time deep web research tasks
-- **Browsing**: Execute one-time web browsing tasks using an AI website navigator (or a browser-use AI agent)
+- **Browsing**: Execute one-time web browsing tasks using an AI website navigator
+- **Skills**: Workflow templates (competitor watch, API/changelog monitoring) for clients that support them
 
 ## Installation
 
+### Requirements
 If you don't already have `uv` installed, install it (it includes `uvx`):
 
 ```bash
@@ -23,28 +26,58 @@ Or with Homebrew:
 brew install uv
 ```
 
-### Authenticate
 
-Run this once to install and log in to your Yutori account:
 
-```bash
-uvx yutori-mcp login
-```
+For the quickstart below, Node.js is also required (for `npx`).
 
-This opens your browser, authenticates with Yutori, and saves an API key locally (`~/.yutori/config.json`). All platforms below will use this saved key automatically.
+### Quickstart
 
-### Choose your platform
+1. Grab your API key. Enter
 
-<details open>
+    ```bash
+    uvx yutori-mcp login
+    ```
+
+    to get your setup automatically.
+
+
+    Or add your API key to your shell profile (once):
+   ```bash
+   echo 'export YUTORI_API_KEY=yt-your-api-key' >> ~/.zshrc
+   source ~/.zshrc
+   ```
+
+
+   If you manually add the key, you will have to install the mcp in Claude Code and Codex!
+
+
+
+2. Install MCP and skills for your tools via [skills.sh](https://skills.sh):
+   ```bash
+   npx skills add yutori-ai/yutori-mcp
+   ```
+   When prompted, choose which skills to install and which tools (e.g. Claude Code, OpenClaw, Codex).
+
+### Per-client setup
+
+<details>
 <summary>Claude Code</summary>
 
 1. **Plugin (Recommended)** - Includes MCP tools + workflow skills
 
-   Run these commands inside Claude Code:
+   First, add your API key to your shell profile (only needed once):
+   ```bash
+   echo 'export YUTORI_API_KEY=yt-your-api-key' >> ~/.zshrc
+   source ~/.zshrc
+   ```
+
+   Then run these commands inside Claude Code:
    ```
    /plugin marketplace add yutori-ai/yutori-mcp
    /plugin install yutori@yutori-plugins
    ```
+
+   This installs both the MCP tools and workflow skills:
 
    | Skill | Description |
    |-------|-------------|
@@ -63,11 +96,6 @@ This opens your browser, authenticates with Yutori, and saves an API key locally
 2. **MCP Only** (if you prefer not to use the plugin)
 
    ```bash
-   claude mcp add --scope user yutori -- uvx yutori-mcp
-   ```
-
-   Or pass your API key explicitly instead of logging in:
-   ```bash
    claude mcp add --scope user yutori --env YUTORI_API_KEY=yt-your-api-key -- uvx yutori-mcp
    ```
 </details>
@@ -76,19 +104,6 @@ This opens your browser, authenticates with Yutori, and saves an API key locally
 <summary>Claude Desktop</summary>
 
 Add to your `claude_desktop_config.json`:
-
-```json
-{
-  "mcpServers": {
-    "yutori": {
-      "command": "uvx",
-      "args": ["yutori-mcp"]
-    }
-  }
-}
-```
-
-Or pass your API key explicitly via env var:
 
 ```json
 {
@@ -114,6 +129,12 @@ For setup details, see the [Claude Desktop MCP install guide](https://modelconte
 
 [<img src="https://cursor.com/deeplink/mcp-install-dark.svg" alt="Install in Cursor">](https://cursor.com/en/install-mcp?name=Yutori&config=eyJjb21tYW5kIjoidXZ4IHl1dG9yaS1tY3AifQ%3D%3D)
 
+The Cursor install button does not support env vars, so you must set `YUTORI_API_KEY` manually after install.
+
+Set `YUTORI_API_KEY` in the server env settings (Cursor Settings → MCP), then restart the server.
+
+![Cursor MCP server env settings](images/cursor-mcp-settings.png)
+
 **Or install manually:**
 
 Go to Cursor Settings → MCP → Add new MCP Server, then add:
@@ -123,7 +144,10 @@ Go to Cursor Settings → MCP → Add new MCP Server, then add:
   "mcpServers": {
     "yutori": {
       "command": "uvx",
-      "args": ["yutori-mcp"]
+      "args": ["yutori-mcp"],
+      "env": {
+        "YUTORI_API_KEY": "yt-your-api-key"
+      }
     }
   }
 }
@@ -139,10 +163,12 @@ See the [Cursor MCP guide](https://cursor.com/docs/context/mcp) for setup detail
 
 [<img src="https://img.shields.io/badge/VS_Code-VS_Code?style=flat-square&label=Install%20Server&color=0098FF" alt="Install in VS Code">](https://insiders.vscode.dev/redirect?url=vscode%3Amcp%2Finstall%3F%257B%2522name%2522%253A%2522yutori%2522%252C%2522command%2522%253A%2522uvx%2522%252C%2522args%2522%253A%255B%2522yutori-mcp%2522%255D%257D) [<img alt="Install in VS Code Insiders" src="https://img.shields.io/badge/VS_Code_Insiders-VS_Code_Insiders?style=flat-square&label=Install%20Server&color=24bfa5">](https://insiders.vscode.dev/redirect?url=vscode-insiders%3Amcp%2Finstall%3F%257B%2522name%2522%253A%2522yutori%2522%252C%2522command%2522%253A%2522uvx%2522%252C%2522args%2522%253A%255B%2522yutori-mcp%2522%255D%257D)
 
+Set `YUTORI_API_KEY` in your environment before first use.
+
 **Or install manually:**
 
 ```bash
-code --add-mcp '{"name":"yutori","command":"uvx","args":["yutori-mcp"]}'
+code --add-mcp '{"name":"yutori","command":"uvx","args":["yutori-mcp"],"envFile":"path/to/.env"}'
 ```
 </details>
 
@@ -156,7 +182,10 @@ Open ChatGPT Desktop and go to Settings -> Connectors -> MCP Servers -> Add serv
   "mcpServers": {
     "yutori": {
       "command": "uvx",
-      "args": ["yutori-mcp"]
+      "args": ["yutori-mcp"],
+      "env": {
+        "YUTORI_API_KEY": "yt-your-api-key"
+      }
     }
   }
 }
@@ -165,13 +194,13 @@ Open ChatGPT Desktop and go to Settings -> Connectors -> MCP Servers -> Add serv
 For setup details, see the [OpenAI MCP guide](https://platform.openai.com/docs/mcp).
 </details>
 
-<details open>
+<details>
 <summary>Codex</summary>
 
 1. **MCP Server:**
 
    ```bash
-   codex mcp add yutori -- uvx yutori-mcp
+   codex mcp add yutori --env YUTORI_API_KEY=yt-your-api-key -- uvx yutori-mcp
    ```
 
    Or add to `~/.codex/config.toml`:
@@ -180,6 +209,9 @@ For setup details, see the [OpenAI MCP guide](https://platform.openai.com/docs/m
    [mcp_servers.yutori]
    command = "uvx"
    args = ["yutori-mcp"]
+
+   [mcp_servers.yutori.env]
+   YUTORI_API_KEY = "yt-your-api-key"
    ```
 
 2. **Skills** (optional, for workflow guidance):
@@ -215,30 +247,53 @@ For setup details, see the [OpenAI MCP guide](https://platform.openai.com/docs/m
 </details>
 
 <details>
+<summary>OpenClaw</summary>
+
+Follow the **Quickstart** above:
+
+1. Add your API key to your shell profile (only needed once):
+   ```bash
+   echo 'export YUTORI_API_KEY=yt-your-api-key' >> ~/.zshrc
+   source ~/.zshrc
+   ```
+
+2. Install skills and MCP for OpenClaw (and optionally other tools) via [skills.sh](https://skills.sh):
+   ```bash
+   npx skills add yutori-ai/yutori-mcp
+   ```
+   When prompted, choose which Yutori skills to install and select **OpenClaw** as the tool.
+
+</details>
+
+<details>
 <summary>Gemini CLI</summary>
 
-Add to `~/.gemini/settings.json`:
+Add to `~/.gemini/settings.json`. If you already have `mcp` or `mcpServers`, merge these keys into your existing config:
 
 ```json
-{ ...file contains other config objects
+{
   "mcp": {
-    "allowed": ["yutori", "...other MCPs you already allow..."]
+    "allowed": ["yutori"]
   },
-  ...file contains other config objects
   "mcpServers": {
     "yutori": {
       "command": "uvx",
-      "args": ["yutori-mcp"]
+      "args": ["yutori-mcp"],
+      "env": {
+        "YUTORI_API_KEY": "yt-your-api-key"
+      }
     }
   }
 }
 ```
 
-For more details, see the [Gemini CLI MCP settings guide](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md#configure-the-mcp-server-in-settingsjson).
+Add `"yutori"` to `mcp.allowed` if you already list other MCPs there. For more details, see the [Gemini CLI MCP settings guide](https://github.com/google-gemini/gemini-cli/blob/main/docs/tools/mcp-server.md#configure-the-mcp-server-in-settingsjson).
 </details>
 
 <details>
-<summary>Using pip</summary>
+<summary>Run with pip</summary>
+
+Install the package to run the MCP server (e.g. for custom or self-hosted setups):
 
 ```bash
 pip install yutori-mcp
@@ -247,436 +302,7 @@ pip install yutori-mcp
 
 ## Tools
 
-All tool outputs are formatted as human-readable text optimized for LLM consumption.
-
-### Scout Tools
-
-#### list_scouts
-
-List scouts for the user with optional filtering.
-
-```json
-{
-  "limit": 10,
-  "status": "active"
-}
-```
-
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `limit` | No | Max scouts to return (1-100). Default: 10 |
-| `status` | No | Filter by `active`, `paused`, or `done` |
-
-Example response:
-
-```
-Found 87 scouts: 72 active, 12 paused, 3 done.
-
-Showing 10 of 87:
-
-1. Yutori news and updates (active)
-   Query: "Tell me about the latest news, product updates, or..."
-   ID: 690bd26c-0ef8-42f4-99e4-8fca6ea20e6f
-   Runs daily | Next: 2026-01-16
-
-2. Yutori API changelog (paused)
-   Query: "Monitor Yutori API changelog for breaking changes"
-   ID: 36d178a0-591f-4567-8019-32d24f9e55ba
-   Runs every 12 hours | Next: 2026-01-10
-
-... (8 more)
-
-Use list_scouts(status="active") to filter by status.
-Use list_scouts(limit=50) to see more.
-Use get_scout_detail(scout_id) for full details.
-```
-
-#### get_scout_detail
-
-Get detailed information for a specific scout.
-
-```json
-{
-  "scout_id": "690bd26c-0ef8-42f4-99e4-8fca6ea20e6f"
-}
-```
-
-Example response:
-
-```
-Scout: Yutori news and updates
-ID: 690bd26c-0ef8-42f4-99e4-8fca6ea20e6f
-Status: active
-
-Query: "Tell me about the latest news, product updates, or announcements about Yutori"
-
-Schedule:
-  Interval: daily
-  Next run: 2026-01-16 18:32 UTC
-  Timezone: America/Los_Angeles
-
-Configuration:
-  Webhook: not configured
-  Email notifications: enabled
-  Public: yes
-
-Created: 2026-01-15
-```
-
-#### create_scout
-
-Create a new monitoring scout for continuous web monitoring. Scouts track changes relevant to a query at a configurable schedule and alert you with structured data.
-
-**Basic example:**
-
-```json
-{
-  "query": "Tell me about the latest news, product updates, press releases, social media announcements, investments into, or other relevant information about Yutori"
-}
-```
-
-**Advanced example (scheduling, webhooks, structured output):**
-
-```json
-{
-  "query": "Tell me about the latest news, product updates, press releases, social media announcements, investments into, or other relevant information about Yutori",
-  "output_interval": 86400,
-  "user_timezone": "America/Los_Angeles",
-  "skip_email": true,
-  "webhook_url": "https://example.com/webhook",
-  "output_fields": ["headline", "summary", "source_url"]
-}
-```
-
-Example response:
-
-```
-Scout created successfully.
-
-Name: Yutori news and updates
-ID: 3d1d5e2a-5b6c-4a9c-8f8c-2f2e3b4a5c6d
-Status: active
-
-Query: "Tell me about the latest news, product updates, press releases, social..."
-Schedule: runs daily
-First run: 2026-01-07 03:10 UTC
-```
-
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `query` | Yes | Natural language description of what to monitor |
-| `output_interval` | No | Seconds between runs (min: 1800). Default: 86400 |
-| `webhook_url` | No | URL for webhook notifications |
-| `webhook_format` | No | `scout` (default), `slack`, or `zapier` |
-| `output_fields` | No | List of field names for structured output as array of objects |
-| `user_timezone` | No | Timezone for scheduling |
-| `skip_email` | No | Skip email notifications |
-| `start_timestamp` | No | Unix timestamp for when monitoring should start (0 = immediately) |
-| `user_location` | No | Location for geo-relevant searches |
-| `is_public` | No | Whether scout results are publicly accessible |
-
-#### edit_scout
-
-Update an existing scout's query, schedule, webhook configuration, or status.
-
-**Change status only (pause a scout):**
-
-```json
-{
-  "scout_id": "abc123-...",
-  "status": "paused"
-}
-```
-
-**Update configuration:**
-
-```json
-{
-  "scout_id": "abc123-...",
-  "output_interval": 43200,
-  "user_timezone": "America/New_York"
-}
-```
-
-**Update configuration and resume:**
-
-```json
-{
-  "scout_id": "abc123-...",
-  "query": "updated monitoring query",
-  "status": "active"
-}
-```
-
-Example response:
-
-```
-Scout updated successfully.
-
-Name: Yutori API changelog
-ID: 7c8692c3-c637-4302-a982-b9f4f7b49407
-
-Changes applied:
-  • Status: paused → active
-  • Query: "Monitor Yutori API changelog..." → "updated monitoring query"
-```
-
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `scout_id` | Yes | Scout UUID |
-| `status` | No | `active` (resume), `paused` (pause), or `done` (archive) |
-| `query` | No | Updated monitoring query |
-| `output_interval` | No | Seconds between runs (min 1800) |
-| `webhook_url` | No | Webhook notification URL |
-| `webhook_format` | No | `scout`, `slack`, or `zapier` |
-| `output_fields` | No | List of field names for structured output |
-| `user_timezone` | No | Timezone for scheduling |
-| `user_location` | No | Location for geo-relevant searches |
-| `skip_email` | No | Skip email notifications |
-
-#### delete_scout
-
-Permanently delete a scout. **This cannot be undone.**
-
-```json
-{
-  "scout_id": "abc123-..."
-}
-```
-
-Example response:
-
-```
-Scout deleted.
-
-ID: abc123-...
-
-This action cannot be undone.
-```
-
-#### get_scout_updates
-
-Get paginated updates from a scout.
-
-```json
-{
-  "scout_id": "690bd26c-0ef8-42f4-99e4-8fca6ea20e6f",
-  "limit": 2
-}
-```
-
-Example response:
-
-```
-Found 2 update(s):
-
---- Update #1 —
-Date: 2026-01-16 05:45 UTC
-
-Yutori Product Updates
-
-Yutori has released new MCP server tools for web monitoring and browsing automation...
-
---- Update #2 —
-Date: 2026-01-15 05:45 UTC
-
-No new findings since last update.
-```
-
-### Research Tools
-
-#### run_research_task
-
-Execute a one-time deep web research task. The research agent searches, reads, and synthesizes information from across the web.
-
-**Basic example:**
-
-```json
-{
-  "query": "What are the latest developments in quantum computing from the past week? Include company announcements, research papers, and product releases."
-}
-```
-
-**Advanced example (webhooks, structured output):**
-
-```json
-{
-  "query": "What are the latest developments in quantum computing from the past week? Include company announcements, research papers, and product releases.",
-  "user_timezone": "America/Los_Angeles",
-  "webhook_url": "https://example.com/webhook",
-  "output_fields": ["title", "summary", "source_url", "category"]
-}
-```
-
-Example response:
-
-```
-Research task started.
-
-Task ID: ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395
-Status: queued
-View progress: https://scouts.yutori.com/ae27a17c-a4ed-4c69-8b2a-4bec330fc935
-
-Poll with get_research_task_result(task_id="ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395") to check status.
-```
-
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `query` | Yes | Natural language description of what to research |
-| `user_timezone` | No | Timezone for context. Default: 'America/Los_Angeles' |
-| `user_location` | No | Location for context. Default: 'San Francisco, CA, US' |
-| `output_fields` | No | List of field names for structured output as array of objects |
-| `webhook_url` | No | URL for completion notification |
-| `webhook_format` | No | `scout` (default), `slack`, or `zapier` |
-
-#### get_research_task_result
-
-Poll for the status and result of a research task. Call this after `run_research_task` until status is `succeeded` or `failed`.
-
-```json
-{
-  "task_id": "ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395"
-}
-```
-
-Example response (running):
-
-```
-Task in progress.
-
-Task ID: ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395
-Status: running
-
-Poll again in a few seconds.
-```
-
-Example response (succeeded):
-
-```
-Task completed.
-
-Task ID: ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395
-Status: succeeded
-
-Result:
-Hardware strides and strategic moves this week
-
-I focused on notable hardware breakthroughs, leadership changes, applied research,
-and an industry appearance from January 12–19, 2026.
-
-• MIT demonstrated chip-based cooling for trapped-ion qubits
-• EeroQ unveiled a scalable quantum control chip
-• IonQ appointed Katie Arrington as Chief Information Officer
-• Researchers introduced QUPID, a quantum neural network
-```
-
-### Browsing Tools
-
-#### run_browsing_task
-
-Execute a one-time web browsing task using the navigator agent. The agent runs a cloud browser and operates it like a person - clicking, typing, scrolling, and navigating for you.
-
-**Basic example:**
-
-```json
-{
-  "task": "Give me a list of all employees (names and titles) of Yutori.",
-  "start_url": "https://yutori.com"
-}
-```
-
-**Advanced example (webhooks, structured output):**
-
-```json
-{
-  "task": "Give me a list of all employees (names and titles) of Yutori.",
-  "start_url": "https://yutori.com",
-  "max_steps": 75,
-  "webhook_url": "https://example.com/webhook",
-  "output_fields": ["name", "title"]
-}
-```
-
-Example response:
-
-```
-Browsing task started.
-
-Task ID: 54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396
-Status: queued
-View progress: https://scouts.yutori.com/54fb19fd-277e-4098-ab72-5a9f8a4347fc
-
-Poll with get_browsing_task_result(task_id="54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396") to check status.
-```
-
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `task` | Yes | Natural language instruction for the navigator |
-| `start_url` | Yes | URL where browsing begins |
-| `max_steps` | No | Max browser actions (1-100). Default: 25 |
-| `output_fields` | No | List of field names for structured output as array of objects |
-| `webhook_url` | No | URL for completion notification |
-| `webhook_format` | No | `scout` (default) or `slack` |
-
-#### get_browsing_task_result
-
-Poll for the status and result of a browsing task. Call this after `run_browsing_task` until status is `succeeded` or `failed`.
-
-```json
-{
-  "task_id": "54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396"
-}
-```
-
-Example response (running):
-
-```
-Task in progress.
-
-Task ID: 54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396
-Status: running
-
-Poll again in a few seconds.
-```
-
-Example response (succeeded):
-
-```
-Task completed.
-
-Task ID: 54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396
-Status: succeeded
-
-Result:
-Summary of All Yutori Employees
-
-I have successfully located all employees of Yutori on their company page.
-Here is the complete list of 17 employees with their names and titles:
-
-Founders & Leadership:
-1. Abhishek Das - Co-founder and Co-CEO
-2. Devi Parikh - Co-founder and Co-CEO
-3. Dhruv Batra - Co-founder and Chief Scientist
-
-Executive:
-4. Kristi Edleson - Chief of Staff
-
-Technical Staff:
-5. Rui Wang - Member of Technical Staff
-... (17 employees total)
-
-Source Page: https://yutori.com/company#team
-```
-
-## Tool Annotations
-
-Tools include hints for client behavior:
-
-| Tool | Annotation |
-|------|------------|
-| `list_scouts`, `get_scout_detail`, `get_scout_updates`, `get_browsing_task_result`, `get_research_task_result` | `readOnlyHint: true` |
-| `edit_scout` | `idempotentHint: true` |
-| `delete_scout` | `destructiveHint: true` |
+Parameters, example requests/responses, and annotations for all MCP tools. See **[TOOLS.md](TOOLS.md)** for the full reference (Scout, Research, and Browsing tools).
 
 ## Development
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -1,0 +1,433 @@
+# Tools
+
+All tool outputs are formatted as human-readable text optimized for LLM consumption.
+
+## Scout Tools
+
+### list_scouts
+
+List scouts for the user with optional filtering.
+
+```json
+{
+  "limit": 10,
+  "status": "active"
+}
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `limit` | No | Max scouts to return (1-100). Default: 10 |
+| `status` | No | Filter by `active`, `paused`, or `done` |
+
+Example response:
+
+```
+Found 87 scouts: 72 active, 12 paused, 3 done.
+
+Showing 10 of 87:
+
+1. Yutori news and updates (active)
+   Query: "Tell me about the latest news, product updates, or..."
+   ID: 690bd26c-0ef8-42f4-99e4-8fca6ea20e6f
+   Runs daily | Next: 2026-01-16
+
+2. Yutori API changelog (paused)
+   Query: "Monitor Yutori API changelog for breaking changes"
+   ID: 36d178a0-591f-4567-8019-32d24f9e55ba
+   Runs every 12 hours | Next: 2026-01-10
+
+... (8 more)
+
+Use list_scouts(status="active") to filter by status.
+Use list_scouts(limit=50) to see more.
+Use get_scout_detail(scout_id) for full details.
+```
+
+### get_scout_detail
+
+Get detailed information for a specific scout.
+
+```json
+{
+  "scout_id": "690bd26c-0ef8-42f4-99e4-8fca6ea20e6f"
+}
+```
+
+Example response:
+
+```
+Scout: Yutori news and updates
+ID: 690bd26c-0ef8-42f4-99e4-8fca6ea20e6f
+Status: active
+
+Query: "Tell me about the latest news, product updates, or announcements about Yutori"
+
+Schedule:
+  Interval: daily
+  Next run: 2026-01-16 18:32 UTC
+  Timezone: America/Los_Angeles
+
+Configuration:
+  Webhook: not configured
+  Email notifications: enabled
+  Public: yes
+
+Created: 2026-01-15
+```
+
+### create_scout
+
+Create a new monitoring scout for continuous web monitoring. Scouts track changes relevant to a query at a configurable schedule and alert you with structured data.
+
+**Basic example:**
+
+```json
+{
+  "query": "Tell me about the latest news, product updates, press releases, social media announcements, investments into, or other relevant information about Yutori"
+}
+```
+
+**Advanced example (scheduling, webhooks, structured output):**
+
+```json
+{
+  "query": "Tell me about the latest news, product updates, press releases, social media announcements, investments into, or other relevant information about Yutori",
+  "output_interval": 86400,
+  "user_timezone": "America/Los_Angeles",
+  "skip_email": true,
+  "webhook_url": "https://example.com/webhook",
+  "output_fields": ["headline", "summary", "source_url"]
+}
+```
+
+Example response:
+
+```
+Scout created successfully.
+
+Name: Yutori news and updates
+ID: 3d1d5e2a-5b6c-4a9c-8f8c-2f2e3b4a5c6d
+Status: active
+
+Query: "Tell me about the latest news, product updates, press releases, social..."
+Schedule: runs daily
+First run: 2026-01-07 03:10 UTC
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `query` | Yes | Natural language description of what to monitor |
+| `output_interval` | No | Seconds between runs (min: 1800). Default: 86400 |
+| `webhook_url` | No | URL for webhook notifications |
+| `webhook_format` | No | `scout` (default), `slack`, or `zapier` |
+| `output_fields` | No | List of field names for structured output as array of objects |
+| `user_timezone` | No | Timezone for scheduling |
+| `skip_email` | No | Skip email notifications |
+| `start_timestamp` | No | ISO timestamp for when monitoring should start |
+| `user_location` | No | Location for geo-relevant searches |
+| `is_public` | No | Whether scout results are publicly accessible |
+
+### edit_scout
+
+Update an existing scout's query, schedule, webhook configuration, or status.
+
+**Change status only (pause a scout):**
+
+```json
+{
+  "scout_id": "abc123-...",
+  "status": "paused"
+}
+```
+
+**Update configuration:**
+
+```json
+{
+  "scout_id": "abc123-...",
+  "output_interval": 43200,
+  "user_timezone": "America/New_York"
+}
+```
+
+**Update configuration and resume:**
+
+```json
+{
+  "scout_id": "abc123-...",
+  "query": "updated monitoring query",
+  "status": "active"
+}
+```
+
+Example response:
+
+```
+Scout updated successfully.
+
+Name: Yutori API changelog
+ID: 7c8692c3-c637-4302-a982-b9f4f7b49407
+
+Changes applied:
+  • Status: paused → active
+  • Query: "Monitor Yutori API changelog..." → "updated monitoring query"
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `scout_id` | Yes | Scout UUID |
+| `status` | No | `active` (resume), `paused` (pause), or `done` (archive) |
+| `query` | No | Updated monitoring query |
+| `output_interval` | No | Seconds between runs (min 1800) |
+| `webhook_url` | No | Webhook notification URL |
+| `webhook_format` | No | `scout`, `slack`, or `zapier` |
+| `output_fields` | No | List of field names for structured output |
+| `user_timezone` | No | Timezone for scheduling |
+| `user_location` | No | Location for geo-relevant searches |
+| `is_public` | No | Whether results are public |
+| `skip_email` | No | Skip email notifications |
+
+### delete_scout
+
+Permanently delete a scout. **This cannot be undone.**
+
+```json
+{
+  "scout_id": "abc123-..."
+}
+```
+
+Example response:
+
+```
+Scout deleted.
+
+ID: abc123-...
+
+This action cannot be undone.
+```
+
+### get_scout_updates
+
+Get paginated updates from a scout.
+
+```json
+{
+  "scout_id": "690bd26c-0ef8-42f4-99e4-8fca6ea20e6f",
+  "limit": 2
+}
+```
+
+Example response:
+
+```
+Found 2 update(s):
+
+--- Update #1 —
+Date: 2026-01-16 05:45 UTC
+
+Yutori Product Updates
+
+Yutori has released new MCP server tools for web monitoring and browsing automation...
+
+--- Update #2 —
+Date: 2026-01-15 05:45 UTC
+
+No new findings since last update.
+```
+
+## Research Tools
+
+### run_research_task
+
+Execute a one-time deep web research task. The research agent searches, reads, and synthesizes information from across the web.
+
+**Basic example:**
+
+```json
+{
+  "query": "What are the latest developments in quantum computing from the past week? Include company announcements, research papers, and product releases."
+}
+```
+
+**Advanced example (webhooks, structured output):**
+
+```json
+{
+  "query": "What are the latest developments in quantum computing from the past week? Include company announcements, research papers, and product releases.",
+  "user_timezone": "America/Los_Angeles",
+  "webhook_url": "https://example.com/webhook",
+  "output_fields": ["title", "summary", "source_url", "category"]
+}
+```
+
+Example response:
+
+```
+Research task started.
+
+Task ID: ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395
+Status: queued
+View progress: https://scouts.yutori.com/ae27a17c-a4ed-4c69-8b2a-4bec330fc935
+
+Poll with get_research_task_result(task_id="ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395") to check status.
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `query` | Yes | Natural language description of what to research |
+| `user_timezone` | No | Timezone for context. Default: 'America/Los_Angeles' |
+| `user_location` | No | Location for context. Default: 'San Francisco, CA, US' |
+| `output_fields` | No | List of field names for structured output as array of objects |
+| `webhook_url` | No | URL for completion notification |
+| `webhook_format` | No | `scout` (default), `slack`, or `zapier` |
+
+### get_research_task_result
+
+Poll for the status and result of a research task. Call this after `run_research_task` until status is `succeeded` or `failed`.
+
+```json
+{
+  "task_id": "ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395"
+}
+```
+
+Example response (running):
+
+```
+Task in progress.
+
+Task ID: ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395
+Status: running
+
+Poll again in a few seconds.
+```
+
+Example response (succeeded):
+
+```
+Task completed.
+
+Task ID: ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395
+Status: succeeded
+
+Result:
+Hardware strides and strategic moves this week
+
+I focused on notable hardware breakthroughs, leadership changes, applied research,
+and an industry appearance from January 12–19, 2026.
+
+• MIT demonstrated chip-based cooling for trapped-ion qubits
+• EeroQ unveiled a scalable quantum control chip
+• IonQ appointed Katie Arrington as Chief Information Officer
+• Researchers introduced QUPID, a quantum neural network
+```
+
+## Browsing Tools
+
+### run_browsing_task
+
+Execute a one-time web browsing task using the navigator agent. The agent runs a cloud browser and operates it like a person - clicking, typing, scrolling, and navigating for you.
+
+**Basic example:**
+
+```json
+{
+  "task": "Give me a list of all employees (names and titles) of Yutori.",
+  "start_url": "https://yutori.com"
+}
+```
+
+**Advanced example (webhooks, structured output):**
+
+```json
+{
+  "task": "Give me a list of all employees (names and titles) of Yutori.",
+  "start_url": "https://yutori.com",
+  "max_steps": 75,
+  "webhook_url": "https://example.com/webhook",
+  "output_fields": ["name", "title"]
+}
+```
+
+Example response:
+
+```
+Browsing task started.
+
+Task ID: 54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396
+Status: queued
+View progress: https://scouts.yutori.com/54fb19fd-277e-4098-ab72-5a9f8a4347fc
+
+Poll with get_browsing_task_result(task_id="54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396") to check status.
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `task` | Yes | Natural language instruction for the navigator |
+| `start_url` | Yes | URL where browsing begins |
+| `max_steps` | No | Max browser actions (1-100). Default: 25 |
+| `output_fields` | No | List of field names for structured output as array of objects |
+| `webhook_url` | No | URL for completion notification |
+| `webhook_format` | No | `scout` (default) or `slack` |
+
+### get_browsing_task_result
+
+Poll for the status and result of a browsing task. Call this after `run_browsing_task` until status is `succeeded` or `failed`.
+
+```json
+{
+  "task_id": "54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396"
+}
+```
+
+Example response (running):
+
+```
+Task in progress.
+
+Task ID: 54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396
+Status: running
+
+Poll again in a few seconds.
+```
+
+Example response (succeeded):
+
+```
+Task completed.
+
+Task ID: 54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396
+Status: succeeded
+
+Result:
+Summary of All Yutori Employees
+
+I have successfully located all employees of Yutori on their company page.
+Here is the complete list of 17 employees with their names and titles:
+
+Founders & Leadership:
+1. Abhishek Das - Co-founder and Co-CEO
+2. Devi Parikh - Co-founder and Co-CEO
+3. Dhruv Batra - Co-founder and Chief Scientist
+
+Executive:
+4. Kristi Edleson - Chief of Staff
+
+Technical Staff:
+5. Rui Wang - Member of Technical Staff
+... (17 employees total)
+
+Source Page: https://yutori.com/company#team
+```
+
+## Tool Annotations
+
+Tools include hints for client behavior:
+
+| Tool | Annotation |
+|------|------------|
+| `list_scouts`, `get_scout_detail`, `get_scout_updates`, `get_browsing_task_result`, `get_research_task_result` | `readOnlyHint: true` |
+| `edit_scout` | `idempotentHint: true` |
+| `delete_scout` | `destructiveHint: true` |

--- a/skills/01-scout/SKILL.md
+++ b/skills/01-scout/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: scout
+name: Yutori scout
 description: Set up continuous web monitoring with Yutori Scouts. Use when the user wants to track news, competitors, product updates, funding rounds, price changes, or any recurring web information.
 argument-hint: "[topic or monitoring goal]"
 ---

--- a/skills/02-research/SKILL.md
+++ b/skills/02-research/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: research
+name: Yutori research
 description: Execute deep web research on any topic using Yutori's research agents. Use for competitive analysis, market research, finding documentation, or answering complex questions that require synthesizing information from multiple sources.
 argument-hint: "[research question]"
 ---

--- a/skills/03-browse/SKILL.md
+++ b/skills/03-browse/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: browse
+name: Yutori browse
 description: Automate browser tasks like form filling, data extraction, or multi-step web workflows. Use when the user needs to interact with websites that require clicking, typing, or navigation.
 argument-hint: "[task description] [starting URL]"
 ---

--- a/skills/04-competitor-watch/SKILL.md
+++ b/skills/04-competitor-watch/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: competitor-watch
+name:  Yutori competitor-watch
 description: Quickly set up monitoring for a competitor company. Tracks news, product updates, funding, and public announcements.
 argument-hint: "[competitor name]"
 disable-model-invocation: true

--- a/skills/05-api-monitor/SKILL.md
+++ b/skills/05-api-monitor/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: api-monitor
+name: Yutori api-monitor
 description: Set up monitoring for API changes, changelogs, or documentation updates. Useful for tracking breaking changes in services you depend on.
 argument-hint: "[service or API name]"
 disable-model-invocation: true


### PR DESCRIPTION
- Revised README to reflect the addition of skills and clarify installation steps.
- Introduced a new TOOLS.md file detailing available tools and their functionalities.
- Renamed skills to include "Yutori" for consistency and improved identification (e.g., "scout" to "Yutori scout").
- Enhanced descriptions for skills to better convey their purpose and usage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (README/skills metadata) with no runtime code modifications; main risk is confusing install/env-var instructions if inaccurate.
> 
> **Overview**
> Updates `README.md` to emphasize **skills support** and broaden the supported MCP hosts, with a new quickstart that uses `uvx yutori-mcp login` for API key setup plus `npx skills add yutori-ai/yutori-mcp` for installing MCP + skills, and expanded per-client configuration (notably explicit `YUTORI_API_KEY` env wiring for Cursor/VS Code/ChatGPT/Codex, plus a new OpenClaw section).
> 
> Moves the detailed MCP tool reference out of the README into a new `TOOLS.md` (full parameter/examples + tool annotations), and renames skill frontmatter names to include the `Yutori` prefix for clearer identification (e.g., `Yutori scout`, `Yutori research`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f4a53c5282201009a9db7468f2a54ea4ff8954f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->