### PR TITLE
Update README and skill names for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,23 +32,20 @@ For the quickstart below, Node.js is also required (for `npx`).
 
 ### Quickstart
 
-1. Grab your API key. Enter
+1. Authenticate using
 
     ```bash
     uvx yutori-mcp login
     ```
-
     to get your setup automatically.
 
+    Or
 
-    Or add your API key to your shell profile (once):
+    Go to (https://platform.yutori.com) and add your API key to your shell profile (once):
    ```bash
    echo 'export YUTORI_API_KEY=yt-your-api-key' >> ~/.zshrc
    source ~/.zshrc
    ```
-
-
-   If you manually add the key, you will have to install the mcp in Claude Code and Codex!
 
 
 
@@ -56,7 +53,17 @@ For the quickstart below, Node.js is also required (for `npx`).
    ```bash
    npx skills add yutori-ai/yutori-mcp
    ```
-   When prompted, choose which skills to install and which tools (e.g. Claude Code, OpenClaw, Codex).
+   When prompted, choose which skills to install and which tools (e.g. OpenClaw, Codex).
+
+3. For Claude Code
+
+Inside Claude
+   ```
+   /plugin marketplace add yutori-ai/yutori-mcp
+   /plugin install yutori@yutori-plugins
+   ```
+
+
 
 ### Per-client setup
 

--- a/skills/01-scout/SKILL.md
+++ b/skills/01-scout/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Yutori scout
+name: Yutori-scout
 description: Set up continuous web monitoring with Yutori Scouts. Use when the user wants to track news, competitors, product updates, funding rounds, price changes, or any recurring web information.
 argument-hint: "[topic or monitoring goal]"
 ---

--- a/skills/02-research/SKILL.md
+++ b/skills/02-research/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Yutori research
+name: Yutori-research
 description: Execute deep web research on any topic using Yutori's research agents. Use for competitive analysis, market research, finding documentation, or answering complex questions that require synthesizing information from multiple sources.
 argument-hint: "[research question]"
 ---

--- a/skills/03-browse/SKILL.md
+++ b/skills/03-browse/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Yutori browse
+name: Yutori-browse
 description: Automate browser tasks like form filling, data extraction, or multi-step web workflows. Use when the user needs to interact with websites that require clicking, typing, or navigation.
 argument-hint: "[task description] [starting URL]"
 ---

--- a/skills/04-competitor-watch/SKILL.md
+++ b/skills/04-competitor-watch/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name:  Yutori competitor-watch
+name:  Yutori-competitor-watch
 description: Quickly set up monitoring for a competitor company. Tracks news, product updates, funding, and public announcements.
 argument-hint: "[competitor name]"
 disable-model-invocation: true

--- a/skills/05-api-monitor/SKILL.md
+++ b/skills/05-api-monitor/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: Yutori api-monitor
+name: Yutori-api-monitor
 description: Set up monitoring for API changes, changelogs, or documentation updates. Useful for tracking breaking changes in services you depend on.
 argument-hint: "[service or API name]"
 disable-model-invocation: true


### PR DESCRIPTION
- Revised the README to clarify authentication steps and installation instructions.
- Updated skill names to follow a consistent naming convention (e.g., "Yutori scout" to "Yutori-scout").
- Enhanced skill descriptions for better clarity on their functionalities.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and skill-metadata naming changes only; no runtime logic is modified, with the main risk being potential downstream references to the old skill names.
> 
> **Overview**
> Clarifies `README.md` quickstart setup by emphasizing `uvx yutori-mcp login` as the primary auth path, pointing users to `platform.yutori.com` for API key retrieval, and adding explicit Claude Code plugin install commands; it also removes Claude Code from the `skills.sh` prompt examples.
> 
> Standardizes skill metadata names in `skills/*/SKILL.md` to a hyphenated convention (e.g., `Yutori-scout`, `Yutori-research`, etc.) for consistency across the skill set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6438ae588bff5b7a05dc6a6168e0c7bf4afd1041. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->