### PR TITLE
Update README to reflect project name change and simplify installatio…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Yutori MCP Server / Plugin / Skills
+# The Yutori MCP Toolkit
 
 An MCP server and skills for [Yutori](https://yutori.com/api) — web monitoring and browsing automation.
 
@@ -58,13 +58,7 @@ For the quickstart below, Node.js is also required (for `npx`).
    /plugin marketplace add yutori-ai/yutori-mcp
    /plugin install yutori@yutori-plugins
    ```
-
-3. For all other clients, install skills and MCP via [skills.sh](https://skills.sh):
-   ```bash
-   npx skills add yutori-ai/yutori-mcp
-   ```
-   When prompted, select the skills and clients you want (e.g. Cursor, Codex, OpenClaw).
-
+    Restart claude.
 
 
 ### Manual per-client setup


### PR DESCRIPTION
…n instructions

- Changed project title from "Yutori MCP Server / Plugin / Skills" to "The Yutori MCP Toolkit".
- Removed outdated installation instructions for skills via skills.sh, streamlining the quickstart guide.
- Added a note to restart the service after installation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that adjust naming and installation instructions without touching runtime code.
> 
> **Overview**
> Updates `README.md` to reflect the renamed project title (**"The Yutori MCP Toolkit"**).
> 
> Simplifies the quickstart by removing the generic `skills.sh` install path for non-Claude clients and adds an explicit note to restart Claude after installing the Claude Code plugin.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d49307d4b06619c89e28c65564582302a139ced. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->