### PR TITLE
Rename login skill to yutori-login for consistency

### DIFF
--- a/skills/yutori-login/SKILL.md
+++ b/skills/yutori-login/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: login
+name: yutori-login
 description: Log in to Yutori to connect your account
 argument-hint: ""
 ---


### PR DESCRIPTION
## Summary

Renames the skill directory from `login` to `yutori-login` to match the naming convention of other Yutori skills.

## Changes

- Renamed `skills/login/` → `skills/yutori-login/`
- Updated skill name in frontmatter: `name: login` → `name: yutori-login`

## Rationale

This makes the skill naming consistent with:
- `yutori-scout`
- `yutori-research`
- `yutori-browse`
- `yutori-competitor-watch`
- `yutori-api-monitor`

The `yutori-` prefix allows users to quickly identify what they're logging into when using the skill in their CLI (e.g., `/yutori-login` in Claude Code).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change updating the skill frontmatter name; no runtime or data/auth logic is modified.
> 
> **Overview**
> Renames the `login` skill to `yutori-login` by updating the `name` in `skills/yutori-login/SKILL.md` frontmatter for naming consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e84324b0f847c20585586dfc1919f0936a3d471. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->