### PR TITLE
Improve README copy: tagline, features section, tools reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ You can use it with Claude Code, Codex, Cursor, VS Code, ChatGPT, OpenClaw, and 
 
 ## Features
 
-**API tools:**
-- **Scouts** — Monitor the web continuously for anything you care about at a desired frequency
+**Capabilities:**
+- **Scouting** — Monitor the web continuously for anything you care about at a desired frequency
 - **Research** — Run one-time deep web research tasks
 - **Browsing** — Automate websites with an AI navigator
 

--- a/README.md
+++ b/README.md
@@ -1,14 +1,22 @@
 # The Yutori MCP Toolkit
 
-An MCP server and skills for [Yutori](https://yutori.com/api) — web monitoring and browsing automation.
+MCP tools and skills for web monitoring, deep research, and browser automation — powered by [Yutori](https://yutori.com/api)'s web agentic tech.
 
 You can use it with Claude Code, Codex, Cursor, VS Code, ChatGPT, OpenClaw, and other MCP hosts.
 
 ## Features
 
-- **Scouts**: Create agents that monitor the web for anything you care about at a desired frequency, list them and check the status
-- **Research**: Execute one-time deep web research tasks
-- **Browsing**: Execute one-time web browsing tasks using an AI website navigator
+**API tools:**
+- **Scouts** — Monitor the web continuously for anything you care about at a desired frequency
+- **Research** — Run one-time deep web research tasks
+- **Browsing** — Automate websites with an AI navigator
+
+**Workflow skills** (for clients that support slash commands):
+- [`/yutori-scout`](skills/01-scout/SKILL.md) — Set up continuous web monitoring
+- [`/yutori-research`](skills/02-research/SKILL.md) — Deep web research (async, 5–10 min)
+- [`/yutori-browse`](skills/03-browse/SKILL.md) — Browser automation
+- [`/yutori-competitor-watch`](skills/04-competitor-watch/SKILL.md) — Competitor monitoring template
+- [`/yutori-api-monitor`](skills/05-api-monitor/SKILL.md) — API/changelog monitoring template
 
 ## Installation
 
@@ -293,7 +301,7 @@ pip install yutori-mcp
 
 ## Tools
 
-Parameters, example requests/responses, and annotations for all MCP tools. See **[TOOLS.md](TOOLS.md)** for the full reference (Scout, Research, and Browsing tools).
+See [TOOLS.md](TOOLS.md) for the full tool reference — Scout, Research, and Browsing tools with parameters, examples, and response formats.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Or with Homebrew:
 brew install uv
 ```
 
-
+Python 3.10 or higher is required (`uv` manages this automatically for most installs).
 
 For the quickstart below, Node.js is also required (for `npx`).
 
@@ -61,19 +61,19 @@ For the quickstart below, Node.js is also required (for `npx`).
 
 
 
-2. Install mcp using [add-mcp](https://neon.com/blog/add-mcp)
+2. Install MCP using [add-mcp](https://neon.com/blog/add-mcp) (requires Node.js):
    ```
    npx add-mcp "uvx yutori-mcp"
    ```
 
-    Pick the tools that you want to configure.
+    Pick the clients you want to configure.
 
-3. Install skills using [skills.sh](https://skills.sh)
+3. (Optional) Install workflow skills using [skills.sh](https://skills.sh) (requires Node.js):
    ```
    npx skills add yutori-ai/yutori-mcp
    ```
 
-    Pick the tools that you want to configure.
+    Adds slash-command shortcuts like `/yutori-scout`, `/yutori-research`, and more. Skip if you only need the MCP tools.
 
 4. Restart the tool you are using.
 
@@ -85,7 +85,7 @@ For the quickstart below, Node.js is also required (for `npx`).
 
 1. **Plugin (Recommended)** - Includes MCP tools + workflow skills
 
-   Run these commands inside Claude Code:
+   Type these commands in Claude Code's input (not in a terminal):
    ```
    /plugin marketplace add yutori-ai/yutori-mcp
    /plugin install yutori@yutori-plugins
@@ -323,7 +323,7 @@ pytest
 
 ```bash
 yutori-mcp login    # authenticate (one-time)
-python -m yutori_mcp.server
+yutori-mcp          # run the server (or: python -m yutori_mcp.server)
 ```
 
 ### Debugging with MCP Inspector

--- a/src/yutori_mcp/__init__.py
+++ b/src/yutori_mcp/__init__.py
@@ -1,3 +1,5 @@
 """Yutori MCP Server - Web monitoring and browsing automation."""
 
-__version__ = "0.2.2"
+from importlib.metadata import version
+
+__version__ = version("yutori-mcp")

--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -120,6 +120,10 @@ class EditScoutInput(BaseModel):
         default=None,
         description="User location for geo-relevant searches",
     )
+    is_public: bool | None = Field(
+        default=None,
+        description="Whether scout results are publicly accessible",
+    )
 
     @model_validator(mode="after")
     def validate_has_changes(self) -> "EditScoutInput":
@@ -134,6 +138,7 @@ class EditScoutInput(BaseModel):
             self.skip_email,
             self.user_timezone,
             self.user_location,
+            self.is_public,
         ]
         if not any(f is not None for f in fields):
             raise ValueError("edit_scout requires at least one field to update")

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -275,6 +275,8 @@ def _handle_tool(client: MCPClientAdapter, name: str, arguments: dict) -> tuple[
                 config_kwargs["user_timezone"] = params.user_timezone
             if params.user_location is not None:
                 config_kwargs["user_location"] = params.user_location
+            if params.is_public is not None:
+                config_kwargs["is_public"] = params.is_public
 
             if config_kwargs:
                 client.edit_scout(scout_id=params.scout_id, **config_kwargs)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Mostly documentation and small plumbing changes; the only behavior change is passing a new optional `is_public` flag through `edit_scout`, which is low impact if the underlying API supports it.
> 
> **Overview**
> Refreshes `README.md` copy and onboarding: clarifies capabilities vs. workflow skills, tightens installation requirements/steps (Node.js notes, wording), and updates the local run command and `TOOLS.md` reference phrasing.
> 
> On the server side, `__version__` is now read from package metadata instead of a hardcoded constant, and `edit_scout` gains a new optional `is_public` field that is validated and forwarded to the API when provided.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 175bc96d4a25fcc66683bd68a346da350a3e99e7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->