### PR TITLE
Update TOOLS.md and formatters.py to change task progress URLs 

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -269,7 +269,7 @@ Research task started.
 
 Task ID: ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395
 Status: queued
-View progress: https://scouts.yutori.com/ae27a17c-a4ed-4c69-8b2a-4bec330fc935
+View progress: https://platform.yutori.com/research/tasks/ae27a17c-a4ed-4c69-8b2a-4bec330fc935
 
 Poll with get_research_task_result(task_id="ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395") to check status.
 ```
@@ -358,7 +358,7 @@ Browsing task started.
 
 Task ID: 54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396
 Status: queued
-View progress: https://scouts.yutori.com/54fb19fd-277e-4098-ab72-5a9f8a4347fc
+View progress: https://platform.yutori.com/browsing/tasks/54fb19fd-277e-4098-ab72-5a9f8a4347fc
 
 Poll with get_browsing_task_result(task_id="54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396") to check status.
 ```

--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -156,6 +156,7 @@ def format_list_scouts(response: dict[str, Any], **context: Any) -> str:
         lines.append(f"\n{i}. {name} ({status})")
         lines.append(f'   Query: "{_truncate(query)}"')
         lines.append(f"   ID: {scout_id}")
+        lines.append(f"   URL: https://platform.yutori.com/scouting/tasks/{scout_id}")
         lines.append(f"   Runs {interval} | Next: {next_run}")
 
     # Add hints
@@ -179,6 +180,7 @@ def format_scout_detail(response: dict[str, Any], **context: Any) -> str:
     lines = [
         f"Scout: {name}",
         f"ID: {scout_id}",
+        f"URL: https://platform.yutori.com/scouting/tasks/{scout_id}",
         f"Status: {status}",
         "",
         f'Query: "{query}"',
@@ -283,6 +285,7 @@ def format_scout_created(response: dict[str, Any], **context: Any) -> str:
         "",
         f"Name: {name}",
         f"ID: {scout_id}",
+        f"URL: https://platform.yutori.com/scouting/tasks/{scout_id}",
         f"Status: {status}",
         "",
         f'Query: "{_truncate(query, 80)}"',
@@ -310,6 +313,7 @@ def format_scout_edited(response: dict[str, Any], **context: Any) -> str:
                 "",
                 f"Name: {name}",
                 f"ID: {scout_id}",
+                f"URL: https://platform.yutori.com/scouting/tasks/{scout_id}",
                 f"Status: {status}",
                 "",
                 "Use get_scout_detail(scout_id) for full details.",
@@ -325,6 +329,7 @@ def format_scout_edited(response: dict[str, Any], **context: Any) -> str:
         "",
         f"Name: {name}",
         f"ID: {scout_id}",
+        f"URL: https://platform.yutori.com/scouting/tasks/{scout_id}",
         "",
         "Changes applied:",
     ]


### PR DESCRIPTION
to the new platform and add task URLs in scout details

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs/output-only changes that adjust displayed URLs and add an extra line to formatted responses; no behavioral or data-handling logic changes.
> 
> **Overview**
> Updates tool documentation to point *research* and *browsing* task progress links at `platform.yutori.com` instead of the legacy `scouts.yutori.com` URLs.
> 
> Enhances scout-related formatter outputs (`list_scouts`, `get_scout_detail`, `create_scout`, `edit_scout`) to include a direct `URL` field linking to the scout task page on the new platform.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e3ee664f4de6a9004163613b6bc65fedc784f3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->