### PR TITLE
Add Accept: text/markdown header hint to skill instructions

### DIFF
--- a/skills/01-scout/SKILL.md
+++ b/skills/01-scout/SKILL.md
@@ -79,4 +79,7 @@ Help the user set up a Yutori Scout for continuous web monitoring.
 - Missing context about the monitoring goal
 - No output format specification
 
+**Fetching documentation or source URLs:**
+If you use a web fetch tool to look up source URLs, documentation, or reference pages while preparing the query, include the `Accept: text/markdown` header. Many documentation sites (Cloudflare-hosted) will return clean Markdown instead of HTML — fewer tokens, easier to parse.
+
 $ARGUMENTS

--- a/skills/02-research/SKILL.md
+++ b/skills/02-research/SKILL.md
@@ -40,4 +40,9 @@ Help the user conduct thorough web research using Yutori's Research API.
    - Highlight key insights
    - Note sources for verification
 
+## Tips
+
+**Fetching documentation or reference URLs:**
+If you use a web fetch tool to look up documentation, API references, or other pages while preparing the research query, include the `Accept: text/markdown` header. Many documentation sites (Cloudflare-hosted) will return clean Markdown instead of HTML — fewer tokens, easier to parse.
+
 $ARGUMENTS

--- a/skills/04-competitor-watch/SKILL.md
+++ b/skills/04-competitor-watch/SKILL.md
@@ -41,3 +41,6 @@ After creation, inform the user:
 - Scout will run daily and email results
 - They can check updates anytime with `get_scout_updates`
 - They can pause/resume with `edit_scout`
+
+**Fetching documentation or source URLs:**
+If you use a web fetch tool to look up the competitor's blog, docs, or other pages while preparing the query, include the `Accept: text/markdown` header. Many documentation sites (Cloudflare-hosted) will return clean Markdown instead of HTML — fewer tokens, easier to parse.

--- a/skills/05-api-monitor/SKILL.md
+++ b/skills/05-api-monitor/SKILL.md
@@ -42,3 +42,6 @@ After creation, explain:
 - Scout will check twice daily for changes
 - Critical for staying ahead of breaking changes
 - Can set up webhook for immediate notifications
+
+**Fetching API documentation or changelogs:**
+If you use a web fetch tool to look up the service's changelog, API reference, or developer docs while preparing the query, include the `Accept: text/markdown` header. Many developer documentation sites (Cloudflare-hosted) will return clean Markdown instead of HTML — fewer tokens, easier to parse.


### PR DESCRIPTION
## Summary

- Adds a short tip to the 4 relevant skills (`yutori-scout`, `yutori-research`, `yutori-competitor-watch`, `yutori-api-monitor`) instructing AI agents to include `Accept: text/markdown` when fetching external documentation or reference URLs
- Skipped `yutori-browse` (interactive browser automation, not doc fetching) and `yutori-login`

## Why

Cloudflare supports an `Accept: text/markdown` header that causes documentation sites to return clean Markdown instead of HTML. This means fewer tokens consumed and cleaner content for AI agents to parse. Many developer docs and changelogs are hosted on Cloudflare-backed platforms that support this.

The skills delegate actual web monitoring to Yutori backend but AI coding agents (Claude Code, Cursor, etc.) often fetch docs themselves to look up source URLs or understand an API before crafting the scout query. This tip ensures they take advantage of Markdown responses where available.

Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that adjust guidance text; no code paths or runtime behavior are affected.
> 
> **Overview**
> Adds a new tip across the `yutori-scout`, `yutori-research`, `yutori-competitor-watch`, and `yutori-api-monitor` skill instructions recommending using `Accept: text/markdown` when fetching external docs/source URLs so Cloudflare-backed sites return Markdown instead of HTML (lower token usage, easier parsing).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fef7d1088a8778fab6c4e7b56821149a351eeb1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->