### PR TITLE
Add browser='local' parameter to run_browsing_task

### DIFF
--- a/src/yutori_mcp/adapter.py
+++ b/src/yutori_mcp/adapter.py
@@ -74,6 +74,8 @@ class MCPClientAdapter:
     # -------------------------------------------------------------------------
 
     def run_browsing_task(self, task: str, start_url: str, **kwargs: Any) -> dict[str, Any]:
+        # The SDK's browsing.create() may not support 'browser' yet; pass it as extra kwarg
+        # which _strip_none will keep if non-None.
         return self._call(self._client.browsing.create, task, start_url, **_strip_none(kwargs))
 
     def get_browsing_task(self, task_id: str) -> dict[str, Any]:

--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -443,8 +443,11 @@ def format_task_started(response: dict[str, Any], **context: Any) -> str:
         else:
             task_type = "Task"
 
+    browser = context.get("browser")
+    browser_note = " (using local desktop browser)" if browser == "local" else ""
+
     lines = [
-        f"{task_type} task started.",
+        f"{task_type} task started{browser_note}.",
         "",
         f"Task ID: {task_id}",
         f"Status: {status}",

--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -229,6 +229,14 @@ class BrowsingTaskInput(BaseModel):
         le=100,
         description="Maximum number of browser actions (1-100). Default: 25",
     )
+    browser: str | None = Field(
+        default=None,
+        description=(
+            "Where to run the browser. 'cloud' (default) uses Yutori's cloud browser. "
+            "'local' uses the desktop app (Yutori's Computer) with the user's logged-in sessions. "
+            "Requires the desktop app to be running."
+        ),
+    )
     output_fields: list[str] | None = Field(
         default=None,
         description=(

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -152,8 +152,9 @@ TOOLS = [
     Tool(
         name="run_browsing_task",
         description=(
-            "Execute a one-time web browsing task. The navigator agent runs a cloud browser and "
-            "operates it like a person. Returns a task_id for polling. Example: 'list employees'."
+            "Execute a one-time web browsing task. The navigator agent runs a browser and "
+            "operates it like a person. Returns a task_id for polling. Example: 'list employees'. "
+            "Set browser='local' to use the desktop app with the user's logged-in sessions."
         ),
         inputSchema=_get_simplified_schema(BrowsingTaskInput),
     ),
@@ -300,11 +301,12 @@ def _handle_tool(client: MCPClientAdapter, name: str, arguments: dict) -> tuple[
                 task=params.task,
                 start_url=params.start_url,
                 max_steps=params.max_steps,
+                browser=params.browser,
                 output_schema=_output_fields_to_output_schema(params.output_fields),
                 webhook_url=params.webhook_url,
                 webhook_format=params.webhook_format,
             )
-            return result, {"task_type": "Browsing"}
+            return result, {"task_type": "Browsing", "browser": params.browser}
         case "get_browsing_task_result":
             params = TaskIdInput(**arguments)
             return client.get_browsing_task(params.task_id), {"task_type": "Browsing"}


### PR DESCRIPTION
## Summary
- Add `browser` field to `BrowsingTaskInput` schema — accepts `"local"` to route through desktop app with user's logged-in sessions
- Pass through to SDK in `run_browsing_task` handler and show "(using local desktop browser)" in task started message

## Test plan
- [ ] Call `run_browsing_task` with `browser="local"` — verify param passed through to API
- [ ] Call `run_browsing_task` without `browser` — verify existing behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change that only extends the browsing task API surface and messaging; default behavior remains unchanged when `browser` is omitted.
> 
> **Overview**
> Adds an optional `browser` field to the `run_browsing_task` input schema so callers can request `browser='local'` to run via the desktop app (instead of the default cloud browser).
> 
> Plumbs `browser` through the server handler into the SDK call (filtered via `_strip_none`), updates the tool description to document the new option, and annotates the “task started” formatter output when `browser` is set to `local`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13b819a93843be34a9e2018f53eb8747f609bedb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->