### PR TITLE
Bump yutori SDK to >=0.4.0 and version to 0.2.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.2.6"
+version = "0.2.7"
 description = "MCP server for Yutori - web monitoring, deep research, and browser automation"
 readme = "README.md"
 license = "Apache-2.0"
@@ -25,7 +25,7 @@ classifiers = [
 dependencies = [
     "mcp>=1.0.0",
     "pydantic>=2.0.0",
-    "yutori>=0.3.0,<0.4.0",
+    "yutori>=0.4.0,<0.5.0",
 ]
 
 [project.optional-dependencies]

--- a/src/yutori_mcp/adapter.py
+++ b/src/yutori_mcp/adapter.py
@@ -74,8 +74,6 @@ class MCPClientAdapter:
     # -------------------------------------------------------------------------
 
     def run_browsing_task(self, task: str, start_url: str, **kwargs: Any) -> dict[str, Any]:
-        # The SDK's browsing.create() may not support 'browser' yet; pass it as extra kwarg
-        # which _strip_none will keep if non-None.
         return self._call(self._client.browsing.create, task, start_url, **_strip_none(kwargs))
 
     def get_browsing_task(self, task_id: str) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- Widens SDK constraint from `>=0.3.0,<0.4.0` to `>=0.4.0,<0.5.0`
- Bumps MCP version to 0.2.7
- Removes stale comment in adapter

This allows `uvx yutori-mcp` to install yutori SDK 0.4.4+, which natively supports the `browser='local'` parameter on `browsing.create()`. Without this, the MCP's local browser support (added in #27) couldn't work because the SDK rejected the `browser` kwarg.

## Test plan
- [ ] `uvx yutori-mcp` installs yutori >=0.4.4
- [ ] `run_browsing_task` with `browser='local'` works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk due to upgrading the `yutori` SDK major-minor line, which could introduce behavior or API changes at runtime. Code changes are minimal and limited to dependency constraints and comment cleanup.
> 
> **Overview**
> Bumps `yutori-mcp` to version `0.2.7` and widens the `yutori` SDK dependency constraint to `>=0.4.0,<0.5.0`.
> 
> Cleans up `MCPClientAdapter.run_browsing_task` by removing a stale comment about `browsing.create()` kwarg support; the call signature/forwarding behavior remains the same (still passes through non-`None` kwargs).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68f0f95382737bc61570e8936c605378f73db05e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->