### PR TITLE
Remove unused DEFAULT_LIMIT constant

### DIFF
--- a/.claude/CLEANUP.md
+++ b/.claude/CLEANUP.md
@@ -1,0 +1,7 @@
+# Cleanup Backlog
+
+Items identified for future cleanup runs. Pick one per run.
+
+- [ ] `tests/test_adapter.py:109` — `mock_resolve` is assigned but never used (dead code)
+- [ ] `src/yutori_mcp/formatters.py:245` — Asymmetric separator `--- Update #{i} —` uses `---` on left but em-dash `—` on right
+- [ ] `src/yutori_mcp/server.py:195,214` — `arguments: dict` should be `arguments: dict[str, Any]` to match codebase convention

--- a/.claude/CLEANUP_LOG.md
+++ b/.claude/CLEANUP_LOG.md
@@ -1,0 +1,5 @@
+# Cleanup Log
+
+| Date | Action | Details |
+|------|--------|---------|
+| 2026-04-03 | Changed | Removed unused `DEFAULT_LIMIT = 10` from `src/yutori_mcp/formatters.py` — dead code, never referenced anywhere in the codebase. Branch `cleanup/remove-unused-default-limit` pushed. PR creation blocked: no GitHub API auth available in this session. |

--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -4,8 +4,6 @@ from __future__ import annotations
 
 from typing import Any
 
-DEFAULT_LIMIT = 10
-
 
 def dict_to_markdown(obj: Any, level: int = 0) -> str:
     """Convert a nested dict/list structure to markdown text."""


### PR DESCRIPTION
## Summary

- Remove unused `DEFAULT_LIMIT = 10` from `formatters.py` — defined but never referenced anywhere in the codebase (dead code)
- Add `.claude/CLEANUP.md` backlog with other small cleanup opportunities identified during investigation
- Add `.claude/CLEANUP_LOG.md` to track cleanup actions

All 94 tests pass before and after this change.

## Code owners

cc @dhruvbatra @jagilley (primary contributors to `formatters.py`)

## Test plan

- [x] Confirmed `DEFAULT_LIMIT` is not referenced anywhere via `grep` across the entire codebase
- [x] Ran `pytest tests/ -x -q` — all 94 tests pass

https://claude.ai/code/session_01FFGwcc46mchUPrG1Mzvg4V

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes dead code and adds documentation-only cleanup tracking files with no runtime behavior changes expected.
> 
> **Overview**
> Removes the unused `DEFAULT_LIMIT` constant from `src/yutori_mcp/formatters.py`.
> 
> Adds `.claude/CLEANUP.md` (a backlog of future cleanup candidates) and `.claude/CLEANUP_LOG.md` (a log of performed cleanup actions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86363215ab4984aa1388ed047d5aade8a8a68b31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->