### PR TITLE
Fix asymmetric separator in scout update formatting

### DIFF
--- a/.claude/CLEANUP.md
+++ b/.claude/CLEANUP.md
@@ -3,5 +3,4 @@
 Items identified for future cleanup runs. Pick one per run.
 
 - [ ] `tests/test_adapter.py:109` — `mock_resolve` is assigned but never used (dead code)
-- [ ] `src/yutori_mcp/formatters.py:245` — Asymmetric separator `--- Update #{i} —` uses `---` on left but em-dash `—` on right
 - [ ] `src/yutori_mcp/server.py:195,214` — `arguments: dict` should be `arguments: dict[str, Any]` to match codebase convention

--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -240,7 +240,7 @@ def format_scout_updates(response: dict[str, Any], **context: Any) -> str:
 
     for i, update in enumerate(updates, 1):
         lines.append("")
-        lines.append(f"--- Update #{i} —")
+        lines.append(f"--- Update #{i} ---")
 
         timestamp = _format_datetime(
             update.get("created_at") or update.get("timestamp")


### PR DESCRIPTION
## Summary

- Fix inconsistent separator in `formatters.py:243`: `--- Update #{i} —` used three hyphens on the left but an em-dash (`—`) on the right. Normalized to `--- Update #{i} ---`.
- Remove completed item from `.claude/CLEANUP.md`.

Original code by @dhruvbatra.

## Test plan

- [ ] Verify scout update formatting renders correctly with the consistent `---` separator

https://claude.ai/code/session_01Db7TWn6kzDjcqNzhmzC4Ki

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a display string in `format_scout_updates` and removes a completed cleanup-backlog entry, with no behavior changes beyond output text.
> 
> **Overview**
> Normalizes the per-update header in `format_scout_updates` from an asymmetric `--- Update #{i} —` to a consistent `--- Update #{i} ---`.
> 
> Removes the corresponding resolved item from `.claude/CLEANUP.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20637a38e0c70c6f6a4dbdf16020d6ce63ef954b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->