### PR TITLE
Fix asymmetric separator in scout update formatting

### DIFF
--- a/.claude/CLEANUP.md
+++ b/.claude/CLEANUP.md
@@ -3,5 +3,4 @@
 Items identified for future cleanup runs. Pick one per run.
 
 - [ ] `tests/test_adapter.py:109` — `mock_resolve` is assigned but never used (dead code)
-- [ ] `src/yutori_mcp/formatters.py:245` — Asymmetric separator `--- Update #{i} —` uses `---` on left but em-dash `—` on right
 - [ ] `src/yutori_mcp/server.py:195,214` — `arguments: dict` should be `arguments: dict[str, Any]` to match codebase convention

--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -240,7 +240,7 @@ def format_scout_updates(response: dict[str, Any], **context: Any) -> str:
 
     for i, update in enumerate(updates, 1):
         lines.append("")
-        lines.append(f"--- Update #{i} —")
+        lines.append(f"--- Update #{i} ---")
 
         timestamp = _format_datetime(
             update.get("created_at") or update.get("timestamp")


### PR DESCRIPTION
## Summary

- Fix visual inconsistency in `formatters.py:243`: the separator `--- Update #{i} —` used three hyphens on the left but an em-dash (`—`) on the right. Normalized to `--- Update #{i} ---`.
- Remove completed item from `.claude/CLEANUP.md`.

cc @juanpinzon @dhruvbatra — primary contributors to `formatters.py`.

## Test plan
- [ ] Verify `format_scout_updates()` renders symmetric separators
- [ ] Confirm no other formatting regressions

https://claude.ai/code/session_01PrTBcC9zt618xErXCEPwbe

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: string-only formatting tweak in `format_scout_updates()` plus a cleanup backlog update, with no logic, API, or data-handling changes.
> 
> **Overview**
> Fixes a visual formatting inconsistency in `format_scout_updates()` by changing the per-update header separator from `--- Update #{i} —` to the symmetric `--- Update #{i} ---`.
> 
> Removes the now-completed formatter cleanup item from `.claude/CLEANUP.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9f3b44451607b3313e017ac90779a1395501d2db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->