### PR TITLE
Narrow `arguments: dict` to `dict[str, Any]` in server.py

### DIFF
--- a/.claude/CLEANUP.md
+++ b/.claude/CLEANUP.md
@@ -3,4 +3,3 @@
 Items identified for future cleanup runs. Pick one per run.
 
 - [ ] `tests/test_adapter.py:109` — `mock_resolve` is assigned but never used (dead code)
-- [ ] `src/yutori_mcp/server.py:195,214` — `arguments: dict` should be `arguments: dict[str, Any]` to match codebase convention

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -202,7 +202,7 @@ def create_server() -> Server:
         return TOOLS
 
     @server.call_tool()
-    async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+    async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
         try:
             with MCPClientAdapter() as client:
                 result, context = _handle_tool(client, name, arguments)
@@ -221,7 +221,7 @@ def create_server() -> Server:
     return server
 
 
-def _handle_tool(client: MCPClientAdapter, name: str, arguments: dict) -> tuple[dict, dict]:
+def _handle_tool(client: MCPClientAdapter, name: str, arguments: dict[str, Any]) -> tuple[dict, dict]:
     """Route tool calls to the appropriate client method.
 
     Returns:

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -221,7 +221,7 @@ def create_server() -> Server:
     return server
 
 
-def _handle_tool(client: MCPClientAdapter, name: str, arguments: dict[str, Any]) -> tuple[dict, dict]:
+def _handle_tool(client: MCPClientAdapter, name: str, arguments: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
     """Route tool calls to the appropriate client method.
 
     Returns:


### PR DESCRIPTION
## Summary

- Narrows bare `dict` type annotations to `dict[str, Any]` on `call_tool()` and `_handle_tool()` in `server.py`, matching the convention used everywhere else in the codebase.
- Removes completed item from `.claude/CLEANUP.md`.

Purely cosmetic — no runtime behavior change (annotations are strings due to `from __future__ import annotations`).

cc @dhruvbatra @jagilley

## Test plan
- [x] Verify `Any` is already imported
- [x] Confirm all other `dict` annotations in codebase use `dict[str, Any]`
- [x] No runtime change due to `from __future__ import annotations`

https://claude.ai/code/session_01KnJrMdepjc8zBXpdsTbhDL

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only tightens type annotations and updates a cleanup checklist; no runtime logic changes.
> 
> **Overview**
> Updates MCP server tool handlers to annotate `arguments`/return types as `dict[str, Any]` (instead of bare `dict`) in `call_tool()` and `_handle_tool()`.
> 
> Removes the now-completed type-annotation cleanup item from `.claude/CLEANUP.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a855efe89b013963e6d139930ec6ca8d9f9573ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->