### PR TITLE
Fix misplaced output_fields after validator in EditScoutInput

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -118,13 +118,6 @@ class EditScoutInput(BaseModel):
         default=None,
         description="Updated webhook format: 'scout', 'slack', or 'zapier'",
     )
-
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        if v is not None and not v.startswith("https://"):
-            raise ValueError("webhook_url must use HTTPS (https://)")
-        return v
     output_fields: list[str] | None = Field(
         default=None,
         description=(
@@ -150,6 +143,13 @@ class EditScoutInput(BaseModel):
         default=None,
         description="Whether scout results are publicly accessible",
     )
+
+    @field_validator("webhook_url")
+    @classmethod
+    def validate_webhook_url(cls, v: str | None) -> str | None:
+        if v is not None and not v.startswith("https://"):
+            raise ValueError("webhook_url must use HTTPS (https://)")
+        return v
 
     @model_validator(mode="after")
     def validate_has_changes(self) -> "EditScoutInput":


### PR DESCRIPTION
## Summary

- Move `output_fields` field in `EditScoutInput` from after the `@field_validator` method to sit with the other fields
- Restores conventional Pydantic class ordering: fields first, then validators
- The field was syntactically valid but confusingly placed between a field validator and model validator

cc @dhruvbatra (original author of schemas.py)

## Test plan
- [ ] Verify Pydantic model still validates correctly
- [ ] Confirm `output_fields` is still accessible on `EditScoutInput`

https://claude.ai/code/session_01DmVaUmyLmZRvMzS7fPUie7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes class member ordering in a Pydantic schema without altering validation logic or runtime behavior.
> 
> **Overview**
> **Reorders `EditScoutInput` in `schemas.py` for clarity.** The `output_fields` declaration is moved back into the block of field definitions (fields first), and the `@field_validator("webhook_url")` is moved down to sit with the other validators before the `@model_validator`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf08c86896ef0ea795900e276942a85410c28888. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->