### PR TITLE
cleanup: deduplicate webhook URL validator in schemas.py

### DIFF
--- a/.claude/CLEANUP.md
+++ b/.claude/CLEANUP.md
@@ -1,3 +1,7 @@
 # Cleanup Backlog
 
 Items identified for future cleanup runs. Pick one per run.
+
+## Completed
+- [x] `schemas.py` — Duplicate `validate_webhook_url` method copied identically in 4 classes; extracted to shared `_check_webhook_https` validator.
+- [x] `schemas.py:119-127` — `output_fields` field defined after a `@field_validator`, breaking conventional Pydantic class ordering; moved before validators.

--- a/.claude/CLEANUP_LOG.md
+++ b/.claude/CLEANUP_LOG.md
@@ -3,3 +3,4 @@
 | Date | Action | Details |
 |------|--------|---------|
 | 2026-04-03 | Changed | Removed unused `DEFAULT_LIMIT = 10` from `src/yutori_mcp/formatters.py` — dead code, never referenced anywhere in the codebase |
+| 2026-04-05 | Changed | Deduplicated `validate_webhook_url` in `schemas.py` — extracted shared `_check_webhook_https()` function, replaced 4 identical copy-pasted validators. Also fixed misplaced `output_fields` field in `EditScoutInput`. |

--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -89,10 +89,7 @@ class CreateScoutInput(BaseModel):
         description="Whether scout results are publicly accessible",
     )
 
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        return _check_webhook_https(v)
+    validate_webhook_url = field_validator("webhook_url")(_check_webhook_https)
 
 
 class EditScoutInput(BaseModel):
@@ -149,10 +146,7 @@ class EditScoutInput(BaseModel):
         description="Whether scout results are publicly accessible",
     )
 
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        return _check_webhook_https(v)
+    validate_webhook_url = field_validator("webhook_url")(_check_webhook_https)
 
     @model_validator(mode="after")
     def validate_has_changes(self) -> "EditScoutInput":
@@ -268,10 +262,7 @@ class BrowsingTaskInput(BaseModel):
         description="Webhook payload format: 'scout' (default) or 'slack'",
     )
 
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        return _check_webhook_https(v)
+    validate_webhook_url = field_validator("webhook_url")(_check_webhook_https)
 
 
 class TaskIdInput(BaseModel):
@@ -327,7 +318,4 @@ class ResearchTaskInput(BaseModel):
         description="Webhook payload format: 'scout' (default), 'slack', or 'zapier'",
     )
 
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        return _check_webhook_https(v)
+    validate_webhook_url = field_validator("webhook_url")(_check_webhook_https)

--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -7,6 +7,13 @@ from typing import Literal
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 
+def _check_webhook_https(v: str | None) -> str | None:
+    """Validate that a webhook URL uses HTTPS."""
+    if v is not None and not v.startswith("https://"):
+        raise ValueError("webhook_url must use HTTPS (https://)")
+    return v
+
+
 class UsageInput(BaseModel):
     """Input for retrieving API usage statistics."""
 
@@ -85,9 +92,7 @@ class CreateScoutInput(BaseModel):
     @field_validator("webhook_url")
     @classmethod
     def validate_webhook_url(cls, v: str | None) -> str | None:
-        if v is not None and not v.startswith("https://"):
-            raise ValueError("webhook_url must use HTTPS (https://)")
-        return v
+        return _check_webhook_https(v)
 
 
 class EditScoutInput(BaseModel):
@@ -118,13 +123,6 @@ class EditScoutInput(BaseModel):
         default=None,
         description="Updated webhook format: 'scout', 'slack', or 'zapier'",
     )
-
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        if v is not None and not v.startswith("https://"):
-            raise ValueError("webhook_url must use HTTPS (https://)")
-        return v
     output_fields: list[str] | None = Field(
         default=None,
         description=(
@@ -150,6 +148,11 @@ class EditScoutInput(BaseModel):
         default=None,
         description="Whether scout results are publicly accessible",
     )
+
+    @field_validator("webhook_url")
+    @classmethod
+    def validate_webhook_url(cls, v: str | None) -> str | None:
+        return _check_webhook_https(v)
 
     @model_validator(mode="after")
     def validate_has_changes(self) -> "EditScoutInput":
@@ -268,9 +271,7 @@ class BrowsingTaskInput(BaseModel):
     @field_validator("webhook_url")
     @classmethod
     def validate_webhook_url(cls, v: str | None) -> str | None:
-        if v is not None and not v.startswith("https://"):
-            raise ValueError("webhook_url must use HTTPS (https://)")
-        return v
+        return _check_webhook_https(v)
 
 
 class TaskIdInput(BaseModel):
@@ -329,6 +330,4 @@ class ResearchTaskInput(BaseModel):
     @field_validator("webhook_url")
     @classmethod
     def validate_webhook_url(cls, v: str | None) -> str | None:
-        if v is not None and not v.startswith("https://"):
-            raise ValueError("webhook_url must use HTTPS (https://)")
-        return v
+        return _check_webhook_https(v)


### PR DESCRIPTION
## Summary

- Extract identical `validate_webhook_url` logic (copy-pasted across 4 schema classes) into a shared `_check_webhook_https()` helper function
- Fix `output_fields` field placement in `EditScoutInput` — it was incorrectly positioned after a `@field_validator` method instead of with the other field declarations

All 106 tests pass.

## Items from `.claude/CLEANUP.md`
- `schemas.py` — Duplicate `validate_webhook_url` method
- `schemas.py:119-127` — `output_fields` field ordering

cc @dhruvbatra (primary maintainer of schemas.py)

## Test plan
- [x] `pytest tests/test_schemas.py` — 38 tests pass
- [x] `pytest tests/` — all 106 tests pass
- [ ] Verify webhook URL validation still rejects non-HTTPS URLs

https://claude.ai/code/session_01Q5LyDvGGCurvAw69LgsWTf

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor: validation behavior should remain the same, with only minor schema definition reordering and shared helper extraction.
> 
> **Overview**
> Extracts the repeated `validate_webhook_url` logic in `schemas.py` into a shared `_check_webhook_https()` helper and wires it into the four affected Pydantic models via `field_validator`.
> 
> Reorders `EditScoutInput.output_fields` to be declared with the other fields (before validators) and updates `.claude/CLEANUP.md`/`CLEANUP_LOG.md` to record the completed cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b48be7f6e423a0fa3e13ee1821d24358391eeba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->