### PR TITLE
Extract shared WebhookUrl validator to deduplicate schemas.py

### DIFF
--- a/.claude/CLEANUP_LOG.md
+++ b/.claude/CLEANUP_LOG.md
@@ -3,3 +3,4 @@
 | Date | Action | Details |
 |------|--------|---------|
 | 2026-04-03 | Changed | Removed unused `DEFAULT_LIMIT = 10` from `src/yutori_mcp/formatters.py` — dead code, never referenced anywhere in the codebase |
+| 2026-04-05 | Changed | Extracted duplicate `validate_webhook_url` into shared `WebhookUrl` annotated type in `schemas.py`; also fixed misplaced `output_fields` in `EditScoutInput` |

--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -2,9 +2,18 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import AfterValidator, BaseModel, Field, model_validator
+
+
+def _validate_https_url(v: str | None) -> str | None:
+    if v is not None and not v.startswith("https://"):
+        raise ValueError("webhook_url must use HTTPS (https://)")
+    return v
+
+
+WebhookUrl = Annotated[str | None, AfterValidator(_validate_https_url)]
 
 
 class UsageInput(BaseModel):
@@ -40,7 +49,7 @@ class CreateScoutInput(BaseModel):
         ge=1800,
         description="Seconds between scout runs. Minimum 1800 (30 minutes). Default: 86400 (daily)",
     )
-    webhook_url: str | None = Field(
+    webhook_url: WebhookUrl = Field(
         default=None,
         description=(
             "HTTPS URL to receive webhook notifications when updates are available. "
@@ -82,13 +91,6 @@ class CreateScoutInput(BaseModel):
         description="Whether scout results are publicly accessible",
     )
 
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        if v is not None and not v.startswith("https://"):
-            raise ValueError("webhook_url must use HTTPS (https://)")
-        return v
-
 
 class EditScoutInput(BaseModel):
     """Input for editing an existing scout or changing its status."""
@@ -110,7 +112,7 @@ class EditScoutInput(BaseModel):
         ge=1800,
         description="Updated run interval in seconds. Minimum 1800 (30 minutes)",
     )
-    webhook_url: str | None = Field(
+    webhook_url: WebhookUrl = Field(
         default=None,
         description="Updated HTTPS webhook URL. Must use https://. Confirm the URL with the user before setting.",
     )
@@ -118,13 +120,6 @@ class EditScoutInput(BaseModel):
         default=None,
         description="Updated webhook format: 'scout', 'slack', or 'zapier'",
     )
-
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        if v is not None and not v.startswith("https://"):
-            raise ValueError("webhook_url must use HTTPS (https://)")
-        return v
     output_fields: list[str] | None = Field(
         default=None,
         description=(
@@ -256,7 +251,7 @@ class BrowsingTaskInput(BaseModel):
             "https://docs.yutori.com/reference/browsing-create#using-webhooks-and-a-structured-output-schema)."
         ),
     )
-    webhook_url: str | None = Field(
+    webhook_url: WebhookUrl = Field(
         default=None,
         description="HTTPS URL to receive webhook notification when task completes. Must use https://.",
     )
@@ -264,13 +259,6 @@ class BrowsingTaskInput(BaseModel):
         default=None,
         description="Webhook payload format: 'scout' (default) or 'slack'",
     )
-
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        if v is not None and not v.startswith("https://"):
-            raise ValueError("webhook_url must use HTTPS (https://)")
-        return v
 
 
 class TaskIdInput(BaseModel):
@@ -317,7 +305,7 @@ class ResearchTaskInput(BaseModel):
             "https://docs.yutori.com/reference/research-create#using-webhooks-and-a-structured-output-schema)."
         ),
     )
-    webhook_url: str | None = Field(
+    webhook_url: WebhookUrl = Field(
         default=None,
         description="HTTPS URL to receive webhook notification when research completes. Must use https://.",
     )
@@ -325,10 +313,3 @@ class ResearchTaskInput(BaseModel):
         default=None,
         description="Webhook payload format: 'scout' (default), 'slack', or 'zapier'",
     )
-
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        if v is not None and not v.startswith("https://"):
-            raise ValueError("webhook_url must use HTTPS (https://)")
-        return v


### PR DESCRIPTION
## Summary

- Replaced 4 identical `validate_webhook_url` `@field_validator` methods with a shared `WebhookUrl` annotated type using Pydantic's `AfterValidator`
- Fixed misplaced `output_fields` field in `EditScoutInput` that was incorrectly positioned after a `@field_validator` method, breaking conventional Pydantic class ordering
- Net removal of ~18 lines of duplicated code

## Details

The `validate_webhook_url` classmethod was copy-pasted identically across `CreateScoutInput`, `EditScoutInput`, `BrowsingTaskInput`, and `ResearchTaskInput`. This PR extracts the validation logic into a standalone `_validate_https_url` function and a reusable `WebhookUrl = Annotated[str | None, AfterValidator(...)]` type alias, which is the idiomatic Pydantic v2 approach.

All 38 existing tests pass without modification.

cc @dhruvbatra @jaspergilley — you two have the most commits on this file.

## Test plan

- [x] All 38 tests in `tests/test_schemas.py` pass
- [x] Webhook URL validation behavior is preserved (HTTPS required, None allowed)
- [x] No changes to public API — field names, types, and descriptions unchanged

https://claude.ai/code/session_011pjER1McWTpUtTdsKcQYxc

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to Pydantic schema validation, intended to preserve existing HTTPS-only behavior. Minor risk if `AfterValidator` semantics differ from the prior `@field_validator` in edge cases.
> 
> **Overview**
> Centralizes `webhook_url` HTTPS validation in `schemas.py` by adding `_validate_https_url` and a reusable `WebhookUrl` (`Annotated` + Pydantic `AfterValidator`), and switches the `webhook_url` fields in multiple input models to use this shared type.
> 
> Also fixes `EditScoutInput` field ordering by placing `output_fields` with the other model fields (instead of after the removed validator), and records the cleanup in `.claude/CLEANUP_LOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53052237b81802e567823b6d6b33d9505ef879bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->