### PR TITLE
Extract shared webhook URL validator in schemas.py

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -7,6 +7,13 @@ from typing import Literal
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 
+def _check_webhook_https(v: str | None) -> str | None:
+    """Validate that webhook_url uses HTTPS."""
+    if v is not None and not v.startswith("https://"):
+        raise ValueError("webhook_url must use HTTPS (https://)")
+    return v
+
+
 class UsageInput(BaseModel):
     """Input for retrieving API usage statistics."""
 
@@ -85,9 +92,7 @@ class CreateScoutInput(BaseModel):
     @field_validator("webhook_url")
     @classmethod
     def validate_webhook_url(cls, v: str | None) -> str | None:
-        if v is not None and not v.startswith("https://"):
-            raise ValueError("webhook_url must use HTTPS (https://)")
-        return v
+        return _check_webhook_https(v)
 
 
 class EditScoutInput(BaseModel):
@@ -118,13 +123,6 @@ class EditScoutInput(BaseModel):
         default=None,
         description="Updated webhook format: 'scout', 'slack', or 'zapier'",
     )
-
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        if v is not None and not v.startswith("https://"):
-            raise ValueError("webhook_url must use HTTPS (https://)")
-        return v
     output_fields: list[str] | None = Field(
         default=None,
         description=(
@@ -150,6 +148,11 @@ class EditScoutInput(BaseModel):
         default=None,
         description="Whether scout results are publicly accessible",
     )
+
+    @field_validator("webhook_url")
+    @classmethod
+    def validate_webhook_url(cls, v: str | None) -> str | None:
+        return _check_webhook_https(v)
 
     @model_validator(mode="after")
     def validate_has_changes(self) -> "EditScoutInput":
@@ -268,9 +271,7 @@ class BrowsingTaskInput(BaseModel):
     @field_validator("webhook_url")
     @classmethod
     def validate_webhook_url(cls, v: str | None) -> str | None:
-        if v is not None and not v.startswith("https://"):
-            raise ValueError("webhook_url must use HTTPS (https://)")
-        return v
+        return _check_webhook_https(v)
 
 
 class TaskIdInput(BaseModel):
@@ -329,6 +330,4 @@ class ResearchTaskInput(BaseModel):
     @field_validator("webhook_url")
     @classmethod
     def validate_webhook_url(cls, v: str | None) -> str | None:
-        if v is not None and not v.startswith("https://"):
-            raise ValueError("webhook_url must use HTTPS (https://)")
-        return v
+        return _check_webhook_https(v)


### PR DESCRIPTION
## Summary

- Extract identical `validate_webhook_url` logic from 4 schema classes (`CreateScoutInput`, `EditScoutInput`, `BrowsingTaskInput`, `ResearchTaskInput`) into a shared `_check_webhook_https` module-level helper
- Fix misplaced `output_fields` field in `EditScoutInput` that was defined after a `@field_validator` method, breaking conventional Pydantic class ordering (fields first, then validators)

All 106 tests pass.

cc @dhruvbatra

## Test plan
- [x] All 38 schema tests pass
- [x] Full test suite (106 tests) passes
- [ ] Verify webhook URL validation still rejects non-HTTPS URLs

https://claude.ai/code/session_01CAzdS1wA1gChjFQLXhDumv

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to Pydantic schema validation; behavior should remain identical aside from possible ordering/validation edge cases.
> 
> **Overview**
> Refactors `schemas.py` to deduplicate identical `webhook_url` HTTPS validation by introducing `_check_webhook_https()` and reusing it across the affected input models.
> 
> Also reorders `EditScoutInput` so `output_fields` is defined with the other fields (before validators), keeping class structure consistent and avoiding field/validator ordering issues.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3ac32a211cb510d6449e2a92f6165d0c7b3e92b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->