### PR TITLE
Remove stale CLEANUP.md — consolidated in yutori monorepo

### DIFF
--- a/.claude/CLEANUP.md
+++ b/.claude/CLEANUP.md
@@ -1,5 +1,0 @@
-# Cleanup Backlog
-
-Items identified for future cleanup runs. Pick one per run.
-
-(empty — add new items as they are discovered)


### PR DESCRIPTION
## Summary

- Remove .claude/CLEANUP.md from this repo
- The single source of truth for cleanup backlog is yutori-ai/yutori/.claude/CLEANUP.md

https://claude.ai/code/session_01RhG8zRL9UMW5CRMw1ow653

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk change that only deletes an unused documentation/backlog file and does not affect runtime code or behavior.
> 
> **Overview**
> Removes the stale `.claude/CLEANUP.md` cleanup-backlog document from this repository, leaving cleanup tracking to be handled elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3548d7f85534b8cd461d87f3e138585a2a82f15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->