### PR TITLE
Add require_auth, browser, rejection_reason, zapier webhook (ENG-4632)

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -393,7 +393,6 @@ Execute a one-time web browsing task using the navigator agent. The agent runs e
   "start_url": "https://example.com/login",
   "max_steps": 75,
   "require_auth": true,
-  "browser": "local",
   "webhook_url": "https://example.com/webhook",
   "output_fields": ["name", "title"]
 }
@@ -416,7 +415,7 @@ Poll with get_browsing_task_result(task_id="54fb19fd-277e-4098-ab72-5a9f8a4347fc
 | `task` | Yes | Natural language instruction for the navigator |
 | `start_url` | Yes | URL where browsing begins |
 | `max_steps` | No | Max browser actions (1-100). Default: 25 |
-| `require_auth` | No | If true, use the auth-optimized browser for login and other authenticated flows |
+| `require_auth` | No | If true, use an auth-optimized cloud browser provider for login flows. Only applies when browser is `cloud` (default) |
 | `browser` | No | `cloud` (default) or `local` to use Yutori Local with the user's logged-in desktop browser |
 | `output_fields` | No | List of field names for structured output as array of objects |
 | `webhook_url` | No | URL for completion notification |

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -301,6 +301,7 @@ Execute a one-time deep web research task. The research agent searches, reads, a
 {
   "query": "What are the latest developments in quantum computing from the past week? Include company announcements, research papers, and product releases.",
   "user_timezone": "America/Los_Angeles",
+  "browser": "local",
   "webhook_url": "https://example.com/webhook",
   "output_fields": ["title", "summary", "source_url", "category"]
 }
@@ -323,6 +324,7 @@ Poll with get_research_task_result(task_id="ae27a17c-a4ed-4c69-8b2a-4bec330fc935
 | `query` | Yes | Natural language description of what to research |
 | `user_timezone` | No | Timezone for context. Default: 'America/Los_Angeles' |
 | `user_location` | No | Location for context. Default: 'San Francisco, CA, US' |
+| `browser` | No | `cloud` (default) or `local` to use Yutori Local with the user's logged-in desktop browser |
 | `output_fields` | No | List of field names for structured output as array of objects |
 | `webhook_url` | No | URL for completion notification |
 | `webhook_format` | No | `scout` (default), `slack`, or `zapier` |
@@ -372,7 +374,7 @@ and an industry appearance from January 12–19, 2026.
 
 ### run_browsing_task
 
-Execute a one-time web browsing task using the navigator agent. The agent runs a cloud browser and operates it like a person - clicking, typing, scrolling, and navigating for you.
+Execute a one-time web browsing task using the navigator agent. The agent runs either a cloud browser or Yutori Local on the desktop and operates it like a person - clicking, typing, scrolling, and navigating for you.
 
 **Basic example:**
 
@@ -387,9 +389,11 @@ Execute a one-time web browsing task using the navigator agent. The agent runs a
 
 ```json
 {
-  "task": "Give me a list of all employees (names and titles) of Yutori.",
-  "start_url": "https://yutori.com",
+  "task": "Log in and export the latest invoice.",
+  "start_url": "https://example.com/login",
   "max_steps": 75,
+  "require_auth": true,
+  "browser": "local",
   "webhook_url": "https://example.com/webhook",
   "output_fields": ["name", "title"]
 }
@@ -412,9 +416,11 @@ Poll with get_browsing_task_result(task_id="54fb19fd-277e-4098-ab72-5a9f8a4347fc
 | `task` | Yes | Natural language instruction for the navigator |
 | `start_url` | Yes | URL where browsing begins |
 | `max_steps` | No | Max browser actions (1-100). Default: 25 |
+| `require_auth` | No | If true, use the auth-optimized browser for login and other authenticated flows |
+| `browser` | No | `cloud` (default) or `local` to use Yutori Local with the user's logged-in desktop browser |
 | `output_fields` | No | List of field names for structured output as array of objects |
 | `webhook_url` | No | URL for completion notification |
-| `webhook_format` | No | `scout` (default) or `slack` |
+| `webhook_format` | No | `scout` (default), `slack`, or `zapier` |
 
 ### get_browsing_task_result
 

--- a/skills/02-research/SKILL.md
+++ b/skills/02-research/SKILL.md
@@ -27,6 +27,7 @@ Help the user conduct thorough web research using Yutori's Research API.
    Use `run_research_task` with:
    - `query`: The research question with context
    - `user_timezone`: For time-relevant searches
+   - `browser: "local"`: When the research needs a logged-in desktop browser session through Yutori Local
    - `output_fields`: If structured output is needed (e.g., ["title", "summary", "source_url", "date"])
 
 4. **Poll for results**

--- a/skills/03-browse/SKILL.md
+++ b/skills/03-browse/SKILL.md
@@ -25,6 +25,8 @@ Help the user automate browser-based tasks using Yutori's Navigator agent.
    - `task`: Clear natural language instructions
    - `start_url`: The URL to begin browsing
    - `max_steps`: 25 (default) to 100 for complex flows
+   - `require_auth: true`: For login forms or other authenticated workflows
+   - `browser: "local"`: When the task should run through Yutori Local with the user's desktop session
    - `output_fields`: For structured data extraction (e.g., ["name", "price", "url"])
 
 4. **Poll for results**

--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -113,6 +113,14 @@ def _truncate(text: str, max_len: int = 60) -> str:
     return text[: max_len - 3] + "..."
 
 
+def _append_rejection_reason(
+    lines: list[str], rejection_reason: str | None, *, indent: str = ""
+) -> None:
+    """Append rejection_reason when present."""
+    if rejection_reason:
+        lines.append(f"{indent}Rejection reason: {rejection_reason}")
+
+
 # -----------------------------------------------------------------------------
 # Usage formatter
 # -----------------------------------------------------------------------------
@@ -209,6 +217,7 @@ def format_list_scouts(response: dict[str, Any], **context: Any) -> str:
         lines.append(f"   ID: {scout_id}")
         lines.append(f"   URL: https://platform.yutori.com/scouting/tasks/{scout_id}")
         lines.append(f"   Runs {interval} | Next: {next_run}")
+        _append_rejection_reason(lines, scout.get("rejection_reason"), indent="   ")
 
     # Add hints
     lines.append("")
@@ -233,13 +242,18 @@ def format_scout_detail(response: dict[str, Any], **context: Any) -> str:
         f"ID: {scout_id}",
         f"URL: https://platform.yutori.com/scouting/tasks/{scout_id}",
         f"Status: {status}",
-        "",
-        f'Query: "{query}"',
-        "",
-        "Schedule:",
-        f"  Interval: {_format_interval(response.get('output_interval'))}",
-        f"  Next run: {_format_datetime(response.get('next_output_timestamp'))}",
     ]
+    _append_rejection_reason(lines, response.get("rejection_reason"))
+    lines.extend(
+        [
+            "",
+            f'Query: "{query}"',
+            "",
+            "Schedule:",
+            f"  Interval: {_format_interval(response.get('output_interval'))}",
+            f"  Next run: {_format_datetime(response.get('next_output_timestamp'))}",
+        ]
+    )
 
     if response.get("user_timezone"):
         lines.append(f"  Timezone: {response['user_timezone']}")
@@ -373,11 +387,16 @@ def format_scout_created(response: dict[str, Any], **context: Any) -> str:
         f"ID: {scout_id}",
         f"URL: https://platform.yutori.com/scouting/tasks/{scout_id}",
         f"Status: {status}",
-        "",
-        f'Query: "{_truncate(query, 80)}"',
-        f"Schedule: runs {interval}",
-        f"First run: {next_run}",
     ]
+    _append_rejection_reason(lines, response.get("rejection_reason"))
+    lines.extend(
+        [
+            "",
+            f'Query: "{_truncate(query, 80)}"',
+            f"Schedule: runs {interval}",
+            f"First run: {next_run}",
+        ]
+    )
 
     return "\n".join(lines)
 
@@ -392,19 +411,17 @@ def format_scout_edited(response: dict[str, Any], **context: Any) -> str:
         name = new.get("display_name") or new.get("query", "")[:40]
         scout_id = new.get("id", "")
         status = new.get("status", "unknown")
-
-        return "\n".join(
-            [
-                "Scout updated successfully.",
-                "",
-                f"Name: {name}",
-                f"ID: {scout_id}",
-                f"URL: https://platform.yutori.com/scouting/tasks/{scout_id}",
-                f"Status: {status}",
-                "",
-                "Use get_scout_detail(scout_id) for full details.",
-            ]
-        )
+        lines = [
+            "Scout updated successfully.",
+            "",
+            f"Name: {name}",
+            f"ID: {scout_id}",
+            f"URL: https://platform.yutori.com/scouting/tasks/{scout_id}",
+            f"Status: {status}",
+        ]
+        _append_rejection_reason(lines, new.get("rejection_reason"))
+        lines.extend(["", "Use get_scout_detail(scout_id) for full details."])
+        return "\n".join(lines)
 
     # Show diff
     name = new.get("display_name") or new.get("query", "")[:40]
@@ -455,6 +472,11 @@ def format_scout_edited(response: dict[str, Any], **context: Any) -> str:
     if not changes_found:
         lines.append("  (no changes detected)")
 
+    reason = new.get("rejection_reason")
+    if reason:
+        lines.append("")
+        _append_rejection_reason(lines, reason)
+
     return "\n".join(lines)
 
 
@@ -497,12 +519,25 @@ def format_task_started(response: dict[str, Any], **context: Any) -> str:
     browser = context.get("browser")
     browser_note = " (using local desktop browser)" if browser == "local" else ""
 
+    if status == "failed":
+        lines = [
+            f"{task_type} task failed to start{browser_note}.",
+            "",
+            f"Task ID: {task_id}",
+            f"Status: {status}",
+        ]
+        _append_rejection_reason(lines, response.get("rejection_reason"))
+        if view_url:
+            lines.append(f"View details: {view_url}")
+        return "\n".join(lines)
+
     lines = [
         f"{task_type} task started{browser_note}.",
         "",
         f"Task ID: {task_id}",
         f"Status: {status}",
     ]
+    _append_rejection_reason(lines, response.get("rejection_reason"))
 
     if view_url:
         lines.append(f"View progress: {view_url}")
@@ -547,14 +582,14 @@ def format_task_result(response: dict[str, Any], **context: Any) -> str:
     # Handle failed state
     if status == "failed":
         error = response.get("error") or response.get("message") or "Unknown error"
-        return "\n".join(
-            [
-                "Task failed.",
-                "",
-                f"Task ID: {task_id}",
-                f"Error: {error}",
-            ]
-        )
+        lines = [
+            "Task failed.",
+            "",
+            f"Task ID: {task_id}",
+            f"Error: {error}",
+        ]
+        _append_rejection_reason(lines, response.get("rejection_reason"))
+        return "\n".join(lines)
 
     # Handle completed state
     lines = [

--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -54,7 +54,7 @@ class CreateScoutInput(BaseModel):
             "Must use https://. Confirm the URL with the user before setting."
         ),
     )
-    webhook_format: str | None = Field(
+    webhook_format: Literal["scout", "slack", "zapier"] | None = Field(
         default=None,
         description="Webhook payload format: 'scout' (default), 'slack', or 'zapier'",
     )
@@ -119,7 +119,7 @@ class EditScoutInput(BaseModel):
         default=None,
         description="Updated HTTPS webhook URL. Must use https://. Confirm the URL with the user before setting.",
     )
-    webhook_format: str | None = Field(
+    webhook_format: Literal["scout", "slack", "zapier"] | None = Field(
         default=None,
         description="Updated webhook format: 'scout', 'slack', or 'zapier'",
     )
@@ -241,11 +241,15 @@ class BrowsingTaskInput(BaseModel):
         le=100,
         description="Maximum number of browser actions (1-100). Default: 25",
     )
-    browser: str | None = Field(
+    require_auth: bool | None = Field(
+        default=None,
+        description="If true, use the auth-optimized browser for login and other authenticated flows.",
+    )
+    browser: Literal["cloud", "local"] | None = Field(
         default=None,
         description=(
             "Where to run the browser. 'cloud' (default) uses Yutori's cloud browser. "
-            "'local' uses the desktop app (Yutori's Computer) with the user's logged-in sessions. "
+            "'local' uses Yutori Local with the user's logged-in sessions on the desktop. "
             "Requires the desktop app to be running."
         ),
     )
@@ -263,9 +267,9 @@ class BrowsingTaskInput(BaseModel):
         default=None,
         description="HTTPS URL to receive webhook notification when task completes. Must use https://.",
     )
-    webhook_format: str | None = Field(
+    webhook_format: Literal["scout", "slack", "zapier"] | None = Field(
         default=None,
-        description="Webhook payload format: 'scout' (default) or 'slack'",
+        description="Webhook payload format: 'scout' (default), 'slack', or 'zapier'",
     )
 
     @field_validator("webhook_url")
@@ -308,6 +312,14 @@ class ResearchTaskInput(BaseModel):
         default=None,
         description="Location for contextual awareness. Format: 'city, region, country'. Default: 'San Francisco, CA, US'",
     )
+    browser: Literal["cloud", "local"] | None = Field(
+        default=None,
+        description=(
+            "Where to run the browser when research needs web interaction. 'cloud' (default) uses "
+            "Yutori's cloud browser. 'local' uses Yutori Local with the user's logged-in sessions "
+            "on the desktop. Requires the desktop app to be running."
+        ),
+    )
     output_fields: list[str] | None = Field(
         default=None,
         description=(
@@ -322,7 +334,7 @@ class ResearchTaskInput(BaseModel):
         default=None,
         description="HTTPS URL to receive webhook notification when research completes. Must use https://.",
     )
-    webhook_format: str | None = Field(
+    webhook_format: Literal["scout", "slack", "zapier"] | None = Field(
         default=None,
         description="Webhook payload format: 'scout' (default), 'slack', or 'zapier'",
     )

--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -243,7 +243,7 @@ class BrowsingTaskInput(BaseModel):
     )
     require_auth: bool | None = Field(
         default=None,
-        description="If true, use the auth-optimized browser for login and other authenticated flows.",
+        description="If true, use an auth-optimized cloud browser provider for login flows. Only applies when browser is 'cloud' (default).",
     )
     browser: Literal["cloud", "local"] | None = Field(
         default=None,

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -180,7 +180,8 @@ TOOLS = [
         description=(
             "Execute a one-time deep web research task. The research agent searches, "
             "reads, and synthesizes information from across the web. Returns a task_id for polling. "
-            "Example: 'latest AI startup funding announcements'."
+            "Example: 'latest AI startup funding announcements'. Set browser='local' "
+            "to use Yutori Local with the user's logged-in sessions."
         ),
         inputSchema=_get_simplified_schema(ResearchTaskInput),
     ),
@@ -317,6 +318,7 @@ def _handle_tool(client: MCPClientAdapter, name: str, arguments: dict[str, Any])
                 task=params.task,
                 start_url=params.start_url,
                 max_steps=params.max_steps,
+                require_auth=params.require_auth,
                 browser=params.browser,
                 output_schema=_output_fields_to_output_schema(params.output_fields),
                 webhook_url=params.webhook_url,
@@ -334,11 +336,12 @@ def _handle_tool(client: MCPClientAdapter, name: str, arguments: dict[str, Any])
                 query=params.query,
                 user_timezone=params.user_timezone,
                 user_location=params.user_location,
+                browser=params.browser,
                 output_schema=_output_fields_to_output_schema(params.output_fields),
                 webhook_url=params.webhook_url,
                 webhook_format=params.webhook_format,
             )
-            return result, {"task_type": "Research"}
+            return result, {"task_type": "Research", "browser": params.browser}
         case "get_research_task_result":
             params = TaskIdInput(**arguments)
             return client.get_research_task(params.task_id), {"task_type": "Research"}

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -190,3 +190,29 @@ class TestEditScoutForwarding:
         _, kwargs = adapter._client.scouts.update.call_args
         assert kwargs["query"] == "updated query"
         assert kwargs["skip_email"] is True
+
+
+class TestBrowsingAndResearchForwarding:
+    """Browsing and research should forward newly supported developer API fields."""
+
+    def test_browsing_forwards_require_auth_browser_and_zapier(self, adapter):
+        adapter._client.browsing.create = MagicMock(return_value={"task_id": "t1"})
+        adapter.run_browsing_task(
+            "Log in and export data",
+            "https://example.com/login",
+            require_auth=True,
+            browser="local",
+            webhook_format="zapier",
+        )
+
+        _, kwargs = adapter._client.browsing.create.call_args
+        assert kwargs["require_auth"] is True
+        assert kwargs["browser"] == "local"
+        assert kwargs["webhook_format"] == "zapier"
+
+    def test_research_forwards_browser(self, adapter):
+        adapter._client.research.create = MagicMock(return_value={"task_id": "r1"})
+        adapter.run_research_task("Research a logged-in dashboard", browser="local")
+
+        _, kwargs = adapter._client.research.create.call_args
+        assert kwargs["browser"] == "local"

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -172,6 +172,23 @@ class TestFormatListScouts:
         result = format_list_scouts(response)
         assert "limit=50" in result
 
+    def test_shows_rejection_reason(self):
+        """Scout list includes rejection reason when present."""
+        response = {
+            "scouts": [
+                {
+                    "id": "abc-123",
+                    "query": "monitor something",
+                    "status": "paused",
+                    "rejection_reason": "invalid_query",
+                }
+            ],
+            "total": 1,
+            "summary": {"active": 0, "paused": 1, "done": 0},
+        }
+        result = format_list_scouts(response)
+        assert "Rejection reason: invalid_query" in result
+
 
 class TestFormatScoutDetail:
     def test_full_detail(self):
@@ -196,6 +213,17 @@ class TestFormatScoutDetail:
         assert "daily" in result
         assert "Email notifications: enabled" in result
         assert "Public: yes" in result
+
+    def test_shows_rejection_reason(self):
+        """Scout detail includes rejection reason when present."""
+        response = {
+            "id": "abc-123",
+            "query": "monitor AI news",
+            "status": "paused",
+            "rejection_reason": "invalid_query",
+        }
+        result = format_scout_detail(response)
+        assert "Rejection reason: invalid_query" in result
 
 
 class TestFormatScoutCreated:
@@ -301,6 +329,18 @@ class TestFormatTaskStarted:
         assert "get_browsing_task_result" in result
         assert "https://yutori.com/tasks/xyz" in result
 
+    def test_shows_rejection_reason(self):
+        """Failed create output includes rejection reason when present."""
+        response = {
+            "task_id": "task-abc",
+            "status": "failed",
+            "rejection_reason": "billing_limit_reached",
+        }
+        result = format_task_started(response, task_type="Research")
+        assert "Research task failed to start" in result
+        assert "Rejection reason: billing_limit_reached" in result
+        assert "Poll with" not in result
+
 
 class TestFormatTaskResult:
     def test_in_progress(self):
@@ -318,6 +358,18 @@ class TestFormatTaskResult:
         assert "Task completed" in result
         assert "succeeded" in result
         assert "Here are the findings" in result
+
+    def test_failed_shows_rejection_reason(self):
+        """Failed task output includes rejection reason when present."""
+        response = {
+            "task_id": "task-abc",
+            "status": "failed",
+            "error": "Rejected",
+            "rejection_reason": "billing_limit_reached",
+        }
+        result = format_task_result(response)
+        assert "Task failed" in result
+        assert "Rejection reason: billing_limit_reached" in result
 
     def test_failed(self):
         """Failed task shows error."""

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -195,6 +195,8 @@ class TestBrowsingTaskInput:
         )
         assert data.task == "Find AAPL stock price"
         assert data.start_url == "https://finance.yahoo.com"
+        assert data.require_auth is None
+        assert data.browser is None
 
     def test_missing_task(self):
         """task is required."""
@@ -230,6 +232,19 @@ class TestBrowsingTaskInput:
         """output_fields is optional."""
         data = BrowsingTaskInput(task="Test", start_url="https://example.com")
         assert data.output_fields is None
+
+    def test_full_input(self):
+        """Local browser, auth, and zapier webhook are accepted."""
+        data = BrowsingTaskInput(
+            task="Log in and export data",
+            start_url="https://example.com/login",
+            require_auth=True,
+            browser="local",
+            webhook_format="zapier",
+        )
+        assert data.require_auth is True
+        assert data.browser == "local"
+        assert data.webhook_format == "zapier"
 
 
 class TestScoutIdInput:
@@ -319,6 +334,7 @@ class TestResearchTaskInput:
         assert data.query == "Research quantum computing developments"
         assert data.user_timezone is None
         assert data.user_location is None
+        assert data.browser is None
 
     def test_full_input(self):
         """All fields can be provided."""
@@ -326,12 +342,14 @@ class TestResearchTaskInput:
             query="Research quantum computing developments",
             user_timezone="America/New_York",
             user_location="New York, NY, US",
+            browser="local",
             output_fields=["title", "summary", "source_url"],
             webhook_url="https://example.com/webhook",
             webhook_format="slack",
         )
         assert data.user_timezone == "America/New_York"
         assert data.user_location == "New York, NY, US"
+        assert data.browser == "local"
         assert data.webhook_format == "slack"
         assert data.output_fields == ["title", "summary", "source_url"]
 
@@ -344,3 +362,69 @@ class TestResearchTaskInput:
         """output_fields is optional."""
         data = ResearchTaskInput(query="Research AI")
         assert data.output_fields is None
+
+    def test_local_browser_supported(self):
+        """Research can target the local desktop browser."""
+        data = ResearchTaskInput(
+            query="Research a logged-in dashboard",
+            browser="local",
+        )
+        assert data.browser == "local"
+
+
+class TestInvalidBrowserRejected:
+    """Verify that invalid browser values are rejected."""
+
+    def test_browsing_task_rejects_invalid_browser(self):
+        """BrowsingTaskInput rejects browser='remote'."""
+        with pytest.raises(ValidationError):
+            BrowsingTaskInput(
+                task="Test task",
+                start_url="https://example.com",
+                browser="remote",
+            )
+
+    def test_research_task_rejects_invalid_browser(self):
+        """ResearchTaskInput rejects browser='remote'."""
+        with pytest.raises(ValidationError):
+            ResearchTaskInput(
+                query="Test query",
+                browser="remote",
+            )
+
+
+class TestInvalidWebhookFormatRejected:
+    """Verify that invalid webhook_format values are rejected."""
+
+    def test_browsing_task_rejects_invalid_webhook_format(self):
+        """BrowsingTaskInput rejects webhook_format='discord'."""
+        with pytest.raises(ValidationError):
+            BrowsingTaskInput(
+                task="Test task",
+                start_url="https://example.com",
+                webhook_format="discord",
+            )
+
+    def test_research_task_rejects_invalid_webhook_format(self):
+        """ResearchTaskInput rejects webhook_format='discord'."""
+        with pytest.raises(ValidationError):
+            ResearchTaskInput(
+                query="Test query",
+                webhook_format="discord",
+            )
+
+    def test_create_scout_rejects_invalid_webhook_format(self):
+        """CreateScoutInput rejects webhook_format='discord'."""
+        with pytest.raises(ValidationError):
+            CreateScoutInput(
+                query="Test query",
+                webhook_format="discord",
+            )
+
+    def test_edit_scout_rejects_invalid_webhook_format(self):
+        """EditScoutInput rejects webhook_format='discord'."""
+        with pytest.raises(ValidationError):
+            EditScoutInput(
+                scout_id="abc-123",
+                webhook_format="discord",
+            )


### PR DESCRIPTION
## Summary
- Add `require_auth` to `BrowsingTaskInput` and wire through server/adapter
- Add `browser` to `ResearchTaskInput` and wire through server/adapter
- Tighten `webhook_format` from `str` to `Literal["scout","slack","zapier"]` on all 4 schemas
- Update "Yutori's Computer" to "Yutori Local" in descriptions
- Clarify `require_auth` is cloud-only (does not apply with `browser: "local"`)
- Add `_append_rejection_reason` helper and surface in all formatters (including failed task creation)
- Add negative validation tests for invalid `browser`/`webhook_format` values
- Update TOOLS.md and skill docs

## Test plan
- [x] `pytest tests/` — 126 passed
- [x] Manual: `run_browsing_task` with `require_auth: true` (cloud) — task queued successfully
- [x] Manual: `run_browsing_task` with `browser: "local"` — task queued successfully
- [x] Manual: `run_research_task` with `browser: "local"` — task queued successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)