### PR TITLE
chore: fix doc drift — add missing webhook params and fix start_timestamp description

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -168,7 +168,7 @@ First run: 2026-01-07 03:10 UTC
 | `output_fields` | No | List of field names for structured output as array of objects |
 | `user_timezone` | No | Timezone for scheduling |
 | `skip_email` | No | Skip email notifications |
-| `start_timestamp` | No | ISO timestamp for when monitoring should start |
+| `start_timestamp` | No | Unix timestamp for when monitoring should start (0 = immediately) |
 | `user_location` | No | Location for geo-relevant searches |
 | `is_public` | No | Whether scout results are publicly accessible |
 

--- a/skills/02-research/SKILL.md
+++ b/skills/02-research/SKILL.md
@@ -29,6 +29,8 @@ Help the user conduct thorough web research using Yutori's Research API.
    - `user_timezone`: For time-relevant searches
    - `browser: "local"`: When the research needs a logged-in desktop browser session through Yutori Local
    - `output_fields`: If structured output is needed (e.g., ["title", "summary", "source_url", "date"])
+   - `webhook_url`: HTTPS URL for completion notification
+   - `webhook_format`: `scout` (default), `slack`, or `zapier`
 
 4. **Poll for results**
    - **Important:** Research typically takes 5-10 minutes (300-600 seconds)

--- a/skills/03-browse/SKILL.md
+++ b/skills/03-browse/SKILL.md
@@ -28,6 +28,8 @@ Help the user automate browser-based tasks using Yutori's Navigator agent.
    - `require_auth: true`: For login forms or other authenticated workflows
    - `browser: "local"`: When the task should run through Yutori Local with the user's desktop session
    - `output_fields`: For structured data extraction (e.g., ["name", "price", "url"])
+   - `webhook_url`: HTTPS URL for completion notification
+   - `webhook_format`: `scout` (default), `slack`, or `zapier`
 
 4. **Poll for results**
    - Browsing typically takes 30-120 seconds depending on complexity


### PR DESCRIPTION
## Summary

- Fix `start_timestamp` description in TOOLS.md: 'ISO timestamp' → 'Unix timestamp' to match schema
- Add missing `webhook_url` and `webhook_format` (including zapier) to research SKILL.md
- Add missing `webhook_url` and `webhook_format` (including zapier) to browse SKILL.md

## Context

Daily doc/test drift check found that after ENG-4632 commits, the SKILL.md files were missing webhook delivery params that exist in schemas.py. The TOOLS.md `start_timestamp` description was also inconsistent with the schema definition.

## Test plan

- [ ] Verify TOOLS.md parameter tables match schemas.py
- [ ] Verify SKILL.md parameter guidance is complete

https://claude.ai/code/session_01RMZSFSG1VoJBh4Fs3uhVom

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that clarify parameter semantics and add missing webhook guidance, with no runtime behavior changes.
> 
> **Overview**
> Updates docs to match the tool schemas: `create_scout` now documents `start_timestamp` as a Unix timestamp (0 = immediate) instead of an ISO timestamp.
> 
> Also adds missing `webhook_url`/`webhook_format` guidance (including `zapier`) to the research and browsing skill guides so users can request completion notifications consistently.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b164ef2fb09360b9e31dc92ca47c197181eaca96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->