### PR TITLE
Reuse _strip_none to simplify edit_scout config building

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -10,7 +10,7 @@ from mcp.server.stdio import stdio_server
 from mcp.types import TextContent, Tool
 
 from . import __version__
-from .adapter import MCPClientAdapter, YutoriAPIError
+from .adapter import MCPClientAdapter, YutoriAPIError, _strip_none
 from .formatters import format_response
 from .schemas import (
     BrowsingTaskInput,
@@ -276,25 +276,17 @@ def _handle_tool(client: MCPClientAdapter, name: str, arguments: dict[str, Any])
             old_scout = client.get_scout_detail(params.scout_id)
 
             # Apply config updates (so they take effect before status change)
-            config_kwargs: dict[str, Any] = {}
-            if params.query is not None:
-                config_kwargs["query"] = params.query
-            if params.output_interval is not None:
-                config_kwargs["output_interval"] = params.output_interval
-            if params.webhook_url is not None:
-                config_kwargs["webhook_url"] = params.webhook_url
-            if params.webhook_format is not None:
-                config_kwargs["webhook_format"] = params.webhook_format
-            if params.output_fields is not None:
-                config_kwargs["output_schema"] = _output_fields_to_output_schema(params.output_fields)
-            if params.skip_email is not None:
-                config_kwargs["skip_email"] = params.skip_email
-            if params.user_timezone is not None:
-                config_kwargs["user_timezone"] = params.user_timezone
-            if params.user_location is not None:
-                config_kwargs["user_location"] = params.user_location
-            if params.is_public is not None:
-                config_kwargs["is_public"] = params.is_public
+            config_kwargs = _strip_none({
+                "query": params.query,
+                "output_interval": params.output_interval,
+                "webhook_url": params.webhook_url,
+                "webhook_format": params.webhook_format,
+                "output_schema": _output_fields_to_output_schema(params.output_fields),
+                "skip_email": params.skip_email,
+                "user_timezone": params.user_timezone,
+                "user_location": params.user_location,
+                "is_public": params.is_public,
+            })
 
             if config_kwargs:
                 client.edit_scout(scout_id=params.scout_id, **config_kwargs)


### PR DESCRIPTION
## Summary

- Replace 9 repetitive `if params.X is not None` checks in the `edit_scout` handler with a single `_strip_none({...})` call
- The `_strip_none()` helper already existed in `adapter.py` — this change imports and reuses it in `server.py`
- The `output_fields → output_schema` transformation works naturally: `_output_fields_to_output_schema(None)` returns `None`, which `_strip_none` filters out

## Why this is safe

- No behavioral change — all 126 existing tests pass
- Single call site affected (`edit_scout` handler in `server.py`)
- Net -8 lines (12 added, 20 removed)

## Context

Picked from `.claude/REFACTOR.md` in the yutori monorepo. The item noted that `adapter.py` already has `_strip_none()` that does exactly what the 9 if-blocks do manually.

cc @dhruvbatra (primary maintainer per git blame)

https://claude.ai/code/session_01ULTdAZM3xyBEU5eJ3GzUdy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to the `edit_scout` tool handler, replacing repetitive `None` checks with an existing helper to filter optional fields before calling the API.
> 
> **Overview**
> Simplifies the `edit_scout` handler by replacing a series of `if params.X is not None` checks with a single `_strip_none({...})` call when building `config_kwargs`.
> 
> This reuses the existing helper from `adapter.py` (now imported in `server.py`) and keeps the same behavior for optional updates, including the `output_fields` → `output_schema` transformation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1339b469c0373c695d97b3228fd6c8ecc6d7f76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->