### PR TITLE
refactor: use _strip_none to simplify edit_scout config building

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -10,7 +10,7 @@ from mcp.server.stdio import stdio_server
 from mcp.types import TextContent, Tool
 
 from . import __version__
-from .adapter import MCPClientAdapter, YutoriAPIError
+from .adapter import MCPClientAdapter, YutoriAPIError, _strip_none
 from .formatters import format_response
 from .schemas import (
     BrowsingTaskInput,
@@ -276,25 +276,17 @@ def _handle_tool(client: MCPClientAdapter, name: str, arguments: dict[str, Any])
             old_scout = client.get_scout_detail(params.scout_id)
 
             # Apply config updates (so they take effect before status change)
-            config_kwargs: dict[str, Any] = {}
-            if params.query is not None:
-                config_kwargs["query"] = params.query
-            if params.output_interval is not None:
-                config_kwargs["output_interval"] = params.output_interval
-            if params.webhook_url is not None:
-                config_kwargs["webhook_url"] = params.webhook_url
-            if params.webhook_format is not None:
-                config_kwargs["webhook_format"] = params.webhook_format
-            if params.output_fields is not None:
-                config_kwargs["output_schema"] = _output_fields_to_output_schema(params.output_fields)
-            if params.skip_email is not None:
-                config_kwargs["skip_email"] = params.skip_email
-            if params.user_timezone is not None:
-                config_kwargs["user_timezone"] = params.user_timezone
-            if params.user_location is not None:
-                config_kwargs["user_location"] = params.user_location
-            if params.is_public is not None:
-                config_kwargs["is_public"] = params.is_public
+            config_kwargs = _strip_none({
+                "query": params.query,
+                "output_interval": params.output_interval,
+                "webhook_url": params.webhook_url,
+                "webhook_format": params.webhook_format,
+                "output_schema": _output_fields_to_output_schema(params.output_fields),
+                "skip_email": params.skip_email,
+                "user_timezone": params.user_timezone,
+                "user_location": params.user_location,
+                "is_public": params.is_public,
+            })
 
             if config_kwargs:
                 client.edit_scout(scout_id=params.scout_id, **config_kwargs)


### PR DESCRIPTION
## Summary

- Replaces 9 repetitive `if params.X is not None` checks in the `edit_scout` handler with a single dict literal passed through the existing `_strip_none()` utility from `adapter.py`
- The `output_fields` special case works because `_output_fields_to_output_schema(None)` returns `None`, which `_strip_none` then filters out

## Why this is an improvement

The original code had 18 lines of boilerplate for building `config_kwargs`. The refactored version uses the existing `_strip_none()` utility (already used in 7 places in `adapter.py`) to do the same thing in a declarative dict literal. Adding new fields now requires one line instead of two.

## Why this is safe

No behavioral change — all 126 existing tests pass. The key insight is that `_output_fields_to_output_schema(None)` returns `None` (verified by existing test `test_none_returns_none`), so `_strip_none` correctly filters it out when `output_fields` is not provided.

cc @dhruvbatra (primary maintainer of server.py)

https://claude.ai/code/session_01QAAjvbmyBt3eUCkvAg7BTS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to how `edit_scout` request kwargs are constructed; behavior should remain the same aside from any edge cases where `output_schema` conversion might differ when `output_fields` is omitted.
> 
> **Overview**
> Refactors the `edit_scout` tool handler to build its update payload using the shared `_strip_none()` utility instead of a series of `if params.x is not None` checks.
> 
> This centralizes None-filtering logic, keeps the SDK defaults from being overwritten by nulls, and reduces boilerplate while preserving the existing two-step flow (config updates first, then optional status change).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54eb1efd06682eff766e1e727adaab48ae3f3f60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->