### PR TITLE
refactor: reuse _strip_none in edit_scout handler

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -10,7 +10,7 @@ from mcp.server.stdio import stdio_server
 from mcp.types import TextContent, Tool
 
 from . import __version__
-from .adapter import MCPClientAdapter, YutoriAPIError
+from .adapter import MCPClientAdapter, YutoriAPIError, _strip_none
 from .formatters import format_response
 from .schemas import (
     BrowsingTaskInput,
@@ -276,25 +276,18 @@ def _handle_tool(client: MCPClientAdapter, name: str, arguments: dict[str, Any])
             old_scout = client.get_scout_detail(params.scout_id)
 
             # Apply config updates (so they take effect before status change)
-            config_kwargs: dict[str, Any] = {}
-            if params.query is not None:
-                config_kwargs["query"] = params.query
-            if params.output_interval is not None:
-                config_kwargs["output_interval"] = params.output_interval
-            if params.webhook_url is not None:
-                config_kwargs["webhook_url"] = params.webhook_url
-            if params.webhook_format is not None:
-                config_kwargs["webhook_format"] = params.webhook_format
+            config_kwargs = _strip_none({
+                "query": params.query,
+                "output_interval": params.output_interval,
+                "webhook_url": params.webhook_url,
+                "webhook_format": params.webhook_format,
+                "skip_email": params.skip_email,
+                "user_timezone": params.user_timezone,
+                "user_location": params.user_location,
+                "is_public": params.is_public,
+            })
             if params.output_fields is not None:
                 config_kwargs["output_schema"] = _output_fields_to_output_schema(params.output_fields)
-            if params.skip_email is not None:
-                config_kwargs["skip_email"] = params.skip_email
-            if params.user_timezone is not None:
-                config_kwargs["user_timezone"] = params.user_timezone
-            if params.user_location is not None:
-                config_kwargs["user_location"] = params.user_location
-            if params.is_public is not None:
-                config_kwargs["is_public"] = params.is_public
 
             if config_kwargs:
                 client.edit_scout(scout_id=params.scout_id, **config_kwargs)


### PR DESCRIPTION
## Summary

- Replace 9 repetitive `if params.X is not None` checks in the `edit_scout` handler with the existing `_strip_none()` utility from `adapter.py`
- `output_fields` retains its special handling since it requires transformation via `_output_fields_to_output_schema`
- Net reduction of 7 lines; the intent of each field mapping is now scannable in a single dict literal

## Why this is safe

- **No behavioral change** — `_strip_none` does exactly `{k: v for k, v in d.items() if v is not None}`, which is identical to the previous `if X is not None` checks
- All 126 existing tests pass
- Blast radius: 1 file changed (`server.py`), 1 import added

## Relevant context

Picked from `.claude/REFACTOR.md` in the yutori monorepo. The companion PR in `yutori-ai/yutori` removes this item from the backlog.

cc @dhruvbatra @devip

https://claude.ai/code/session_019YTksW5jMCT6GyC2r3v9Xa

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how `edit_scout` request kwargs are constructed (filtering out `None` values) without altering API calls or data flow.
> 
> **Overview**
> Refactors the `edit_scout` tool handler to build its update payload via a single dict passed through `_strip_none`, replacing several repetitive `if params.X is not None` checks.
> 
> Keeps `output_fields` as a special case (still transformed into `output_schema`) while continuing to apply config updates before any optional status change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e53da74bc4a1a6929ffa08491df0f4ef0f0c34d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->