### PR TITLE
refactor: reuse _strip_none in edit_scout handler

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -10,7 +10,7 @@ from mcp.server.stdio import stdio_server
 from mcp.types import TextContent, Tool
 
 from . import __version__
-from .adapter import MCPClientAdapter, YutoriAPIError
+from .adapter import MCPClientAdapter, YutoriAPIError, _strip_none
 from .formatters import format_response
 from .schemas import (
     BrowsingTaskInput,
@@ -276,25 +276,17 @@ def _handle_tool(client: MCPClientAdapter, name: str, arguments: dict[str, Any])
             old_scout = client.get_scout_detail(params.scout_id)
 
             # Apply config updates (so they take effect before status change)
-            config_kwargs: dict[str, Any] = {}
-            if params.query is not None:
-                config_kwargs["query"] = params.query
-            if params.output_interval is not None:
-                config_kwargs["output_interval"] = params.output_interval
-            if params.webhook_url is not None:
-                config_kwargs["webhook_url"] = params.webhook_url
-            if params.webhook_format is not None:
-                config_kwargs["webhook_format"] = params.webhook_format
-            if params.output_fields is not None:
-                config_kwargs["output_schema"] = _output_fields_to_output_schema(params.output_fields)
-            if params.skip_email is not None:
-                config_kwargs["skip_email"] = params.skip_email
-            if params.user_timezone is not None:
-                config_kwargs["user_timezone"] = params.user_timezone
-            if params.user_location is not None:
-                config_kwargs["user_location"] = params.user_location
-            if params.is_public is not None:
-                config_kwargs["is_public"] = params.is_public
+            config_kwargs = _strip_none({
+                "query": params.query,
+                "output_interval": params.output_interval,
+                "webhook_url": params.webhook_url,
+                "webhook_format": params.webhook_format,
+                "output_schema": _output_fields_to_output_schema(params.output_fields),
+                "skip_email": params.skip_email,
+                "user_timezone": params.user_timezone,
+                "user_location": params.user_location,
+                "is_public": params.is_public,
+            })
 
             if config_kwargs:
                 client.edit_scout(scout_id=params.scout_id, **config_kwargs)


### PR DESCRIPTION
## Summary

- Replace 9 repetitive `if params.X is not None` checks in the `edit_scout` handler with a single dict + `_strip_none()` call, reusing the utility already defined in `adapter.py`
- The `output_fields` → `output_schema` transform works correctly because `_output_fields_to_output_schema(None)` returns `None`, which `_strip_none` filters out
- Net reduction: 20 lines removed, 12 added (-8 LOC)

## Why this is safe

- No behavioral change — all 126 existing tests pass
- `_strip_none` is already battle-tested (used by every adapter method)
- The dict comprehension is semantically identical to the if-chain it replaces

## Code owner

cc @dhruvbatra (primary maintainer of `server.py`)

## Test plan

- [x] All 126 existing tests pass (`pytest tests/ -v`)
- [x] Verified `_output_fields_to_output_schema(None)` returns `None` (filtered by `_strip_none`)
- [x] Verified non-None `output_fields` correctly maps to `output_schema` key

https://claude.ai/code/session_01K6fyRBnkMKf8TrKbFp93zn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to `edit_scout` argument construction; behavior should remain the same aside from filtering `None` values via a shared helper.
> 
> **Overview**
> Refactors the `edit_scout` tool handler to build update parameters via a single dict passed through shared `_strip_none()` instead of a chain of `if params.X is not None` checks.
> 
> This also imports `_strip_none` from `adapter.py`, keeping the `output_fields`→`output_schema` transform while ensuring only non-`None` fields are forwarded to `client.edit_scout`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51fd93b3eb95a7d29c903dfb3ec7f9186269c042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->