### PR TITLE
refactor: extract _format_sources() helper in formatters.py

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -121,6 +121,31 @@ def _append_rejection_reason(
         lines.append(f"{indent}Rejection reason: {rejection_reason}")
 
 
+def _format_sources(
+    response: dict[str, Any], *, indent: str = "  ", max_items: int = 10
+) -> list[str]:
+    """Format sources/citations from a response dict.
+
+    Checks for both "sources" and "citations" keys. Each source can be
+    a dict with url/title keys or a plain string.
+    """
+    sources = response.get("sources") or response.get("citations")
+    if not sources:
+        return []
+
+    lines = ["", "Sources:"]
+    for source in sources[:max_items]:
+        if isinstance(source, dict):
+            url = source.get("url", "")
+            title = source.get("title", url)
+            lines.append(f"{indent}- {title}: {url}")
+        else:
+            lines.append(f"{indent}- {source}")
+    if len(sources) > max_items:
+        lines.append(f"{indent}... and {len(sources) - max_items} more")
+    return lines
+
+
 # -----------------------------------------------------------------------------
 # Usage formatter
 # -----------------------------------------------------------------------------
@@ -273,20 +298,7 @@ def format_scout_detail(response: dict[str, Any], **context: Any) -> str:
     if response.get("user_location"):
         lines.append(f"  Location: {response['user_location']}")
 
-    # Add sources/citations if present
-    sources = response.get("sources") or response.get("citations")
-    if sources:
-        lines.append("")
-        lines.append("Sources:")
-        for source in sources[:10]:
-            if isinstance(source, dict):
-                url = source.get("url", "")
-                title = source.get("title", url)
-                lines.append(f"  - {title}: {url}")
-            else:
-                lines.append(f"  - {source}")
-        if len(sources) > 10:
-            lines.append(f"  ... and {len(sources) - 10} more")
+    lines.extend(_format_sources(response))
 
     lines.append("")
     lines.append(f"Created: {created}")
@@ -347,20 +359,7 @@ def format_scout_updates(response: dict[str, Any], **context: Any) -> str:
                 lines.append(f"  ... and {len(findings) - 5} more")
             lines.append("[EXTERNAL CONTENT END]")
 
-        # Add sources/citations if present
-        sources = update.get("sources") or update.get("citations")
-        if sources:
-            lines.append("")
-            lines.append("Sources:")
-            for source in sources[:10]:
-                if isinstance(source, dict):
-                    url = source.get("url", "")
-                    title = source.get("title", url)
-                    lines.append(f"  - {title}: {url}")
-                else:
-                    lines.append(f"  - {source}")
-            if len(sources) > 10:
-                lines.append(f"  ... and {len(sources) - 10} more")
+        lines.extend(_format_sources(update))
 
     if has_more and next_cursor:
         lines.append("")
@@ -618,19 +617,6 @@ def format_task_result(response: dict[str, Any], **context: Any) -> str:
                     lines.append(f"- {item}")
         lines.append("[EXTERNAL CONTENT END]")
 
-    # Add sources if present
-    sources = response.get("sources") or response.get("citations")
-    if sources:
-        lines.append("")
-        lines.append("Sources:")
-        for source in sources[:10]:  # Limit to 10
-            if isinstance(source, dict):
-                url = source.get("url", "")
-                title = source.get("title", url)
-                lines.append(f"- {title}: {url}")
-            else:
-                lines.append(f"- {source}")
-        if len(sources) > 10:
-            lines.append(f"... and {len(sources) - 10} more")
+    lines.extend(_format_sources(response, indent=""))
 
     return "\n".join(lines)

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,6 +1,7 @@
 """Tests for output formatters."""
 
 from yutori_mcp.formatters import (
+    _format_sources,
     dict_to_markdown,
     format_list_scouts,
     format_response,
@@ -393,3 +394,109 @@ class TestFormatResponse:
         result = format_response("unknown_tool", response)
         assert "some: data" in result
         assert "key: value" in result
+
+
+class TestFormatSources:
+    def test_no_sources(self):
+        """Returns empty list when no sources or citations."""
+        assert _format_sources({}) == []
+        assert _format_sources({"sources": None}) == []
+        assert _format_sources({"sources": []}) == []
+
+    def test_dict_sources_with_url_and_title(self):
+        """Dict sources format as 'title: url'."""
+        response = {
+            "sources": [
+                {"url": "https://example.com", "title": "Example"},
+                {"url": "https://other.com", "title": "Other"},
+            ]
+        }
+        lines = _format_sources(response)
+        assert "Sources:" in lines
+        assert "  - Example: https://example.com" in lines
+        assert "  - Other: https://other.com" in lines
+
+    def test_dict_source_without_title_uses_url(self):
+        """Dict source with no title falls back to url."""
+        response = {"sources": [{"url": "https://example.com"}]}
+        lines = _format_sources(response)
+        assert "  - https://example.com: https://example.com" in lines
+
+    def test_string_sources(self):
+        """String sources are formatted as-is."""
+        response = {"sources": ["https://example.com", "https://other.com"]}
+        lines = _format_sources(response)
+        assert "  - https://example.com" in lines
+        assert "  - https://other.com" in lines
+
+    def test_citations_key(self):
+        """Also works with 'citations' key."""
+        response = {"citations": [{"url": "https://example.com", "title": "Cited"}]}
+        lines = _format_sources(response)
+        assert "  - Cited: https://example.com" in lines
+
+    def test_truncation_at_max_items(self):
+        """Sources beyond max_items are truncated with count."""
+        response = {"sources": [{"url": f"https://{i}.com", "title": f"S{i}"} for i in range(15)]}
+        lines = _format_sources(response, max_items=10)
+        assert "  ... and 5 more" in lines
+        # Should have header + 10 items + truncation line + blank line prefix
+        source_lines = [l for l in lines if l.startswith("  - ")]
+        assert len(source_lines) == 10
+
+    def test_custom_indent(self):
+        """Custom indent is applied to all source lines."""
+        response = {"sources": [{"url": "https://example.com", "title": "Ex"}]}
+        lines = _format_sources(response, indent="")
+        assert "- Ex: https://example.com" in lines
+        # No leading spaces
+        assert "  - Ex: https://example.com" not in lines
+
+    def test_starts_with_blank_line(self):
+        """Output starts with a blank line for spacing."""
+        response = {"sources": [{"url": "https://example.com", "title": "Ex"}]}
+        lines = _format_sources(response)
+        assert lines[0] == ""
+        assert lines[1] == "Sources:"
+
+    def test_scout_detail_includes_sources(self):
+        """format_scout_detail includes sources via _format_sources."""
+        response = {
+            "id": "abc-123",
+            "query": "test",
+            "status": "active",
+            "sources": [
+                {"url": "https://example.com", "title": "Example Source"},
+            ],
+        }
+        result = format_scout_detail(response)
+        assert "Sources:" in result
+        assert "Example Source: https://example.com" in result
+
+    def test_scout_updates_include_sources(self):
+        """format_scout_updates includes sources on individual updates."""
+        response = {
+            "updates": [
+                {
+                    "created_at": "2026-01-20T05:00:00Z",
+                    "content": "Found results",
+                    "citations": [{"url": "https://cited.com", "title": "Cited"}],
+                }
+            ],
+            "has_more": False,
+        }
+        result = format_scout_updates(response)
+        assert "Sources:" in result
+        assert "Cited: https://cited.com" in result
+
+    def test_task_result_includes_sources(self):
+        """format_task_result includes sources with no indent."""
+        response = {
+            "task_id": "task-1",
+            "status": "succeeded",
+            "result": "Done",
+            "sources": [{"url": "https://src.com", "title": "Src"}],
+        }
+        result = format_task_result(response)
+        assert "Sources:" in result
+        assert "- Src: https://src.com" in result


### PR DESCRIPTION
## Summary

- Extract `_format_sources()` helper to consolidate duplicated source/citation formatting logic in `formatters.py`
- Three formatters (`format_scout_detail`, `format_scout_updates`, `format_task_result`) had near-identical 10-line blocks for rendering sources/citations — now each is a one-liner call to the shared helper
- Add 11 new tests covering the helper directly and its integration with each formatter

## Why this is safe

- **No behavioral change** — all 33 existing tests pass unchanged. The helper produces identical output to the inlined code it replaces.
- **Contained to one file** — only `formatters.py` changed (plus test additions)
- The only variation between call sites was indentation (`"  "` vs `""`), which is parameterized via the `indent` kwarg

## Picked from `.claude/REFACTOR.md`

This addresses the item: *"Extract source/citation formatting helper — Source extraction pattern (check dict vs string, format URL+title, truncate) repeated 4 times in formatters.py"*

## Test plan

- [x] All 33 existing formatter tests pass
- [x] 11 new tests for `_format_sources()` helper pass
- [x] Full test suite (137 tests) passes

cc @dhruvbatra @juanpinzon (top contributors to formatters.py)

https://claude.ai/code/session_014rnzEoZ7DAJ6xPx7uZVTg9