### PR TITLE
refactor: consolidate webhook URL validators with Annotated type

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import AfterValidator, BaseModel, Field, model_validator
 
 
 def _check_webhook_https(v: str | None) -> str | None:
@@ -12,6 +12,10 @@ def _check_webhook_https(v: str | None) -> str | None:
     if v is not None and not v.startswith("https://"):
         raise ValueError("webhook_url must use HTTPS (https://)")
     return v
+
+
+# Reusable type: optional HTTPS-only webhook URL
+WebhookUrl = Annotated[str | None, AfterValidator(_check_webhook_https)]
 
 
 class UsageInput(BaseModel):
@@ -47,7 +51,7 @@ class CreateScoutInput(BaseModel):
         ge=1800,
         description="Seconds between scout runs. Minimum 1800 (30 minutes). Default: 86400 (daily)",
     )
-    webhook_url: str | None = Field(
+    webhook_url: WebhookUrl = Field(
         default=None,
         description=(
             "HTTPS URL to receive webhook notifications when updates are available. "
@@ -89,11 +93,6 @@ class CreateScoutInput(BaseModel):
         description="Whether scout results are publicly accessible",
     )
 
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        return _check_webhook_https(v)
-
 
 class EditScoutInput(BaseModel):
     """Input for editing an existing scout or changing its status."""
@@ -115,7 +114,7 @@ class EditScoutInput(BaseModel):
         ge=1800,
         description="Updated run interval in seconds. Minimum 1800 (30 minutes)",
     )
-    webhook_url: str | None = Field(
+    webhook_url: WebhookUrl = Field(
         default=None,
         description="Updated HTTPS webhook URL. Must use https://. Confirm the URL with the user before setting.",
     )
@@ -148,11 +147,6 @@ class EditScoutInput(BaseModel):
         default=None,
         description="Whether scout results are publicly accessible",
     )
-
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        return _check_webhook_https(v)
 
     @model_validator(mode="after")
     def validate_has_changes(self) -> "EditScoutInput":
@@ -263,7 +257,7 @@ class BrowsingTaskInput(BaseModel):
             "https://docs.yutori.com/reference/browsing-create#using-webhooks-and-a-structured-output-schema)."
         ),
     )
-    webhook_url: str | None = Field(
+    webhook_url: WebhookUrl = Field(
         default=None,
         description="HTTPS URL to receive webhook notification when task completes. Must use https://.",
     )
@@ -271,11 +265,6 @@ class BrowsingTaskInput(BaseModel):
         default=None,
         description="Webhook payload format: 'scout' (default), 'slack', or 'zapier'",
     )
-
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        return _check_webhook_https(v)
 
 
 class TaskIdInput(BaseModel):
@@ -330,7 +319,7 @@ class ResearchTaskInput(BaseModel):
             "https://docs.yutori.com/reference/research-create#using-webhooks-and-a-structured-output-schema)."
         ),
     )
-    webhook_url: str | None = Field(
+    webhook_url: WebhookUrl = Field(
         default=None,
         description="HTTPS URL to receive webhook notification when research completes. Must use https://.",
     )
@@ -338,8 +327,3 @@ class ResearchTaskInput(BaseModel):
         default=None,
         description="Webhook payload format: 'scout' (default), 'slack', or 'zapier'",
     )
-
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        return _check_webhook_https(v)


### PR DESCRIPTION
## Summary

- Replace 4 identical `@field_validator("webhook_url")` blocks across `CreateScoutInput`, `EditScoutInput`, `BrowsingTaskInput`, and `ResearchTaskInput` with a reusable `WebhookUrl = Annotated[str | None, AfterValidator(_check_webhook_https)]` type alias
- Removes 16 lines of boilerplate while preserving identical validation behavior
- Uses idiomatic Pydantic v2 pattern (`Annotated` + `AfterValidator`) instead of repeated `@field_validator` decorators

## Why this is safe

No behavioral change — all 126 existing tests pass, including the dedicated `TestWebhookUrlValidation` suite that tests HTTPS enforcement across all 4 schema classes.

## Why this is better

The `Annotated` type approach is the Pydantic v2 recommended pattern for reusable field validation. It ensures any future schema class with a webhook URL field gets HTTPS validation automatically by using the `WebhookUrl` type, rather than requiring developers to remember to add a `@field_validator` block.

From REFACTOR.md item: *Consolidate webhook URL field validators*

cc @dhruvbatra (primary maintainer of schemas.py)

https://claude.ai/code/session_018DcQ1pzFoASvpHoJQgRvb2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes existing `webhook_url` HTTPS validation into a shared Pydantic v2 `Annotated` type; main risk is subtle validation/typing differences across affected schemas.
> 
> **Overview**
> Consolidates `webhook_url` validation across multiple input schemas by introducing a reusable `WebhookUrl = Annotated[str | None, AfterValidator(_check_webhook_https)]` type and switching `CreateScoutInput`, `EditScoutInput`, `BrowsingTaskInput`, and `ResearchTaskInput` to use it.
> 
> Removes the duplicated `@field_validator("webhook_url")` blocks while keeping the same HTTPS-only constraint and error behavior in one place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58881633e9455c813b52c4e72ae0be68925f39f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->