### PR TITLE
refactor: consolidate webhook URL validators using Annotated type

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import AfterValidator, BaseModel, Field, model_validator
 
 
 def _check_webhook_https(v: str | None) -> str | None:
@@ -12,6 +12,9 @@ def _check_webhook_https(v: str | None) -> str | None:
     if v is not None and not v.startswith("https://"):
         raise ValueError("webhook_url must use HTTPS (https://)")
     return v
+
+
+HttpsWebhookUrl = Annotated[str | None, AfterValidator(_check_webhook_https)]
 
 
 class UsageInput(BaseModel):
@@ -47,7 +50,7 @@ class CreateScoutInput(BaseModel):
         ge=1800,
         description="Seconds between scout runs. Minimum 1800 (30 minutes). Default: 86400 (daily)",
     )
-    webhook_url: str | None = Field(
+    webhook_url: HttpsWebhookUrl = Field(
         default=None,
         description=(
             "HTTPS URL to receive webhook notifications when updates are available. "
@@ -89,11 +92,6 @@ class CreateScoutInput(BaseModel):
         description="Whether scout results are publicly accessible",
     )
 
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        return _check_webhook_https(v)
-
 
 class EditScoutInput(BaseModel):
     """Input for editing an existing scout or changing its status."""
@@ -115,7 +113,7 @@ class EditScoutInput(BaseModel):
         ge=1800,
         description="Updated run interval in seconds. Minimum 1800 (30 minutes)",
     )
-    webhook_url: str | None = Field(
+    webhook_url: HttpsWebhookUrl = Field(
         default=None,
         description="Updated HTTPS webhook URL. Must use https://. Confirm the URL with the user before setting.",
     )
@@ -148,11 +146,6 @@ class EditScoutInput(BaseModel):
         default=None,
         description="Whether scout results are publicly accessible",
     )
-
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        return _check_webhook_https(v)
 
     @model_validator(mode="after")
     def validate_has_changes(self) -> "EditScoutInput":
@@ -263,7 +256,7 @@ class BrowsingTaskInput(BaseModel):
             "https://docs.yutori.com/reference/browsing-create#using-webhooks-and-a-structured-output-schema)."
         ),
     )
-    webhook_url: str | None = Field(
+    webhook_url: HttpsWebhookUrl = Field(
         default=None,
         description="HTTPS URL to receive webhook notification when task completes. Must use https://.",
     )
@@ -271,11 +264,6 @@ class BrowsingTaskInput(BaseModel):
         default=None,
         description="Webhook payload format: 'scout' (default), 'slack', or 'zapier'",
     )
-
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        return _check_webhook_https(v)
 
 
 class TaskIdInput(BaseModel):
@@ -330,7 +318,7 @@ class ResearchTaskInput(BaseModel):
             "https://docs.yutori.com/reference/research-create#using-webhooks-and-a-structured-output-schema)."
         ),
     )
-    webhook_url: str | None = Field(
+    webhook_url: HttpsWebhookUrl = Field(
         default=None,
         description="HTTPS URL to receive webhook notification when research completes. Must use https://.",
     )
@@ -338,8 +326,3 @@ class ResearchTaskInput(BaseModel):
         default=None,
         description="Webhook payload format: 'scout' (default), 'slack', or 'zapier'",
     )
-
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        return _check_webhook_https(v)


### PR DESCRIPTION
## Summary

- Replace 4 identical `@field_validator("webhook_url")` methods with a single `HttpsWebhookUrl` annotated type using Pydantic v2's `AfterValidator` pattern
- Removes 17 lines of duplicated boilerplate across `CreateScoutInput`, `EditScoutInput`, `BrowsingTaskInput`, and `ResearchTaskInput`
- Uses idiomatic Pydantic v2 type-level validation instead of per-class method validators

## Why this is better

The validation logic was identical in all 4 classes — same function call, same signature, same decorator. Encoding the constraint in the type itself (`HttpsWebhookUrl`) means:
1. New schemas with webhook URLs automatically get validation by using the type
2. No risk of forgetting to add the validator to a new class
3. Less code to maintain

## Why this is safe

- **No behavioral change** — the same `_check_webhook_https()` function runs on the same field values
- **All 126 existing tests pass unchanged**, including all 6 webhook-specific validation tests
- Single file change (`schemas.py`), no call-site updates needed

Picked from `.claude/REFACTOR.md` in the yutori monorepo. Corresponding REFACTOR.md update pushed to yutori-ai/yutori.

cc @dhruvbatra (primary maintainer of schemas.py)

https://claude.ai/code/session_018PWAi5uFkWzYTprjZaLwA2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how `webhook_url` HTTPS validation is expressed (type-level `AfterValidator`), not the validation rule itself. Main risk is subtle Pydantic v2 validation-order/typing differences affecting error surfaces.
> 
> **Overview**
> Introduces a reusable `HttpsWebhookUrl` type (via `Annotated` + Pydantic v2 `AfterValidator`) and updates all schema models with `webhook_url` fields to use it.
> 
> Removes the per-model `@field_validator("webhook_url")` methods previously duplicated across `CreateScoutInput`, `EditScoutInput`, `BrowsingTaskInput`, and `ResearchTaskInput`, centralizing the HTTPS-only check in one place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0024de45eee59b20a799d11201a2a7f09a3f6b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->