### PR TITLE
refactor: consolidate webhook URL validators into _WebhookValidated mixin

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -14,6 +14,19 @@ def _check_webhook_https(v: str | None) -> str | None:
     return v
 
 
+class _WebhookValidated(BaseModel):
+    """Mixin: validates that ``webhook_url`` uses HTTPS.
+
+    Inherit from this in any schema that declares a ``webhook_url`` field
+    so the HTTPS check is defined in exactly one place.
+    """
+
+    @field_validator("webhook_url", check_fields=False)
+    @classmethod
+    def validate_webhook_url(cls, v: str | None) -> str | None:
+        return _check_webhook_https(v)
+
+
 class UsageInput(BaseModel):
     """Input for retrieving API usage statistics."""
 
@@ -23,7 +36,7 @@ class UsageInput(BaseModel):
     )
 
 
-class CreateScoutInput(BaseModel):
+class CreateScoutInput(_WebhookValidated):
     """Input for creating a new monitoring scout.
 
     Scouts enable continuous monitoring of the web at a configurable schedule
@@ -89,13 +102,8 @@ class CreateScoutInput(BaseModel):
         description="Whether scout results are publicly accessible",
     )
 
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        return _check_webhook_https(v)
 
-
-class EditScoutInput(BaseModel):
+class EditScoutInput(_WebhookValidated):
     """Input for editing an existing scout or changing its status."""
 
     scout_id: str = Field(..., description="The scout's unique identifier (UUID)")
@@ -148,11 +156,6 @@ class EditScoutInput(BaseModel):
         default=None,
         description="Whether scout results are publicly accessible",
     )
-
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        return _check_webhook_https(v)
 
     @model_validator(mode="after")
     def validate_has_changes(self) -> "EditScoutInput":
@@ -211,7 +214,7 @@ class GetUpdatesInput(BaseModel):
     )
 
 
-class BrowsingTaskInput(BaseModel):
+class BrowsingTaskInput(_WebhookValidated):
     """Input for running a one-time browsing task.
 
     The Browsing API enables automation of browser-based workflows.
@@ -272,11 +275,6 @@ class BrowsingTaskInput(BaseModel):
         description="Webhook payload format: 'scout' (default), 'slack', or 'zapier'",
     )
 
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        return _check_webhook_https(v)
-
 
 class TaskIdInput(BaseModel):
     """Input for retrieving a browsing or research task result."""
@@ -284,7 +282,7 @@ class TaskIdInput(BaseModel):
     task_id: str = Field(..., description="The task's unique identifier")
 
 
-class ResearchTaskInput(BaseModel):
+class ResearchTaskInput(_WebhookValidated):
     """Input for running a one-time research task.
 
     The Research API executes deep web research on any topic.
@@ -338,8 +336,3 @@ class ResearchTaskInput(BaseModel):
         default=None,
         description="Webhook payload format: 'scout' (default), 'slack', or 'zapier'",
     )
-
-    @field_validator("webhook_url")
-    @classmethod
-    def validate_webhook_url(cls, v: str | None) -> str | None:
-        return _check_webhook_https(v)


### PR DESCRIPTION
## Summary

- Extract a `_WebhookValidated` Pydantic v2 mixin that defines the shared `@field_validator("webhook_url", check_fields=False)` in one place
- Update `CreateScoutInput`, `EditScoutInput`, `BrowsingTaskInput`, and `ResearchTaskInput` to inherit from `_WebhookValidated` instead of `BaseModel`
- Each class retains its context-specific field descriptions (different doc links, different wording per endpoint)

## Why

The 4 schema classes each had an identical `@field_validator("webhook_url")` method calling `_check_webhook_https()`. This violated DRY and meant any future change to the validation pattern would need to be replicated in 4 places. The mixin uses Pydantic v2's `check_fields=False` parameter, which is the standard pattern for validators on mixins that don't declare the field themselves.

## Safety

- **No behavioral change** — the mixin delegates to the same `_check_webhook_https()` function
- **All 126 existing tests pass** (including the dedicated `TestWebhookUrlValidation` tests that verify HTTPS enforcement on all 4 classes)
- **Net -7 lines** (17 added, 24 removed)

Picked from `.claude/REFACTOR.md` in the yutori monorepo. Companion PR updates REFACTOR.md to remove this item.

cc @dhruvbatra (original webhook extraction in #39) @juanpinzon (original validators)

https://claude.ai/code/session_016PwnWf9jmjAntZzZPzWxok

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes `webhook_url` HTTPS validation without changing the underlying check. Main risk is unintended validator application/order changes from the new mixin inheritance.
> 
> **Overview**
> Refactors webhook URL validation by introducing a shared `_WebhookValidated` Pydantic mixin that enforces `https://` for `webhook_url`.
> 
> Updates `CreateScoutInput`, `EditScoutInput`, `BrowsingTaskInput`, and `ResearchTaskInput` to inherit from the mixin and removes their duplicated `validate_webhook_url` validators, keeping schema fields/descriptions otherwise the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a854f74b7530ae5a6093995a96ed33782445c860. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->