### PR TITLE
refactor: extract schema utilities into schema_utils.py

### DIFF
--- a/src/yutori_mcp/schema_utils.py
+++ b/src/yutori_mcp/schema_utils.py
@@ -1,0 +1,79 @@
+"""Schema conversion utilities for MCP tool definitions."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def _simplify_schema(schema: dict[str, Any]) -> dict[str, Any]:
+    """Simplify JSON Schema for MCP clients by flattening anyOf with null.
+
+    Pydantic generates `anyOf: [{type: X}, {type: null}]` for optional fields.
+    MCP clients don't always understand this, showing "unknown" for types.
+    This function converts such patterns to just `{type: X}` while preserving
+    other properties like default, description, minimum, maximum, enum, etc.
+    """
+    if not isinstance(schema, dict):
+        return schema
+
+    result = {}
+    for key, value in schema.items():
+        if key == "anyOf" and isinstance(value, list) and len(value) == 2:
+            # Check if this is the pattern: [{actual_type}, {type: null}]
+            non_null = [
+                v
+                for v in value
+                if not (isinstance(v, dict) and v.get("type") == "null")
+            ]
+            null_types = [
+                v for v in value if isinstance(v, dict) and v.get("type") == "null"
+            ]
+
+            if len(non_null) == 1 and len(null_types) == 1:
+                # Flatten: merge the non-null type's properties into result
+                for k, v in _simplify_schema(non_null[0]).items():
+                    result[k] = v
+                continue
+
+        # Recursively simplify nested structures
+        if isinstance(value, dict):
+            result[key] = _simplify_schema(value)
+        elif isinstance(value, list):
+            result[key] = [
+                _simplify_schema(item) if isinstance(item, dict) else item
+                for item in value
+            ]
+        else:
+            result[key] = value
+
+    return result
+
+
+def _get_simplified_schema(model: type) -> dict[str, Any]:
+    """Get a simplified JSON Schema from a Pydantic model."""
+    return _simplify_schema(model.model_json_schema())
+
+
+def _output_fields_to_output_schema(
+    output_fields: list[str] | None,
+) -> dict[str, Any] | None:
+    """Convert simple output_fields list to JSON Schema for output_schema parameter.
+
+    Args:
+        output_fields: List of field names, e.g. ['headline', 'summary', 'url']
+
+    Returns:
+        JSON Schema dict for API output_schema parameter, or None if output_fields is None.
+    """
+    if output_fields is None:
+        return None
+
+    properties = {field: {"type": "string"} for field in output_fields}
+
+    return {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": properties,
+        },
+    }

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -12,6 +12,7 @@ from mcp.types import TextContent, Tool
 from . import __version__
 from .adapter import MCPClientAdapter, YutoriAPIError
 from .formatters import format_response
+from .schema_utils import _get_simplified_schema, _output_fields_to_output_schema
 from .schemas import (
     BrowsingTaskInput,
     CreateScoutInput,
@@ -25,80 +26,6 @@ from .schemas import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _simplify_schema(schema: dict[str, Any]) -> dict[str, Any]:
-    """Simplify JSON Schema for MCP clients by flattening anyOf with null.
-
-    Pydantic generates `anyOf: [{type: X}, {type: null}]` for optional fields.
-    MCP clients don't always understand this, showing "unknown" for types.
-    This function converts such patterns to just `{type: X}` while preserving
-    other properties like default, description, minimum, maximum, enum, etc.
-    """
-    if not isinstance(schema, dict):
-        return schema
-
-    result = {}
-    for key, value in schema.items():
-        if key == "anyOf" and isinstance(value, list) and len(value) == 2:
-            # Check if this is the pattern: [{actual_type}, {type: null}]
-            non_null = [
-                v
-                for v in value
-                if not (isinstance(v, dict) and v.get("type") == "null")
-            ]
-            null_types = [
-                v for v in value if isinstance(v, dict) and v.get("type") == "null"
-            ]
-
-            if len(non_null) == 1 and len(null_types) == 1:
-                # Flatten: merge the non-null type's properties into result
-                for k, v in _simplify_schema(non_null[0]).items():
-                    result[k] = v
-                continue
-
-        # Recursively simplify nested structures
-        if isinstance(value, dict):
-            result[key] = _simplify_schema(value)
-        elif isinstance(value, list):
-            result[key] = [
-                _simplify_schema(item) if isinstance(item, dict) else item
-                for item in value
-            ]
-        else:
-            result[key] = value
-
-    return result
-
-
-def _get_simplified_schema(model: type) -> dict[str, Any]:
-    """Get a simplified JSON Schema from a Pydantic model."""
-    return _simplify_schema(model.model_json_schema())
-
-
-def _output_fields_to_output_schema(
-    output_fields: list[str] | None,
-) -> dict[str, Any] | None:
-    """Convert simple output_fields list to JSON Schema for output_schema parameter.
-
-    Args:
-        output_fields: List of field names, e.g. ['headline', 'summary', 'url']
-
-    Returns:
-        JSON Schema dict for API output_schema parameter, or None if output_fields is None.
-    """
-    if output_fields is None:
-        return None
-
-    properties = {field: {"type": "string"} for field in output_fields}
-
-    return {
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": properties,
-        },
-    }
 
 
 # Tool definitions with annotations

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -6,7 +6,8 @@ import pytest
 
 from yutori.auth.types import AuthStatus, LoginResult
 from yutori_mcp import __version__
-from yutori_mcp.server import _output_fields_to_output_schema, _simplify_schema, _get_simplified_schema, main
+from yutori_mcp.schema_utils import _output_fields_to_output_schema, _simplify_schema, _get_simplified_schema
+from yutori_mcp.server import main
 from yutori_mcp.schemas import ListScoutsInput, CreateScoutInput
 
 


### PR DESCRIPTION
## Closed — duplicate of #56

This refactor was already completed in #56 (merged as `bc15e3b`). The only difference was naming convention (underscore-prefixed vs public names). Closing as redundant.

https://claude.ai/code/session_016527msVSymqEpDjPBcS5Vg