### PR TITLE
chore: bump to 0.2.9, drop SDK pin ceiling, use navigator_* fields

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -32,7 +32,7 @@ API Rate Limits (available):
   Remaining: 8750
   Resets at: 2026-03-04T00:00:00+00:00
 
-n1 API Rate Limits:
+Navigator API Rate Limits:
   Requests today: 342
   Daily limit: 50000
   Remaining: 49658
@@ -43,7 +43,7 @@ Activity (7d):
   Scout runs: 47
   Browsing tasks: 12
   Research tasks: 8
-  n1 API calls: 1523
+  Navigator API calls: 1523
 ```
 
 ## Scout Tools

--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -197,25 +197,27 @@ def format_usage(response: dict[str, Any], **context: Any) -> str:
             lines.append(f"  Remaining: {rate_limits.get('remaining_requests', 'N/A')}")
         lines.append(f"  Resets at: {rate_limits.get('reset_at', 'N/A')}")
 
-    # n1 rate limits
-    n1_limits = response.get("n1_rate_limits", {})
-    if n1_limits:
-        lines.append("\nn1 API Rate Limits:")
-        lines.append(f"  Requests today: {n1_limits.get('requests_today', 'N/A')}")
-        lines.append(f"  Daily limit: {n1_limits.get('daily_limit', 'N/A')}")
-        lines.append(f"  Remaining: {n1_limits.get('remaining_requests', 'N/A')}")
-        lines.append(f"  Per-second limit: {n1_limits.get('per_second_limit', 'N/A')}")
-        lines.append(f"  Resets at: {n1_limits.get('reset_at', 'N/A')}")
+    # Navigator rate limits (falls back to deprecated n1_rate_limits on older servers)
+    navigator_limits = response.get("navigator_rate_limits") or response.get("n1_rate_limits") or {}
+    if navigator_limits:
+        lines.append("\nNavigator API Rate Limits:")
+        lines.append(f"  Requests today: {navigator_limits.get('requests_today', 'N/A')}")
+        lines.append(f"  Daily limit: {navigator_limits.get('daily_limit', 'N/A')}")
+        lines.append(f"  Remaining: {navigator_limits.get('remaining_requests', 'N/A')}")
+        lines.append(f"  Per-second limit: {navigator_limits.get('per_second_limit', 'N/A')}")
+        lines.append(f"  Resets at: {navigator_limits.get('reset_at', 'N/A')}")
 
     # Activity
     activity = response.get("activity", {})
     if activity:
         period = activity.get("period", "24h")
+        # `navigator_calls` is the primary key; `n1_calls` is the deprecated alias.
+        navigator_calls = activity.get("navigator_calls", activity.get("n1_calls", 0))
         lines.append(f"\nActivity ({period}):")
         lines.append(f"  Scout runs: {activity.get('scout_runs', 0)}")
         lines.append(f"  Browsing tasks: {activity.get('browsing_tasks', 0)}")
         lines.append(f"  Research tasks: {activity.get('research_tasks', 0)}")
-        lines.append(f"  n1 API calls: {activity.get('n1_calls', 0)}")
+        lines.append(f"  Navigator API calls: {navigator_calls}")
 
     return "\n".join(lines)
 

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -44,6 +44,14 @@ class TestDictToMarkdown:
 
 
 class TestFormatUsage:
+    # Current server emits both navigator_* (primary) and n1_* (deprecated alias) with equal values.
+    _NAVIGATOR_LIMITS = {
+        "requests_today": 100,
+        "daily_limit": 50000,
+        "remaining_requests": 49900,
+        "reset_at": "2026-03-04T00:00:00+00:00",
+        "per_second_limit": 20,
+    }
     USAGE_RESPONSE = {
         "num_active_scouts": 3,
         "active_scout_ids": ["id-1", "id-2", "id-3"],
@@ -54,18 +62,14 @@ class TestFormatUsage:
             "reset_at": "2026-03-04T00:00:00+00:00",
             "status": "available",
         },
-        "n1_rate_limits": {
-            "requests_today": 100,
-            "daily_limit": 50000,
-            "remaining_requests": 49900,
-            "reset_at": "2026-03-04T00:00:00+00:00",
-            "per_second_limit": 20,
-        },
+        "navigator_rate_limits": _NAVIGATOR_LIMITS,
+        "n1_rate_limits": _NAVIGATOR_LIMITS,
         "activity": {
             "period": "7d",
             "scout_runs": 21,
             "browsing_tasks": 5,
             "research_tasks": 3,
+            "navigator_calls": 800,
             "n1_calls": 800,
         },
     }
@@ -83,11 +87,18 @@ class TestFormatUsage:
         assert "Daily limit: 10000" in result
         assert "Remaining: 9500" in result
 
-    def test_n1_rate_limits_shown(self):
+    def test_navigator_rate_limits_shown(self):
         result = format_usage(self.USAGE_RESPONSE)
-        assert "n1 API Rate Limits" in result
+        assert "Navigator API Rate Limits" in result
         assert "Requests today: 100" in result
         assert "Per-second limit: 20" in result
+
+    def test_navigator_rate_limits_fallback_to_deprecated_n1_key(self):
+        """If only the deprecated n1_rate_limits field is present, still render the section."""
+        response = {k: v for k, v in self.USAGE_RESPONSE.items() if k != "navigator_rate_limits"}
+        result = format_usage(response)
+        assert "Navigator API Rate Limits" in result
+        assert "Requests today: 100" in result
 
     def test_activity_shown(self):
         result = format_usage(self.USAGE_RESPONSE)
@@ -95,7 +106,22 @@ class TestFormatUsage:
         assert "Scout runs: 21" in result
         assert "Browsing tasks: 5" in result
         assert "Research tasks: 3" in result
-        assert "n1 API calls: 800" in result
+        assert "Navigator API calls: 800" in result
+
+    def test_activity_falls_back_to_deprecated_n1_calls_key(self):
+        """Older servers may only emit activity.n1_calls."""
+        response = {
+            **self.USAGE_RESPONSE,
+            "activity": {
+                "period": "7d",
+                "scout_runs": 21,
+                "browsing_tasks": 5,
+                "research_tasks": 3,
+                "n1_calls": 42,
+            },
+        }
+        result = format_usage(response)
+        assert "Navigator API calls: 42" in result
 
     def test_unavailable_rate_limits(self):
         """When rate limits are unavailable, don't show request counts."""


### PR DESCRIPTION
## Summary

Three closely-related changes that finish the n1 → Navigator rollout on the MCP side:

1. **Bump `yutori-mcp` from 0.2.8 → 0.2.9.**
2. **Drop the `<0.5.0` ceiling on the `yutori` SDK dependency** — `yutori>=0.4.0,<0.5.0` → `yutori>=0.4.0`. The ceiling was artificially tight; MCP uses only SDK methods that are stable across 0.4.x through 0.6.x, and fresh installs via `uvx yutori-mcp` should pick up the latest SDK. Verified all 137 prior tests pass against both the formerly-pinned 0.4.10 and the current 0.6.0 SDK.
3. **Switch `format_usage` to the new `navigator_*` response fields**, with a fallback to the deprecated `n1_*` aliases so the MCP keeps working during the server's dual-emit window.
   - `response["navigator_rate_limits"]` (falls back to `response["n1_rate_limits"]`) → rendered under "Navigator API Rate Limits".
   - `activity["navigator_calls"]` (falls back to `activity["n1_calls"]`) → rendered as "Navigator API calls".
4. **Tests**: `USAGE_RESPONSE` fixture carries both `navigator_*` and `n1_*` keys (mirroring what the server actually emits during the dual-emit window). Two new tests assert that the formatter still renders the section when only the deprecated `n1_*` key is present.
5. **TOOLS.md** example response for `list_api_usage` updated to the new labels.

## Companion PRs
- yutori-ai/yutori#8174 — server-side dual-emit of `/v1/usage` response + holistic API-dashboard rename.
- yutori-ai/yutori-sdk-python#50 — `api.md` updated to document `navigator_*` fields as canonical with `n1_*` as deprecated aliases.

## Test plan
- [x] `pytest -q` → **139 passed** (137 prior + 2 new fallback tests).
- [x] Verified the updated formatter reads from both canonical and deprecated keys.
- [ ] Smoke-test `list_api_usage` against a deployed server running the dual-emit code path.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to usage-response formatting and documentation, with explicit fallbacks to deprecated `n1_*` fields and added tests covering both new and old payload shapes.
> 
> **Overview**
> Updates `list_api_usage` formatting to prefer the new `navigator_rate_limits` / `activity.navigator_calls` fields and renames the rendered labels to **Navigator**, while retaining compatibility by falling back to the deprecated `n1_rate_limits` / `activity.n1_calls` keys.
> 
> Expands tests to mirror dual-emitted server responses and adds coverage for the fallback behavior, and refreshes the `TOOLS.md` example output to match the new labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2899addf2f541cc723242ccc5bb54b885677fe83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->