### PR TITLE
refactor: extract _scout_url() helper in formatters

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -113,6 +113,11 @@ def _truncate(text: str, max_len: int = 60) -> str:
     return text[: max_len - 3] + "..."
 
 
+def _scout_url(scout_id: str) -> str:
+    """Return the platform URL for a scout."""
+    return f"https://platform.yutori.com/scouting/tasks/{scout_id}"
+
+
 def _append_rejection_reason(
     lines: list[str], rejection_reason: str | None, *, indent: str = ""
 ) -> None:
@@ -240,7 +245,7 @@ def format_list_scouts(response: dict[str, Any], **context: Any) -> str:
         lines.append(f"\n{i}. {name} ({status})")
         lines.append(f'   Query: "{_truncate(query)}"')
         lines.append(f"   ID: {scout_id}")
-        lines.append(f"   URL: https://platform.yutori.com/scouting/tasks/{scout_id}")
+        lines.append(f"   URL: {_scout_url(scout_id)}")
         lines.append(f"   Runs {interval} | Next: {next_run}")
         _append_rejection_reason(lines, scout.get("rejection_reason"), indent="   ")
 
@@ -265,7 +270,7 @@ def format_scout_detail(response: dict[str, Any], **context: Any) -> str:
     lines = [
         f"Scout: {name}",
         f"ID: {scout_id}",
-        f"URL: https://platform.yutori.com/scouting/tasks/{scout_id}",
+        f"URL: {_scout_url(scout_id)}",
         f"Status: {status}",
     ]
     _append_rejection_reason(lines, response.get("rejection_reason"))
@@ -384,7 +389,7 @@ def format_scout_created(response: dict[str, Any], **context: Any) -> str:
         "",
         f"Name: {name}",
         f"ID: {scout_id}",
-        f"URL: https://platform.yutori.com/scouting/tasks/{scout_id}",
+        f"URL: {_scout_url(scout_id)}",
         f"Status: {status}",
     ]
     _append_rejection_reason(lines, response.get("rejection_reason"))
@@ -415,7 +420,7 @@ def format_scout_edited(response: dict[str, Any], **context: Any) -> str:
             "",
             f"Name: {name}",
             f"ID: {scout_id}",
-            f"URL: https://platform.yutori.com/scouting/tasks/{scout_id}",
+            f"URL: {_scout_url(scout_id)}",
             f"Status: {status}",
         ]
         _append_rejection_reason(lines, new.get("rejection_reason"))
@@ -431,7 +436,7 @@ def format_scout_edited(response: dict[str, Any], **context: Any) -> str:
         "",
         f"Name: {name}",
         f"ID: {scout_id}",
-        f"URL: https://platform.yutori.com/scouting/tasks/{scout_id}",
+        f"URL: {_scout_url(scout_id)}",
         "",
         "Changes applied:",
     ]


### PR DESCRIPTION
## What

The platform URL `https://platform.yutori.com/scouting/tasks/{scout_id}` was hard-coded in **5 places** in `formatters.py`:

- `format_list_scouts` (per-scout URL line)
- `format_scout_detail`
- `format_scout_created`
- `format_scout_edited` (no-old branch)
- `format_scout_edited` (with-old branch)

This PR consolidates them into a single `_scout_url()` helper located alongside the other small formatting helpers (`_truncate`, `_append_rejection_reason`, etc.).

## Why

Five copies of the same URL is a maintenance hazard:

- A change to the URL (path rename, staging override, embedded query params) required touching every call site.
- Easy for them to drift out of sync over time.
- Harder for a reader to confirm "we always render the same URL for a scout".

A one-line helper gives a single source of truth and makes future tweaks trivial.

## Safety

- Pure refactor — no behavioral change.
- All **137 existing tests pass** unchanged (including the formatter tests that assert specific URL/output strings).
- Diff is +10/-5 in a single file; verifiable from the diff alone.

https://claude.ai/code/session_013XYHphkpD885sXbLHB68sn

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only centralizes URL string formatting; main risk is unintended URL string drift affecting output snapshots.
> 
> **Overview**
> Consolidates the previously hard-coded scout platform link into a single `_scout_url(scout_id)` helper and updates all scout-related formatters to use it (`format_list_scouts`, `format_scout_detail`, `format_scout_created`, and both branches of `format_scout_edited`). This reduces duplication while keeping the rendered URL format consistent across outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2b8da08eae25f2a985ee422178fa03552516ff8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->