### PR TITLE
refactor(formatters): extract _scout_platform_url() helper

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -113,6 +113,11 @@ def _truncate(text: str, max_len: int = 60) -> str:
     return text[: max_len - 3] + "..."
 
 
+def _scout_platform_url(scout_id: str) -> str:
+    """Build the platform URL for viewing a scout."""
+    return f"https://platform.yutori.com/scouting/tasks/{scout_id}"
+
+
 def _append_rejection_reason(
     lines: list[str], rejection_reason: str | None, *, indent: str = ""
 ) -> None:
@@ -240,7 +245,7 @@ def format_list_scouts(response: dict[str, Any], **context: Any) -> str:
         lines.append(f"\n{i}. {name} ({status})")
         lines.append(f'   Query: "{_truncate(query)}"')
         lines.append(f"   ID: {scout_id}")
-        lines.append(f"   URL: https://platform.yutori.com/scouting/tasks/{scout_id}")
+        lines.append(f"   URL: {_scout_platform_url(scout_id)}")
         lines.append(f"   Runs {interval} | Next: {next_run}")
         _append_rejection_reason(lines, scout.get("rejection_reason"), indent="   ")
 
@@ -265,7 +270,7 @@ def format_scout_detail(response: dict[str, Any], **context: Any) -> str:
     lines = [
         f"Scout: {name}",
         f"ID: {scout_id}",
-        f"URL: https://platform.yutori.com/scouting/tasks/{scout_id}",
+        f"URL: {_scout_platform_url(scout_id)}",
         f"Status: {status}",
     ]
     _append_rejection_reason(lines, response.get("rejection_reason"))
@@ -384,7 +389,7 @@ def format_scout_created(response: dict[str, Any], **context: Any) -> str:
         "",
         f"Name: {name}",
         f"ID: {scout_id}",
-        f"URL: https://platform.yutori.com/scouting/tasks/{scout_id}",
+        f"URL: {_scout_platform_url(scout_id)}",
         f"Status: {status}",
     ]
     _append_rejection_reason(lines, response.get("rejection_reason"))
@@ -415,7 +420,7 @@ def format_scout_edited(response: dict[str, Any], **context: Any) -> str:
             "",
             f"Name: {name}",
             f"ID: {scout_id}",
-            f"URL: https://platform.yutori.com/scouting/tasks/{scout_id}",
+            f"URL: {_scout_platform_url(scout_id)}",
             f"Status: {status}",
         ]
         _append_rejection_reason(lines, new.get("rejection_reason"))
@@ -431,7 +436,7 @@ def format_scout_edited(response: dict[str, Any], **context: Any) -> str:
         "",
         f"Name: {name}",
         f"ID: {scout_id}",
-        f"URL: https://platform.yutori.com/scouting/tasks/{scout_id}",
+        f"URL: {_scout_platform_url(scout_id)}",
         "",
         "Changes applied:",
     ]


### PR DESCRIPTION
## Summary

The scout platform URL template `https://platform.yutori.com/scouting/tasks/{scout_id}` was inlined as an f-string in **5 places** across `src/yutori_mcp/formatters.py`:

- `format_list_scouts` (one instance, indented for list items)
- `format_scout_detail`
- `format_scout_created`
- `format_scout_edited` (both the "no old state" fast path and the diff path)

This PR extracts the template into a single `_scout_platform_url(scout_id)` helper placed alongside the other `_format_*` / `_truncate` helpers.

## Why this is an improvement

- **One source of truth.** If the domain, path prefix, or scheme ever changes, it's a one-line edit instead of five.
- **Same pattern already used in this file.** The module already consolidates shared formatting via `_format_interval`, `_format_date`, `_format_datetime`, `_truncate`, `_format_sources`, and `_append_rejection_reason`. This fits right in.
- **No new concepts.** Plain function, same signature shape as the existing helpers.

## Why it's safe

- **No behavioral change.** The helper returns the same f-string output as the inlined versions. Each call site formerly wrote `f"URL: https://platform.yutori.com/scouting/tasks/{scout_id}"` and now writes `f"URL: {_scout_platform_url(scout_id)}"` — identical result.
- **All call sites updated.** `grep "platform.yutori.com"` under `src/` now shows only the helper definition; no stragglers.
- **No test impact.** `grep "platform.yutori.com"` under `tests/` returns nothing — no test asserts on the URL string.
- **Existing tests pass.** Ran the full suite locally: `137 passed`.

## Test plan

- [x] `python -m ast` parses the file
- [x] `pytest tests/` — 137/137 pass locally
- [ ] CI green on the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only centralizes a repeated URL string into a helper; behavior should remain identical aside from any unintended formatting change.
> 
> **Overview**
> Extracts the repeated scout platform URL template into a single `_scout_platform_url(scout_id)` helper in `formatters.py`.
> 
> Updates all scout-related formatters (`format_list_scouts`, `format_scout_detail`, `format_scout_created`, `format_scout_edited`) to call the helper instead of inlining the `https://platform.yutori.com/scouting/tasks/{scout_id}` string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 154df36d6456686399cd7cb4b6bf1eb8736c0f96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->