### PR TITLE
docs: add URL field to TOOLS.md example outputs

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -74,11 +74,13 @@ Showing 10 of 87:
 1. Yutori news and updates (active)
    Query: "Tell me about the latest news, product updates, or..."
    ID: 690bd26c-0ef8-42f4-99e4-8fca6ea20e6f
+   URL: https://platform.yutori.com/scouting/tasks/690bd26c-0ef8-42f4-99e4-8fca6ea20e6f
    Runs daily | Next: 2026-01-16
 
 2. Yutori API changelog (paused)
    Query: "Monitor Yutori API changelog for breaking changes"
    ID: 36d178a0-591f-4567-8019-32d24f9e55ba
+   URL: https://platform.yutori.com/scouting/tasks/36d178a0-591f-4567-8019-32d24f9e55ba
    Runs every 12 hours | Next: 2026-01-10
 
 ... (8 more)
@@ -103,6 +105,7 @@ Example response:
 ```
 Scout: Yutori news and updates
 ID: 690bd26c-0ef8-42f4-99e4-8fca6ea20e6f
+URL: https://platform.yutori.com/scouting/tasks/690bd26c-0ef8-42f4-99e4-8fca6ea20e6f
 Status: active
 
 Query: "Tell me about the latest news, product updates, or announcements about Yutori"
@@ -152,6 +155,7 @@ Scout created successfully.
 
 Name: Yutori news and updates
 ID: 3d1d5e2a-5b6c-4a9c-8f8c-2f2e3b4a5c6d
+URL: https://platform.yutori.com/scouting/tasks/3d1d5e2a-5b6c-4a9c-8f8c-2f2e3b4a5c6d
 Status: active
 
 Query: "Tell me about the latest news, product updates, press releases, social..."
@@ -212,6 +216,7 @@ Scout updated successfully.
 
 Name: Yutori API changelog
 ID: 7c8692c3-c637-4302-a982-b9f4f7b49407
+URL: https://platform.yutori.com/scouting/tasks/7c8692c3-c637-4302-a982-b9f4f7b49407
 
 Changes applied:
   • Status: paused → active


### PR DESCRIPTION
## Summary

- Add `URL:` field to example outputs in TOOLS.md for `list_scouts`, `get_scout_detail`, `create_scout`, and `edit_scout`
- Aligns documentation examples with the actual formatter output after #61 extracted `_scout_platform_url()` helper

After the `_scout_platform_url()` refactor, all scout formatters emit a `URL: https://platform.yutori.com/scouting/tasks/{scout_id}` line, but the TOOLS.md examples didn't include it.

## Test plan

- [ ] Compare each updated example against actual formatter output from `formatters.py`
- [ ] Verify TOOLS.md renders correctly on GitHub

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates example text outputs; no runtime or API behavior is modified.
> 
> **Overview**
> Updates `TOOLS.md` scout tool examples (`list_scouts`, `get_scout_detail`, `create_scout`, `edit_scout`) to include a `URL: https://platform.yutori.com/scouting/tasks/{scout_id}` line alongside the existing `ID`, aligning the docs with current formatter output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce8468faa31c3a3a198d5827a3d8370ed2ba77b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->