### PR TITLE
refactor(schemas): replace hand-rolled field list in EditScoutInput validator with model_dump

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -150,19 +150,7 @@ class EditScoutInput(BaseModel):
     @model_validator(mode="after")
     def validate_has_changes(self) -> "EditScoutInput":
         """Ensure at least one field besides scout_id is provided."""
-        fields = [
-            self.status,
-            self.query,
-            self.output_interval,
-            self.webhook_url,
-            self.webhook_format,
-            self.output_fields,
-            self.skip_email,
-            self.user_timezone,
-            self.user_location,
-            self.is_public,
-        ]
-        if not any(f is not None for f in fields):
+        if not self.model_dump(exclude={"scout_id"}, exclude_none=True):
             raise ValueError("edit_scout requires at least one field to update")
         return self
 


### PR DESCRIPTION
## Summary

`EditScoutInput.validate_has_changes` duplicated every non-`scout_id` field name in a local list to check "at least one change provided":

```python
fields = [
    self.status,
    self.query,
    self.output_interval,
    self.webhook_url,
    self.webhook_format,
    self.output_fields,
    self.skip_email,
    self.user_timezone,
    self.user_location,
    self.is_public,
]
if not any(f is not None for f in fields):
    raise ValueError(...)
```

Replaced with a single-line `model_dump`-based check:

```python
if not self.model_dump(exclude={"scout_id"}, exclude_none=True):
    raise ValueError(...)
```

## Why this is an improvement

- **Self-maintaining.** Adding a new field to `EditScoutInput` no longer requires a second edit in the validator. Today, forgetting the second edit silently bypasses the "at least one change" check — the field is accepted but never counted.
- **Consistent with existing code.** The same `model_dump(exclude={"scout_id"}, exclude_none=True)` pattern is already used in `server.py:_handle_tool` for the `edit_scout` case (introduced in #50) to build config kwargs. Using it here aligns the two call sites.
- **Less boilerplate.** 14 lines → 2 lines, same behavior.

## Why it's safe

- **No behavioral change.** Both approaches raise iff every field except `scout_id` is `None`. Verified manually:
  - `EditScoutInput(scout_id="abc")` → still raises `ValueError`.
  - `EditScoutInput(scout_id="abc", status="paused")` → still succeeds.
  - `EditScoutInput(scout_id="abc", output_fields=[])` → still counts as a change (empty list is not `None`, same as before).
- **Existing tests cover the behavior.** `test_requires_at_least_one_change`, `test_partial_update`, `test_status_with_config`, etc.

## Test plan

- [x] `pytest tests/` — 137/137 pass locally
- [ ] CI green on the PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to a Pydantic validator; it should preserve behavior but could subtly differ if future fields rely on non-None defaults or excluded serialization behavior.
> 
> **Overview**
> Refactors `EditScoutInput.validate_has_changes` to stop maintaining a manual list of editable fields and instead detect updates by checking `model_dump(exclude={"scout_id"}, exclude_none=True)`.
> 
> This makes the “at least one field to update” validation automatically cover any newly added optional fields without needing to update the validator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d369887e9351235215f5704087af1f3ee284b4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->