### PR TITLE
refactor(schemas): iterate model_fields in EditScoutInput validator

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -150,19 +150,11 @@ class EditScoutInput(BaseModel):
     @model_validator(mode="after")
     def validate_has_changes(self) -> "EditScoutInput":
         """Ensure at least one field besides scout_id is provided."""
-        fields = [
-            self.status,
-            self.query,
-            self.output_interval,
-            self.webhook_url,
-            self.webhook_format,
-            self.output_fields,
-            self.skip_email,
-            self.user_timezone,
-            self.user_location,
-            self.is_public,
-        ]
-        if not any(f is not None for f in fields):
+        if not any(
+            getattr(self, name) is not None
+            for name in type(self).model_fields
+            if name != "scout_id"
+        ):
             raise ValueError("edit_scout requires at least one field to update")
         return self
 


### PR DESCRIPTION
## Summary

`EditScoutInput.validate_has_changes` hard-coded a list of 10 field names that had to stay in sync with the class definition. Any new optional field added to the model would silently be ignored by the "at least one field" check until someone remembered to update the list — a classic source-of-truth drift.

Replaced the duplicated list with iteration over `type(self).model_fields` (excluding `scout_id`). Pydantic maintains `model_fields` automatically, so the validator now picks up new fields for free.

## Why it's safe

- **No behavioral change for current fields.** The set being checked is identical: every field in the model except `scout_id`.
- **All 137 tests pass**, including:
  - `test_requires_at_least_one_change` — validator still rejects scout_id-only inputs.
  - `test_partial_update` — validator still accepts single non-scout_id field.
  - `test_status_with_config`, `test_new_fields`, etc. — multi-field updates continue to validate.
- **Single-file, 5 LOC net delta.** Diff is self-contained and trivially reviewable.

## Why it's an improvement

`pydantic`'s `model_fields` is the canonical source of truth for a model's schema. Enumerating field names alongside the class is a known anti-pattern: future maintainers who add a field (e.g., the recently-added `user_location`, `is_public`) would have to remember to update a second list, and forgetting that would silently weaken the validator without any test failure.

https://claude.ai/code/session_01CXJSfM1vUovPZsUMKEzKTA

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized refactor of schema validation logic with no API surface changes; risk is limited to potential edge cases in the dynamic field iteration.
> 
> **Overview**
> Refactors `EditScoutInput.validate_has_changes` to iterate over `type(self).model_fields` (excluding `scout_id`) when enforcing “at least one field to update,” removing the duplicated, hard-coded field list.
> 
> This keeps current behavior while making the validation automatically cover newly added optional fields without requiring manual updates to the validator.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5677ba456431467c598cf434d93f57a186feb90d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->