### PR TITLE
refactor(formatters): hoist per-call dict and inline import to module scope

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
 
 
@@ -44,21 +45,7 @@ def _to_markdown_lines(obj: Any, level: int = 0) -> list[str]:
 
 def format_response(tool_name: str, response: dict[str, Any], **context: Any) -> str:
     """Route to appropriate formatter based on tool name."""
-    formatters = {
-        "list_api_usage": format_usage,
-        "list_scouts": format_list_scouts,
-        "get_scout_detail": format_scout_detail,
-        "get_scout_updates": format_scout_updates,
-        "create_scout": format_scout_created,
-        "edit_scout": format_scout_edited,
-        "delete_scout": format_scout_deleted,
-        "run_browsing_task": format_task_started,
-        "get_browsing_task_result": format_task_result,
-        "run_research_task": format_task_started,
-        "get_research_task_result": format_task_result,
-    }
-
-    formatter = formatters.get(tool_name)
+    formatter = _TOOL_FORMATTERS.get(tool_name)
     if formatter:
         return formatter(response, **context)
 
@@ -95,8 +82,6 @@ def _format_datetime(timestamp: str | int | None) -> str:
         return "not set"
     # Handle Unix timestamp in milliseconds (integer)
     if isinstance(timestamp, int):
-        from datetime import datetime, timezone
-
         # Convert milliseconds to seconds
         dt = datetime.fromtimestamp(timestamp / 1000, tz=timezone.utc)
         return dt.strftime("%Y-%m-%d %H:%M UTC")
@@ -625,3 +610,21 @@ def format_task_result(response: dict[str, Any], **context: Any) -> str:
     lines.extend(_format_sources(response, indent=""))
 
     return "\n".join(lines)
+
+
+# Tool-name -> formatter registry, referenced by format_response() above.
+# Defined at module scope (after all formatters) so the dict is built once at
+# import time rather than rebuilt on every call.
+_TOOL_FORMATTERS = {
+    "list_api_usage": format_usage,
+    "list_scouts": format_list_scouts,
+    "get_scout_detail": format_scout_detail,
+    "get_scout_updates": format_scout_updates,
+    "create_scout": format_scout_created,
+    "edit_scout": format_scout_edited,
+    "delete_scout": format_scout_deleted,
+    "run_browsing_task": format_task_started,
+    "get_browsing_task_result": format_task_result,
+    "run_research_task": format_task_started,
+    "get_research_task_result": format_task_result,
+}


### PR DESCRIPTION
## Summary

Two small, low-risk cleanups in `src/yutori_mcp/formatters.py`. No behavioral change.

### 1. Hoist the tool-name → formatter dict to module scope

`format_response()` previously constructed the 11-entry dispatch dict inline on every call. Moved it to a module-level `_TOOL_FORMATTERS` constant (defined at the bottom of the file, after all the formatter functions it references), so the registry is built once at import time.

### 2. Lift the inline datetime import to the top of the file

`_format_datetime()` had `from datetime import datetime, timezone` inside the `isinstance(timestamp, int)` branch. Moved it to the module-level imports alongside the existing `from typing import Any`, which is the standard place for these.

## Why it's safe

- `datetime` and `timezone` aren't referenced anywhere else in the module, so the only thing the first change affects is when the import runs (module load vs. first int timestamp). `datetime` is a stdlib module and is essentially free to import eagerly.
- The formatters dispatch dict is static — same keys, same function values — so moving it to module scope is a pure mechanical refactor. `format_response()` looks up `_TOOL_FORMATTERS` lazily at call time, so the forward reference is fine.
- Verified by the existing 137-test suite in `tests/` — all pass locally.

## Test plan

- [x] `pytest tests/` — 137/137 pass
- [x] Diff review: only the two targeted locations change; all formatter function bodies and test expectations are untouched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk mechanical refactor limited to formatter dispatch lookup and import placement, with no intended output/behavior changes.
> 
> **Overview**
> **Refactors formatter dispatch and imports with no intended behavior change.** `format_response()` now looks up formatters from a module-level `_TOOL_FORMATTERS` registry instead of rebuilding the mapping on every call.
> 
> Moves the `datetime`/`timezone` import from inside `_format_datetime()` to the module imports, keeping timestamp formatting logic unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a69e8c5f0936c607db06934acd4a7a09a3efae12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->