### PR TITLE
refactor(formatters): hoist fields_to_compare to module-level constant

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -441,20 +441,8 @@ def format_scout_edited(response: dict[str, Any], **context: Any) -> str:
     lines.extend(_scout_identity_lines(name=name, scout_id=scout_id))
     lines.extend(["", "Changes applied:"])
 
-    # Compare fields
-    fields_to_compare = [
-        ("status", "Status"),
-        ("query", "Query"),
-        ("output_interval", "Interval"),
-        ("webhook_url", "Webhook"),
-        ("skip_email", "Skip email"),
-        ("user_timezone", "Timezone"),
-        ("user_location", "Location"),
-        ("is_public", "Public"),
-    ]
-
     changes_found = False
-    for field, label in fields_to_compare:
+    for field, label in _SCOUT_EDIT_FIELDS:
         old_val = old.get(field)
         new_val = new.get(field)
         if old_val != new_val:
@@ -626,6 +614,19 @@ def format_task_result(response: dict[str, Any], **context: Any) -> str:
 
     return "\n".join(lines)
 
+
+# Scout-edit field comparison list, used by format_scout_edited().
+# Defined at module scope so the tuple list is built once at import time.
+_SCOUT_EDIT_FIELDS = (
+    ("status", "Status"),
+    ("query", "Query"),
+    ("output_interval", "Interval"),
+    ("webhook_url", "Webhook"),
+    ("skip_email", "Skip email"),
+    ("user_timezone", "Timezone"),
+    ("user_location", "Location"),
+    ("is_public", "Public"),
+)
 
 # Tool-name -> formatter registry, referenced by format_response() above.
 # Defined at module scope (after all formatters) so the dict is built once at


### PR DESCRIPTION
## Summary

- Move the `fields_to_compare` list out of `format_scout_edited()` into a module-level `_SCOUT_EDIT_FIELDS` tuple constant
- Follows the same pattern as #66 which hoisted `_TOOL_FORMATTERS` to module scope — the field list is static and was being rebuilt on every call

## Context

Daily code cleanup cron. Commit #66 (merged yesterday) hoisted `_TOOL_FORMATTERS` and moved a function-local `datetime` import to module scope. The `fields_to_compare` list in `format_scout_edited()` was the same class of per-call constant rebuild.

cc @dhruvbatra — you did the original `_TOOL_FORMATTERS` hoist; this is the same treatment for the remaining constant.

## Test plan

- [x] All 137 existing tests pass (`pytest tests/ -x -q`)
- [ ] Manual verification that `format_scout_edited()` produces identical output

https://claude.ai/code/session_017BkXkpsj9idrNyWfKzMeVW

---
_Generated by [Claude Code](https://claude.ai/code/session_017BkXkpsj9idrNyWfKzMeVW)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to `format_scout_edited()` formatting; behavior should be unchanged aside from avoiding rebuilding the field list each call.
> 
> **Overview**
> Refactors `format_scout_edited()` to iterate over a new module-level `_SCOUT_EDIT_FIELDS` tuple instead of constructing the field/label comparison list on every call.
> 
> This hoists a static constant to import time (similar to `_TOOL_FORMATTERS`), reducing per-call allocations while keeping the set/order of compared scout fields the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56cf07803710192da6c0b955b745ac0f4e056a64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->