### PR TITLE
refactor(formatters): extract _scout_identity_lines helper

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -103,14 +103,24 @@ def _scout_platform_url(scout_id: str) -> str:
     return f"https://platform.yutori.com/scouting/tasks/{scout_id}"
 
 
+_STATUS_UNSET: Any = object()
+
+
 def _scout_identity_lines(
     *,
     name: str,
     scout_id: str,
-    status: str | None = None,
+    status: Any = _STATUS_UNSET,
     name_label: str = "Name",
 ) -> list[str]:
     """Build the shared `{name_label}: ...` / `ID: ...` / `URL: ...` (+ `Status: ...`) header block.
+
+    The ``Status:`` line is appended whenever the caller passes a ``status``
+    argument, including when the value is ``None`` — this preserves the
+    pre-refactor behavior where ``response.get("status", "unknown")`` returning
+    a literal ``None`` (explicit null) would still render as ``Status: None``.
+    Callers that want to omit the line entirely (e.g. the diff path of
+    ``format_scout_edited``) simply don't pass ``status``.
 
     Used by the top-level scout detail / created / edited formatters. The list-scouts
     formatter uses its own indented variant and doesn't call this helper.
@@ -120,7 +130,7 @@ def _scout_identity_lines(
         f"ID: {scout_id}",
         f"URL: {_scout_platform_url(scout_id)}",
     ]
-    if status is not None:
+    if status is not _STATUS_UNSET:
         lines.append(f"Status: {status}")
     return lines
 

--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -103,6 +103,28 @@ def _scout_platform_url(scout_id: str) -> str:
     return f"https://platform.yutori.com/scouting/tasks/{scout_id}"
 
 
+def _scout_identity_lines(
+    *,
+    name: str,
+    scout_id: str,
+    status: str | None = None,
+    name_label: str = "Name",
+) -> list[str]:
+    """Build the shared `{name_label}: ...` / `ID: ...` / `URL: ...` (+ `Status: ...`) header block.
+
+    Used by the top-level scout detail / created / edited formatters. The list-scouts
+    formatter uses its own indented variant and doesn't call this helper.
+    """
+    lines = [
+        f"{name_label}: {name}",
+        f"ID: {scout_id}",
+        f"URL: {_scout_platform_url(scout_id)}",
+    ]
+    if status is not None:
+        lines.append(f"Status: {status}")
+    return lines
+
+
 def _append_rejection_reason(
     lines: list[str], rejection_reason: str | None, *, indent: str = ""
 ) -> None:
@@ -252,12 +274,9 @@ def format_scout_detail(response: dict[str, Any], **context: Any) -> str:
     query = response.get("query", "")
     created = _format_date(response.get("created_at"))
 
-    lines = [
-        f"Scout: {name}",
-        f"ID: {scout_id}",
-        f"URL: {_scout_platform_url(scout_id)}",
-        f"Status: {status}",
-    ]
+    lines = _scout_identity_lines(
+        name=name, scout_id=scout_id, status=status, name_label="Scout"
+    )
     _append_rejection_reason(lines, response.get("rejection_reason"))
     lines.extend(
         [
@@ -369,14 +388,8 @@ def format_scout_created(response: dict[str, Any], **context: Any) -> str:
     interval = _format_interval(response.get("output_interval"))
     next_run = _format_datetime(response.get("next_output_timestamp"))
 
-    lines = [
-        "Scout created successfully.",
-        "",
-        f"Name: {name}",
-        f"ID: {scout_id}",
-        f"URL: {_scout_platform_url(scout_id)}",
-        f"Status: {status}",
-    ]
+    lines = ["Scout created successfully.", ""]
+    lines.extend(_scout_identity_lines(name=name, scout_id=scout_id, status=status))
     _append_rejection_reason(lines, response.get("rejection_reason"))
     lines.extend(
         [
@@ -400,14 +413,8 @@ def format_scout_edited(response: dict[str, Any], **context: Any) -> str:
         name = new.get("display_name") or new.get("query", "")[:40]
         scout_id = new.get("id", "")
         status = new.get("status", "unknown")
-        lines = [
-            "Scout updated successfully.",
-            "",
-            f"Name: {name}",
-            f"ID: {scout_id}",
-            f"URL: {_scout_platform_url(scout_id)}",
-            f"Status: {status}",
-        ]
+        lines = ["Scout updated successfully.", ""]
+        lines.extend(_scout_identity_lines(name=name, scout_id=scout_id, status=status))
         _append_rejection_reason(lines, new.get("rejection_reason"))
         lines.extend(["", "Use get_scout_detail(scout_id) for full details."])
         return "\n".join(lines)
@@ -416,15 +423,9 @@ def format_scout_edited(response: dict[str, Any], **context: Any) -> str:
     name = new.get("display_name") or new.get("query", "")[:40]
     scout_id = new.get("id", "")
 
-    lines = [
-        "Scout updated successfully.",
-        "",
-        f"Name: {name}",
-        f"ID: {scout_id}",
-        f"URL: {_scout_platform_url(scout_id)}",
-        "",
-        "Changes applied:",
-    ]
+    lines = ["Scout updated successfully.", ""]
+    lines.extend(_scout_identity_lines(name=name, scout_id=scout_id))
+    lines.extend(["", "Changes applied:"])
 
     # Compare fields
     fields_to_compare = [

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -226,6 +226,17 @@ class TestFormatScoutDetail:
         result = format_scout_detail(response)
         assert "Rejection reason: invalid_query" in result
 
+    def test_explicit_null_status_still_renders_status_line(self):
+        """An explicit ``"status": null`` in the payload still renders ``Status: None``.
+
+        Regression test: ``response.get("status", "unknown")`` returns ``None``
+        when the key is present with a null value (the default is only used
+        when the key is missing), and the pre-refactor inline code formatted
+        that as ``Status: None``.
+        """
+        response = {"id": "abc-123", "display_name": "n", "query": "q", "status": None}
+        assert "Status: None" in format_scout_detail(response)
+
 
 class TestFormatScoutCreated:
     def test_created_confirmation(self):


### PR DESCRIPTION
## Summary

The `Name/ID/URL[/Status]` header block was inlined in **three** separate top-level scout formatters plus repeated a **fourth** time (without `Status:`) in the `format_scout_edited` diff path:

- `format_scout_detail` — uses `Scout:` as the name label
- `format_scout_created` — uses `Name:`
- `format_scout_edited` (no-old-state path) — uses `Name:`
- `format_scout_edited` (diff path) — uses `Name:`, no `Status:` line

This PR extracts `_scout_identity_lines(name, scout_id, status=None, name_label="Name")` and routes all four call sites through it. The helper lives alongside the existing `_scout_platform_url`, `_append_rejection_reason`, and `_format_sources` helpers in the same module — same style, same scope.

## Why this is an improvement

- **One source of truth.** If the header format ever changes (e.g. add a new identifier, rename a label), it's a one-line edit instead of four.
- **Removes a structural inconsistency.** The diff path in `format_scout_edited` was silently omitting `Status:` while the no-old-state path included it — now both sites share the same builder and opt in/out of `Status:` explicitly.
- **Fits a pattern already used heavily here.** The module already consolidates shared formatting via `_scout_platform_url`, `_format_interval`, `_format_date`, `_format_datetime`, `_truncate`, `_format_sources`, and `_append_rejection_reason`.

## Why it's safe

- **No behavioral change.** The helper returns byte-identical lines — each call site previously produced the same 3- or 4-line block the helper now builds.
- **`format_list_scouts` intentionally not migrated.** It uses a different indented per-item variant; parameterizing the helper for a single caller isn't worth the extra surface area. Documented in the helper docstring.
- **All 44 formatter tests pass unchanged** — including `TestFormatScoutDetail`, `TestFormatScoutCreated`, `TestFormatScoutEdited`, which assert on the exact output strings (`Scout: My Scout`, `ID: abc-123`, `Status: active`, etc.).

## Test plan

- [x] `pytest tests/test_formatters.py` — 44/44 pass locally
- [x] `pytest tests/test_formatters.py tests/test_schemas.py` — 96/96 pass locally
- [ ] CI green on the PR

https://claude.ai/code/session_014Xny8hGYSM6GS1mRVbgs6W

---
_Generated by [Claude Code](https://claude.ai/code/session_014Xny8hGYSM6GS1mRVbgs6W)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes repeated scout header formatting; behavior should be unchanged aside from ensuring the `Status:` line is still rendered when the API returns an explicit null status.
> 
> **Overview**
> Introduces `_scout_identity_lines` to build the common scout header block (`Name/Scout`, `ID`, `URL`, optional `Status`) and updates `format_scout_detail`, `format_scout_created`, and both paths of `format_scout_edited` to use it (with the diff path explicitly omitting `Status`).
> 
> Adds a regression test to ensure an explicit `"status": null` payload still prints `Status: None`, preserving prior output semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2e539fcc33e23d34ba56930781f3378a1288711. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->