### PR TITLE
Extract _has_value helper in formatters.py

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -11,6 +11,11 @@ def dict_to_markdown(obj: Any, level: int = 0) -> str:
     return "\n".join(_to_markdown_lines(obj, level))
 
 
+def _has_value(value: Any) -> bool:
+    """Return True when ``value`` is neither ``None`` nor an empty string."""
+    return value is not None and value != ""
+
+
 def _to_markdown_lines(obj: Any, level: int = 0) -> list[str]:
     """Recursively convert obj to markdown lines with indentation."""
     lines: list[str] = []
@@ -21,7 +26,7 @@ def _to_markdown_lines(obj: Any, level: int = 0) -> list[str]:
             if isinstance(val, (dict, list)) and val:
                 lines.append(f"{indent}{key}:")
                 lines.extend(_to_markdown_lines(val, level + 1))
-            elif val is not None and val != "":
+            elif _has_value(val):
                 lines.append(f"{indent}{key}: {val}")
     elif isinstance(obj, list):
         for item in obj:
@@ -32,13 +37,12 @@ def _to_markdown_lines(obj: Any, level: int = 0) -> list[str]:
                 lines.append(f"{indent}- {first_key}: {first_val}")
                 # Add remaining fields indented
                 for k, v in item.items():
-                    if k != first_key and v is not None and v != "":
+                    if k != first_key and _has_value(v):
                         lines.append(f"{indent}  {k}: {v}")
-            elif item is not None and item != "":
+            elif _has_value(item):
                 lines.append(f"{indent}- {item}")
-    else:
-        if obj is not None and obj != "":
-            lines.append(f"{indent}{obj}")
+    elif _has_value(obj):
+        lines.append(f"{indent}{obj}")
 
     return lines
 


### PR DESCRIPTION
## Summary

`_to_markdown_lines` in `formatters.py` repeated the predicate `val is not None and val != ""` four times across the dict / list-of-dicts / list / scalar branches. This PR lifts it into a tiny module-level `_has_value` helper and replaces all four occurrences.

## Why this is an improvement

- **Single source of truth.** If the "what counts as empty" rule ever needs to expand (e.g., to also skip empty lists, or to treat whitespace as empty), there is now one place to change instead of four.
- **Intent is explicit.** `_has_value(val)` reads like what it means; the compound boolean does not.
- **Also collapses a redundant `else`/`if` pair** in the scalar branch into a single `elif`, since `_to_markdown_lines` no longer needs the nested `if` that guarded the old inline check.

## Why this is safe

- Pure refactor. `_has_value(x)` is defined as `x is not None and x != ""` — identical to every inlined check it replaces.
- No public API change: `_has_value` is private and `_to_markdown_lines`'s signature / return shape are unchanged.
- Existing `TestDictToMarkdown` cases (including `test_empty_values_skipped`, `test_nested_dict`, `test_list_of_dicts`, `test_simple_dict`) continue to pass and directly verify the None / empty-string skip semantics across the dict, nested-dict, and list-of-dicts code paths. Full `test_formatters.py` suite (45 tests) passes locally.

## Test plan

- [x] `python -m pytest tests/test_formatters.py` — all 45 tests pass locally.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NY9ryu3qpBFsJJs7FNE9Dx)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk pure refactor that centralizes the None/empty-string check used when rendering dict/list structures to markdown; output should remain unchanged aside from any unforeseen edge-case differences.
> 
> **Overview**
> Refactors `dict_to_markdown`’s internal `_to_markdown_lines` to use a new private `_has_value()` helper instead of repeating `value is not None and value != ""` across dict, list, and scalar branches.
> 
> This also simplifies the scalar branch by collapsing a redundant `else`/`if` into a single `elif`, without changing the function signatures or expected output semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 822d4f59896b2a795a1f84ab1995430f9845afbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->