### PR TITLE
Remove stale browser parameter from Research API

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -306,7 +306,6 @@ Execute a one-time deep web research task. The research agent searches, reads, a
 {
   "query": "What are the latest developments in quantum computing from the past week? Include company announcements, research papers, and product releases.",
   "user_timezone": "America/Los_Angeles",
-  "browser": "local",
   "webhook_url": "https://example.com/webhook",
   "output_fields": ["title", "summary", "source_url", "category"]
 }
@@ -329,7 +328,6 @@ Poll with get_research_task_result(task_id="ae27a17c-a4ed-4c69-8b2a-4bec330fc935
 | `query` | Yes | Natural language description of what to research |
 | `user_timezone` | No | Timezone for context. Default: 'America/Los_Angeles' |
 | `user_location` | No | Location for context. Default: 'San Francisco, CA, US' |
-| `browser` | No | `cloud` (default) or `local` to use Yutori Local with the user's logged-in desktop browser |
 | `output_fields` | No | List of field names for structured output as array of objects |
 | `webhook_url` | No | URL for completion notification |
 | `webhook_format` | No | `scout` (default), `slack`, or `zapier` |

--- a/skills/02-research/SKILL.md
+++ b/skills/02-research/SKILL.md
@@ -27,7 +27,6 @@ Help the user conduct thorough web research using Yutori's Research API.
    Use `run_research_task` with:
    - `query`: The research question with context
    - `user_timezone`: For time-relevant searches
-   - `browser: "local"`: When the research needs a logged-in desktop browser session through Yutori Local
    - `output_fields`: If structured output is needed (e.g., ["title", "summary", "source_url", "date"])
    - `webhook_url`: HTTPS URL for completion notification
    - `webhook_format`: `scout` (default), `slack`, or `zapier`

--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -288,14 +288,6 @@ class ResearchTaskInput(BaseModel):
         default=None,
         description="Location for contextual awareness. Format: 'city, region, country'. Default: 'San Francisco, CA, US'",
     )
-    browser: Literal["cloud", "local"] | None = Field(
-        default=None,
-        description=(
-            "Where to run the browser when research needs web interaction. 'cloud' (default) uses "
-            "Yutori's cloud browser. 'local' uses Yutori Local with the user's logged-in sessions "
-            "on the desktop. Requires the desktop app to be running."
-        ),
-    )
     output_fields: list[str] | None = Field(
         default=None,
         description=(

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -108,8 +108,7 @@ TOOLS = [
         description=(
             "Execute a one-time deep web research task. The research agent searches, "
             "reads, and synthesizes information from across the web. Returns a task_id for polling. "
-            "Example: 'latest AI startup funding announcements'. Set browser='local' "
-            "to use Yutori Local with the user's logged-in sessions."
+            "Example: 'latest AI startup funding announcements'."
         ),
         inputSchema=get_simplified_schema(ResearchTaskInput),
     ),
@@ -300,12 +299,11 @@ def _handle_run_research_task(
         query=params.query,
         user_timezone=params.user_timezone,
         user_location=params.user_location,
-        browser=params.browser,
         output_schema=output_fields_to_output_schema(params.output_fields),
         webhook_url=params.webhook_url,
         webhook_format=params.webhook_format,
     )
-    return result, {"task_type": "Research", "browser": params.browser}
+    return result, {"task_type": "Research"}
 
 
 def _handle_get_research_task_result(

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -210,9 +210,3 @@ class TestBrowsingAndResearchForwarding:
         assert kwargs["browser"] == "local"
         assert kwargs["webhook_format"] == "zapier"
 
-    def test_research_forwards_browser(self, adapter):
-        adapter._client.research.create = MagicMock(return_value={"task_id": "r1"})
-        adapter.run_research_task("Research a logged-in dashboard", browser="local")
-
-        _, kwargs = adapter._client.research.create.call_args
-        assert kwargs["browser"] == "local"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -334,7 +334,6 @@ class TestResearchTaskInput:
         assert data.query == "Research quantum computing developments"
         assert data.user_timezone is None
         assert data.user_location is None
-        assert data.browser is None
 
     def test_full_input(self):
         """All fields can be provided."""
@@ -342,14 +341,12 @@ class TestResearchTaskInput:
             query="Research quantum computing developments",
             user_timezone="America/New_York",
             user_location="New York, NY, US",
-            browser="local",
             output_fields=["title", "summary", "source_url"],
             webhook_url="https://example.com/webhook",
             webhook_format="slack",
         )
         assert data.user_timezone == "America/New_York"
         assert data.user_location == "New York, NY, US"
-        assert data.browser == "local"
         assert data.webhook_format == "slack"
         assert data.output_fields == ["title", "summary", "source_url"]
 
@@ -363,15 +360,6 @@ class TestResearchTaskInput:
         data = ResearchTaskInput(query="Research AI")
         assert data.output_fields is None
 
-    def test_local_browser_supported(self):
-        """Research can target the local desktop browser."""
-        data = ResearchTaskInput(
-            query="Research a logged-in dashboard",
-            browser="local",
-        )
-        assert data.browser == "local"
-
-
 class TestInvalidBrowserRejected:
     """Verify that invalid browser values are rejected."""
 
@@ -381,14 +369,6 @@ class TestInvalidBrowserRejected:
             BrowsingTaskInput(
                 task="Test task",
                 start_url="https://example.com",
-                browser="remote",
-            )
-
-    def test_research_task_rejects_invalid_browser(self):
-        """ResearchTaskInput rejects browser='remote'."""
-        with pytest.raises(ValidationError):
-            ResearchTaskInput(
-                query="Test query",
                 browser="remote",
             )
 


### PR DESCRIPTION
## Summary

The server-side Research API removed the `browser` parameter in yutori-ai/yutori#8512 (commit a8c709ca, merged 2026-04-23) because it only injected a prompt-level hint — unlike the Browsing API which enforces browser selection at the config level. The MCP server was not updated to match, exposing a tool parameter that is silently ignored by the API.

This PR removes the stale `browser` parameter from:

- **Schema**: `ResearchTaskInput` in `schemas.py`
- **Server**: `_handle_run_research_task` handler (drops `browser=params.browser` kwarg and context key) and `run_research_task` tool description
- **Documentation**: TOOLS.md (example JSON, parameter table) and `skills/02-research/SKILL.md`
- **Tests**: `test_local_browser_supported`, `test_research_task_rejects_invalid_browser` (schemas), `test_research_forwards_browser` (adapter)

The Browsing API's `browser` parameter is unaffected — it remains functional and documented.

## What introduced the drift

- yutori-ai/yutori#8512 removed `browser` from the server-side Research API route, OpenAPI spec, and request model
- The MCP server was not updated in that PR since it lives in this repo

## Test plan

- [x] All 137 tests pass locally after the change
- [x] Verified no remaining `browser` references in research-related code paths
- [x] Browsing API `browser` parameter is untouched

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoeyfH9CaZEKg41aKbEu5b)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this removes an unused/ignored `browser` argument from the Research tool schema/handler and updates docs/tests accordingly; functional behavior should be unchanged aside from rejecting the now-unsupported parameter.
> 
> **Overview**
> Aligns the MCP `run_research_task` tool with the upstream Research API by **removing the stale `browser` parameter** end-to-end.
> 
> Updates the `ResearchTaskInput` schema and server handler to stop accepting/forwarding `browser` (and drops it from returned formatting context), and refreshes tool docs/skill guidance plus tests that previously validated `browser` support for research. Browsing’s `browser` parameter remains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2826ed5cd42b8bc74ec25879f202c1198122c75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->