### PR TITLE
Reuse _scout_kwargs in _handle_edit_scout

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -171,13 +171,18 @@ def _handle_tool(
     return handler(client, arguments)
 
 
-def _scout_kwargs(params: BaseModel) -> dict[str, Any]:
+def _scout_kwargs(
+    params: BaseModel, extra_exclude: set[str] | None = None
+) -> dict[str, Any]:
     """Convert a Pydantic input model into adapter kwargs.
 
     Drops None fields (matches adapter._strip_none centralization) and
     transforms `output_fields` into the API's `output_schema` format.
+    Callers can pass `extra_exclude` to drop additional fields (e.g. control
+    fields that are not part of the scout config payload).
     """
-    kwargs = params.model_dump(exclude={"output_fields"}, exclude_none=True)
+    exclude = {"output_fields"} | (extra_exclude or set())
+    kwargs = params.model_dump(exclude=exclude, exclude_none=True)
     if getattr(params, "output_fields", None) is not None:
         kwargs["output_schema"] = output_fields_to_output_schema(params.output_fields)
     return kwargs
@@ -234,14 +239,9 @@ def _handle_edit_scout(
     # Fetch current state for diff (also validates scout exists)
     old_scout = client.get_scout_detail(params.scout_id)
 
-    # Build config kwargs, excluding control fields and None values
-    config_kwargs = params.model_dump(
-        exclude={"scout_id", "status", "output_fields"},
-        exclude_none=True,
-    )
-    # output_fields needs transformation to the API's output_schema format
-    if params.output_fields is not None:
-        config_kwargs["output_schema"] = output_fields_to_output_schema(params.output_fields)
+    # Build config kwargs, excluding control fields (scout_id is passed
+    # explicitly below; status is applied separately after config updates).
+    config_kwargs = _scout_kwargs(params, extra_exclude={"scout_id", "status"})
 
     if config_kwargs:
         client.edit_scout(scout_id=params.scout_id, **config_kwargs)


### PR DESCRIPTION
## What

`_handle_edit_scout` inlined the Pydantic-to-kwargs transform that already lives in `_scout_kwargs` — the same `model_dump(exclude_none=True)` call plus the `output_fields -> output_schema` rewrite, just with a larger `exclude` set covering `scout_id` and `status`.

Extend `_scout_kwargs` with an optional `extra_exclude` parameter and delegate from `_handle_edit_scout`:

```python
config_kwargs = _scout_kwargs(params, extra_exclude={"scout_id", "status"})
```

## Why

Two call sites maintaining the same "drop None, drop `output_fields`, rewrite into `output_schema`" logic is exactly the shape of bug where we'll evolve one and forget the other. Centralising it keeps the transform in a single place without introducing any new abstraction — just a parameter on the helper that already exists.

## Safety

- No behavior change.
- The set-union `{"output_fields"} | (extra_exclude or set())` produces the same three-element exclude set that the inline code used for `edit_scout`, and the default (no `extra_exclude`) matches the previous single-element exclude used by every other caller.
- Verified locally: all 140 tests in `tests/` pass.

https://claude.ai/code/session_01CDaW5SRypoHMBLW1CXx95k

---
_Generated by [Claude Code](https://claude.ai/code/session_01CDaW5SRypoHMBLW1CXx95k)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes parameter-to-kwargs conversion; behavior should remain the same but could affect which fields are excluded from the `edit_scout` payload if misconfigured.
> 
> **Overview**
> Refactors `_handle_edit_scout` to delegate its Pydantic `model_dump(exclude_none=True)` + `output_fields`→`output_schema` transformation to `_scout_kwargs`, instead of duplicating that logic inline.
> 
> Extends `_scout_kwargs` with an optional `extra_exclude` set so callers (now `edit_scout`) can drop additional control fields like `scout_id` and `status` from the config payload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 77ca7feee63f6eb33bac14024548b996fe1e8c92. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->