### PR TITLE
refactor(formatters): collapse format_scout_edited if/elif ladder into per-field formatters

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -102,6 +102,21 @@ def _truncate(text: str, max_len: int = 60) -> str:
     return text[: max_len - 3] + "..."
 
 
+def _format_yes_no(value: Any) -> str:
+    """Render a boolean-ish value as ``yes``/``no`` for diff display."""
+    return "yes" if value else "no"
+
+
+def _format_query_diff(value: Any) -> str:
+    """Render a query string truncated and wrapped in quotes for diff display."""
+    return f'"{_truncate(value or "", 40)}"'
+
+
+def _format_or_unset(value: Any) -> Any:
+    """Render any value, falling back to ``(not set)`` when missing/empty."""
+    return value or "(not set)"
+
+
 def _scout_platform_url(scout_id: str) -> str:
     """Build the platform URL for viewing a scout."""
     return f"https://platform.yutori.com/scouting/tasks/{scout_id}"
@@ -444,24 +459,12 @@ def format_scout_edited(response: dict[str, Any], **context: Any) -> str:
     lines.extend(["", "Changes applied:"])
 
     changes_found = False
-    for field, label in _SCOUT_EDIT_FIELDS:
+    for field, label, fmt in _SCOUT_EDIT_FIELDS:
         old_val = old.get(field)
         new_val = new.get(field)
         if old_val != new_val:
             changes_found = True
-            if field == "output_interval":
-                old_display = _format_interval(old_val)
-                new_display = _format_interval(new_val)
-            elif field in ("skip_email", "is_public"):
-                old_display = "yes" if old_val else "no"
-                new_display = "yes" if new_val else "no"
-            elif field == "query":
-                old_display = f'"{_truncate(old_val or "", 40)}"'
-                new_display = f'"{_truncate(new_val or "", 40)}"'
-            else:
-                old_display = old_val or "(not set)"
-                new_display = new_val or "(not set)"
-            lines.append(f"  • {label}: {old_display} → {new_display}")
+            lines.append(f"  • {label}: {fmt(old_val)} → {fmt(new_val)}")
 
     if not changes_found:
         lines.append("  (no changes detected)")
@@ -618,16 +621,18 @@ def format_task_result(response: dict[str, Any], **context: Any) -> str:
 
 
 # Scout-edit field comparison list, used by format_scout_edited().
-# Defined at module scope so the tuple list is built once at import time.
+# Each tuple is (response_field, display_label, value_formatter). The formatter
+# is called on both old and new values to produce the per-side diff string, so
+# adding a new editable field is a single append here — no branching in the loop.
 _SCOUT_EDIT_FIELDS = (
-    ("status", "Status"),
-    ("query", "Query"),
-    ("output_interval", "Interval"),
-    ("webhook_url", "Webhook"),
-    ("skip_email", "Skip email"),
-    ("user_timezone", "Timezone"),
-    ("user_location", "Location"),
-    ("is_public", "Public"),
+    ("status", "Status", _format_or_unset),
+    ("query", "Query", _format_query_diff),
+    ("output_interval", "Interval", _format_interval),
+    ("webhook_url", "Webhook", _format_or_unset),
+    ("skip_email", "Skip email", _format_yes_no),
+    ("user_timezone", "Timezone", _format_or_unset),
+    ("user_location", "Location", _format_or_unset),
+    ("is_public", "Public", _format_yes_no),
 )
 
 # Tool-name -> formatter registry, referenced by format_response() above.


### PR DESCRIPTION
## What

Promote `_SCOUT_EDIT_FIELDS` in `src/yutori_mcp/formatters.py` from `(field, label)` tuples to `(field, label, formatter)` tuples, and have `format_scout_edited` call `formatter(value)` directly instead of branching on the field name.

## Why

The current `format_scout_edited` loop pairs each `_SCOUT_EDIT_FIELDS` entry with an `if field == "output_interval" / elif field in (...) / elif field == "query" / else` ladder that picks per-field display logic. The field list and the per-field formatting rules live in two different places, so adding a new editable field requires touching the tuple list **and** finding the right branch. That's the kind of duplication that quietly drifts: a future field is one missed `elif` from silently falling through to the generic `or "(not set)"` branch.

Pulling the four formatting rules into named helpers (`_format_interval` already existed, plus new `_format_yes_no`, `_format_query_diff`, `_format_or_unset`) and putting them next to their field in the tuple makes the diff rule for each field a single line, locally readable, and additive.

## Why it's safe (no behavior change)

Each `if/elif` branch maps 1:1 to one of the helpers — output strings are byte-identical:

| Original branch | New helper |
|---|---|
| `field == "output_interval"` → `_format_interval(val)` | `_format_interval` (unchanged) |
| `field in ("skip_email", "is_public")` → `"yes" if val else "no"` | `_format_yes_no` |
| `field == "query"` → `f'"{_truncate(old_val or "", 40)}"'` | `_format_query_diff` |
| `else` → `val or "(not set)"` | `_format_or_unset` |

- `_SCOUT_EDIT_FIELDS` is module-private and only referenced by `format_scout_edited` (verified by grepping the repo).
- The loop itself still iterates the same fields in the same order, still uses `old.get(field) != new.get(field)`, and still emits `f"  • {label}: {fmt(old_val)} → {fmt(new_val)}"`.
- Existing `tests/test_formatters.py::TestFormatScoutEdited` (`test_with_diff`, `test_no_changes`) exercises the loop and continues to pass.

Single file, no public-API change, fully reviewable from the diff.

## Test plan

- [x] `tests/test_formatters.py::TestFormatScoutEdited` still asserts on the same `Status:` / `active` / `paused` / `Query:` / `no changes detected` substrings — unchanged.
- [x] Manual trace of every branch confirms identical output.

https://claude.ai/code/session_01NJsiEwb669ATZgQ7HcwzBU

---
_Generated by [Claude Code](https://claude.ai/code/session_01NJsiEwb669ATZgQ7HcwzBU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to `format_scout_edited` output formatting; main risk is unintended string changes in the rendered diff for edited scouts.
> 
> **Overview**
> Refactors `format_scout_edited` to remove per-field `if/elif` formatting logic and instead drive diff rendering from `_SCOUT_EDIT_FIELDS`, which now includes a formatter function per field.
> 
> Adds small helper formatters (`_format_yes_no`, `_format_query_diff`, `_format_or_unset`) and updates the diff loop to call `fmt(old_val)`/`fmt(new_val)` for each changed field, making new editable fields additive via `_SCOUT_EDIT_FIELDS`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a60de51c354b93d25085a1f00fb69f09bcb1db60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->