### PR TITLE
fix: add missing webhook_format to edit diff, dedup rate limits

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -192,6 +192,24 @@ def _format_sources(
 # -----------------------------------------------------------------------------
 
 
+def _append_rate_limits(
+    lines: list[str],
+    limits: dict[str, Any],
+    extra_fields: tuple[tuple[str, str], ...] = (),
+) -> None:
+    """Append common rate-limit fields to *lines*.
+
+    Appends requests_today, daily_limit, remaining_requests, any
+    *extra_fields* (each a ``(key, label)`` pair), and reset_at.
+    """
+    lines.append(f"  Requests today: {limits.get('requests_today', 'N/A')}")
+    lines.append(f"  Daily limit: {limits.get('daily_limit', 'N/A')}")
+    lines.append(f"  Remaining: {limits.get('remaining_requests', 'N/A')}")
+    for key, label in extra_fields:
+        lines.append(f"  {label}: {limits.get(key, 'N/A')}")
+    lines.append(f"  Resets at: {limits.get('reset_at', 'N/A')}")
+
+
 def format_usage(response: dict[str, Any], **context: Any) -> str:
     """Format list_api_usage response as readable text."""
     num_active = response.get("num_active_scouts", 0)
@@ -211,20 +229,17 @@ def format_usage(response: dict[str, Any], **context: Any) -> str:
         status = rate_limits.get("status", "unknown")
         lines.append(f"\nAPI Rate Limits ({status}):")
         if status == "available":
-            lines.append(f"  Requests today: {rate_limits.get('requests_today', 'N/A')}")
-            lines.append(f"  Daily limit: {rate_limits.get('daily_limit', 'N/A')}")
-            lines.append(f"  Remaining: {rate_limits.get('remaining_requests', 'N/A')}")
-        lines.append(f"  Resets at: {rate_limits.get('reset_at', 'N/A')}")
+            _append_rate_limits(lines, rate_limits)
+        else:
+            lines.append(f"  Resets at: {rate_limits.get('reset_at', 'N/A')}")
 
     # Navigator rate limits (falls back to deprecated n1_rate_limits on older servers)
     navigator_limits = response.get("navigator_rate_limits") or response.get("n1_rate_limits") or {}
     if navigator_limits:
         lines.append("\nNavigator API Rate Limits:")
-        lines.append(f"  Requests today: {navigator_limits.get('requests_today', 'N/A')}")
-        lines.append(f"  Daily limit: {navigator_limits.get('daily_limit', 'N/A')}")
-        lines.append(f"  Remaining: {navigator_limits.get('remaining_requests', 'N/A')}")
-        lines.append(f"  Per-second limit: {navigator_limits.get('per_second_limit', 'N/A')}")
-        lines.append(f"  Resets at: {navigator_limits.get('reset_at', 'N/A')}")
+        _append_rate_limits(
+            lines, navigator_limits, extra_fields=(("per_second_limit", "Per-second limit"),)
+        )
 
     # Activity
     activity = response.get("activity", {})
@@ -333,7 +348,7 @@ def format_scout_detail(response: dict[str, Any], **context: Any) -> str:
     lines.append(f"  Email notifications: {'disabled' if skip_email else 'enabled'}")
 
     is_public = response.get("is_public", False)
-    lines.append(f"  Public: {'yes' if is_public else 'no'}")
+    lines.append(f"  Public: {_format_yes_no(is_public)}")
 
     if response.get("user_location"):
         lines.append(f"  Location: {response['user_location']}")
@@ -629,6 +644,7 @@ _SCOUT_EDIT_FIELDS = (
     ("query", "Query", _format_query_diff),
     ("output_interval", "Interval", _format_interval),
     ("webhook_url", "Webhook", _format_or_unset),
+    ("webhook_format", "Webhook format", _format_or_unset),
     ("skip_email", "Skip email", _format_yes_no),
     ("user_timezone", "Timezone", _format_or_unset),
     ("user_location", "Location", _format_or_unset),


### PR DESCRIPTION
## Summary\n\n- **Bug fix**: Add missing `webhook_format` to `_SCOUT_EDIT_FIELDS` — `EditScoutInput` in `schemas.py` includes this field but `format_scout_edited` silently omitted it from diffs, reporting \"(no changes detected)\" even when `webhook_format` changed\n- **Refactor**: Replace inline `'yes' if is_public else 'no'` ternary in `format_scout_detail` with the existing `_format_yes_no` helper, consistent with how `_SCOUT_EDIT_FIELDS` already uses it\n- **Refactor**: Extract `_append_rate_limits()` helper to consolidate the 4 duplicated rate-limit lines between the API and Navigator sections in `format_usage`\n\nContinues the formatter cleanup from #75 (per-field formatters refactor by @dhruvbatra).\n\ncc @dhruvbatra\n\n## Test plan\n\n- [ ] All 47 existing tests pass\n- [ ] `edit_scout` correctly displays `webhook_format` changes in the diff output\n- [ ] `format_usage` displays both API and Navigator rate limits with correct fields\n\nhttps://claude.ai/code/session_01UZ8sT9MiG6rbw3T2rgyc7p

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZ8sT9MiG6rbw3T2rgyc7p)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to text formatting helpers and add a previously-missed field to the edit diff output, with no behavioral impact beyond displayed strings.
> 
> **Overview**
> Fixes `format_scout_edited` diff output to include `webhook_format`, so edits to that field no longer incorrectly show “(no changes detected)”.
> 
> Refactors `format_usage` by extracting a shared `_append_rate_limits()` helper to remove duplicated rate-limit rendering, and standardizes `is_public` display in `format_scout_detail` to use `_format_yes_no`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82e709e244b17bb1b39dfb16c00354d990e74d1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->