### PR TITLE
refactor(formatters): extract _format_request_count_lines helper

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -192,6 +192,15 @@ def _format_sources(
 # -----------------------------------------------------------------------------
 
 
+def _format_request_count_lines(limits: dict[str, Any]) -> list[str]:
+    """Format the shared `requests_today / daily_limit / remaining` triplet."""
+    return [
+        f"  Requests today: {limits.get('requests_today', 'N/A')}",
+        f"  Daily limit: {limits.get('daily_limit', 'N/A')}",
+        f"  Remaining: {limits.get('remaining_requests', 'N/A')}",
+    ]
+
+
 def format_usage(response: dict[str, Any], **context: Any) -> str:
     """Format list_api_usage response as readable text."""
     num_active = response.get("num_active_scouts", 0)
@@ -211,18 +220,14 @@ def format_usage(response: dict[str, Any], **context: Any) -> str:
         status = rate_limits.get("status", "unknown")
         lines.append(f"\nAPI Rate Limits ({status}):")
         if status == "available":
-            lines.append(f"  Requests today: {rate_limits.get('requests_today', 'N/A')}")
-            lines.append(f"  Daily limit: {rate_limits.get('daily_limit', 'N/A')}")
-            lines.append(f"  Remaining: {rate_limits.get('remaining_requests', 'N/A')}")
+            lines.extend(_format_request_count_lines(rate_limits))
         lines.append(f"  Resets at: {rate_limits.get('reset_at', 'N/A')}")
 
     # Navigator rate limits (falls back to deprecated n1_rate_limits on older servers)
     navigator_limits = response.get("navigator_rate_limits") or response.get("n1_rate_limits") or {}
     if navigator_limits:
         lines.append("\nNavigator API Rate Limits:")
-        lines.append(f"  Requests today: {navigator_limits.get('requests_today', 'N/A')}")
-        lines.append(f"  Daily limit: {navigator_limits.get('daily_limit', 'N/A')}")
-        lines.append(f"  Remaining: {navigator_limits.get('remaining_requests', 'N/A')}")
+        lines.extend(_format_request_count_lines(navigator_limits))
         lines.append(f"  Per-second limit: {navigator_limits.get('per_second_limit', 'N/A')}")
         lines.append(f"  Resets at: {navigator_limits.get('reset_at', 'N/A')}")
 


### PR DESCRIPTION
## Summary

`format_usage` had the same three lines duplicated across the two rate-limit blocks:

```python
lines.append(f"  Requests today: {limits.get('requests_today', 'N/A')}")
lines.append(f"  Daily limit: {limits.get('daily_limit', 'N/A')}")
lines.append(f"  Remaining: {limits.get('remaining_requests', 'N/A')}")
```

Extract a small `_format_request_count_lines(limits)` helper so the API and Navigator sections share a single source for those lines. The diverging fields (`status` gating, `Per-second limit`, `Resets at`) remain inline at each call site.

## Why it's safe

- Pure formatter — no I/O, no state.
- Existing assertions in `test_formatters.py` (`Requests today: 500`, `Daily limit: 10000`, `Remaining: 9500`, plus the navigator counterparts) still hold.
- All 99 `tests/test_formatters.py` + `tests/test_schemas.py` tests pass locally.

## Test plan

- [x] `pytest tests/test_formatters.py tests/test_schemas.py` (99 passed)
- [ ] CI passes

---
_Generated by [Claude Code](https://claude.ai/code/session_018NqW7YgXD1KCFTeVemVQox)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to text formatting; it only deduplicates repeated rate-limit output lines in `format_usage` without changing data flow or external interfaces.
> 
> **Overview**
> Extracts `_format_request_count_lines()` in `formatters.py` to centralize the repeated "Requests today / Daily limit / Remaining" formatting.
> 
> Updates `format_usage` to use this helper for both the main API rate-limit block (when `status == "available"`) and the Navigator rate-limit block, reducing duplication while keeping the rest of the output unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdf02f043ed280a7880ab5992f26ed552a9bc8b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->