### PR TITLE
refactor(formatters): drop dead task_type heuristic in format_task_started

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -503,20 +503,17 @@ def format_scout_deleted(response: dict[str, Any], **context: Any) -> str:
 
 
 def format_task_started(response: dict[str, Any], **context: Any) -> str:
-    """Format run_*_task response showing task ID and next steps."""
+    """Format run_*_task response showing task ID and next steps.
+
+    ``task_type`` (``"Browsing"`` or ``"Research"``) must be supplied via
+    ``context``. The public ``_TOOL_FORMATTERS`` registry only routes the
+    ``run_browsing_task`` / ``run_research_task`` tools to this formatter,
+    and both server handlers stamp the field explicitly.
+    """
     task_id = response.get("task_id", "")
     status = response.get("status", "queued")
     view_url = response.get("view_url", "")
-
-    # Determine task type from context or response
-    task_type = context.get("task_type", "")
-    if not task_type:
-        if "query" in response:
-            task_type = "Research"
-        elif "task" in response or "start_url" in response:
-            task_type = "Browsing"
-        else:
-            task_type = "Task"
+    task_type = context["task_type"]
 
     browser = context.get("browser")
     browser_note = " (using local desktop browser)" if browser == "local" else ""
@@ -545,16 +542,9 @@ def format_task_started(response: dict[str, Any], **context: Any) -> str:
         lines.append(f"View progress: {view_url}")
 
     lines.append("")
-
-    # Determine the right poll function
-    if task_type == "Research":
-        poll_fn = "get_research_task_result"
-    elif task_type == "Browsing":
-        poll_fn = "get_browsing_task_result"
-    else:
-        poll_fn = "get_task_result"
-
-    lines.append(f'Poll with {poll_fn}(task_id="{task_id}") to check status.')
+    lines.append(
+        f'Poll with {_TASK_POLL_FNS[task_type]}(task_id="{task_id}") to check status.'
+    )
 
     return "\n".join(lines)
 
@@ -639,6 +629,14 @@ _SCOUT_EDIT_FIELDS = (
     ("user_location", "Location", _format_or_unset),
     ("is_public", "Public", _format_yes_no),
 )
+
+# Map task_type (as stamped by run_browsing_task / run_research_task handlers
+# in server.py) to the polling tool name surfaced in the user-facing hint
+# emitted by format_task_started().
+_TASK_POLL_FNS: dict[str, str] = {
+    "Research": "get_research_task_result",
+    "Browsing": "get_browsing_task_result",
+}
 
 # Tool-name -> formatter registry, referenced by format_response() above.
 # Defined at module scope (after all formatters) so the dict is built once at


### PR DESCRIPTION
## Structural issue

`format_task_started` carried two pieces of unreachable defensive code:

1. A heuristic that inferred `task_type` from response shape (`"query" in response` -> "Research", `"task" in response or "start_url" in response` -> "Browsing", else "Task").
2. An `else` branch in the poll-function selection that fell back to a non-existent `get_task_result` tool name.

Neither path is reachable. `format_task_started` is registered in `_TOOL_FORMATTERS` only for `run_browsing_task` and `run_research_task`; the corresponding handlers in `server.py` (`_handle_run_browsing_task`, `_handle_run_research_task`) both stamp `task_type` explicitly into the context dict. Every test in `tests/test_formatters.py::TestFormatTaskStarted` also passes `task_type=` explicitly.

## Refactor

- Remove the response-shape heuristic; require `task_type` via `context["task_type"]`.
- Replace the if/elif/else for poll function selection with a small `_TASK_POLL_FNS` dict lookup, defined alongside `_SCOUT_EDIT_FIELDS` near the bottom of the module.
- Document the contract in the docstring.

## Why this is safe

- All call sites in production (`_handle_run_browsing_task` / `_handle_run_research_task`) pass `task_type` -> verified in this commit.
- All tests pass `task_type=` explicitly -> verified in this commit.
- The poll-fn dict has the same two keys ("Research", "Browsing") that the previous if/elif covered, mapping to the same string values.
- Tests already cover both Research and Browsing paths plus the failed-status branch.

## Test plan

- [ ] `pytest tests/test_formatters.py` (TestFormatTaskStarted covers both task types and the failed branch).

---
_Generated by [Claude Code](https://claude.ai/code/session_013oBx6YSqKjNYeFeUM5MCfV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor isolated to user-facing formatting, but it now assumes `task_type` is always provided and will raise if any caller omits it.
> 
> **Overview**
> `format_task_started()` no longer tries to infer `task_type` from the response payload and instead requires `context["task_type"]`, with the expectation that only `run_browsing_task`/`run_research_task` route here.
> 
> The poll-instruction logic is simplified by replacing conditional branching (including a dead fallback to a non-existent `get_task_result`) with a `_TASK_POLL_FNS` lookup that maps `"Browsing"`/`"Research"` to the correct `get_*_task_result` tool name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8d5926acc7b12990a48adb20e252a97c65d8b97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->