### PR TITLE
refactor(formatters): extract _format_scout_name helper

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -57,6 +57,15 @@ def format_response(tool_name: str, response: dict[str, Any], **context: Any) ->
     return dict_to_markdown(response)
 
 
+def _format_scout_name(scout: dict[str, Any], *, fallback: str = "") -> str:
+    """Return ``display_name`` if set, else ``query[:40]``.
+
+    ``fallback`` is used only when the ``query`` key is missing from ``scout``,
+    matching the historical pattern ``scout.get("display_name") or scout.get("query", fallback)[:40]``.
+    """
+    return scout.get("display_name") or scout.get("query", fallback)[:40]
+
+
 def _format_interval(seconds: int | None) -> str:
     """Convert interval in seconds to human-readable string."""
     if seconds is None:
@@ -278,7 +287,7 @@ def format_list_scouts(response: dict[str, Any], **context: Any) -> str:
 
     # Format each scout
     for i, scout in enumerate(scouts, 1):
-        name = scout.get("display_name") or scout.get("query", "Untitled")[:40]
+        name = _format_scout_name(scout, fallback="Untitled")
         status = scout.get("status", "unknown")
         query = scout.get("query", "")
         scout_id = scout.get("id", "")
@@ -417,7 +426,7 @@ def format_scout_updates(response: dict[str, Any], **context: Any) -> str:
 
 def format_scout_created(response: dict[str, Any], **context: Any) -> str:
     """Format create_scout response as confirmation."""
-    name = response.get("display_name") or response.get("query", "")[:40]
+    name = _format_scout_name(response)
     scout_id = response.get("id", "")
     status = response.get("status", "active")
     query = response.get("query", "")
@@ -446,7 +455,7 @@ def format_scout_edited(response: dict[str, Any], **context: Any) -> str:
 
     # If we don't have old state, just show current state
     if not old:
-        name = new.get("display_name") or new.get("query", "")[:40]
+        name = _format_scout_name(new)
         scout_id = new.get("id", "")
         status = new.get("status", "unknown")
         lines = ["Scout updated successfully.", ""]
@@ -456,7 +465,7 @@ def format_scout_edited(response: dict[str, Any], **context: Any) -> str:
         return "\n".join(lines)
 
     # Show diff
-    name = new.get("display_name") or new.get("query", "")[:40]
+    name = _format_scout_name(new)
     scout_id = new.get("id", "")
 
     lines = ["Scout updated successfully.", ""]


### PR DESCRIPTION
## Summary

Four call sites in `formatters.py` repeated the pattern `dict.get("display_name") or dict.get("query", fallback)[:40]`:

- `format_list_scouts` (line 281, fallback `"Untitled"`)
- `format_scout_created` (line 420, fallback `""`)
- `format_scout_edited` × 2 branches (lines 449, 459, fallback `""`)

Extract `_format_scout_name()` so the rule is named once. The helper inlines the original expression verbatim, so all four call sites preserve byte-for-byte behavior — including the asymmetry where `"Untitled"` is only used when the `query` key is _missing_ (not when it's empty/None).

## Why it's safe

- **No behavior change.** The helper body is `scout.get("display_name") or scout.get("query", fallback)[:40]` — identical to each original line, parameterized only on the `fallback` arg.
- **Verified** by `pytest tests/test_formatters.py` (47 passed), which exercises all four call sites.

## Test plan

- [x] `pytest tests/test_formatters.py` → 47 passed
- [x] No imports added; one new private helper, 4 call sites updated.

https://claude.ai/code/session_019BQqFFtXRNbYYH7mb2V4yz

---
_Generated by [Claude Code](https://claude.ai/code/session_019BQqFFtXRNbYYH7mb2V4yz)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes scout name formatting; behavior should remain the same except for potential regressions if any caller relied on the inline expression quirks.
> 
> **Overview**
> Extracts a new private helper ` _format_scout_name()` in `formatters.py` to centralize the repeated “prefer `display_name` else truncate `query`” logic.
> 
> Updates the scout-related formatters (`format_list_scouts`, `format_scout_created`, and both branches of `format_scout_edited`) to call the helper, preserving the prior fallback behavior via a `fallback` parameter (e.g., `"Untitled"` when `query` is missing).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f065bd9f2dbf6ec2b78084e22bf56157049fe462. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->