### PR TITLE
refactor(schemas): extract WebhookFormat literal alias

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -16,6 +16,8 @@ def _check_webhook_https(v: str | None) -> str | None:
 
 HttpsWebhookUrl = Annotated[str | None, AfterValidator(_check_webhook_https)]
 
+WebhookFormat = Literal["scout", "slack", "zapier"] | None
+
 
 class UsageInput(BaseModel):
     """Input for retrieving API usage statistics."""
@@ -57,7 +59,7 @@ class CreateScoutInput(BaseModel):
             "Must use https://. Confirm the URL with the user before setting."
         ),
     )
-    webhook_format: Literal["scout", "slack", "zapier"] | None = Field(
+    webhook_format: WebhookFormat = Field(
         default=None,
         description="Webhook payload format: 'scout' (default), 'slack', or 'zapier'",
     )
@@ -117,7 +119,7 @@ class EditScoutInput(BaseModel):
         default=None,
         description="Updated HTTPS webhook URL. Must use https://. Confirm the URL with the user before setting.",
     )
-    webhook_format: Literal["scout", "slack", "zapier"] | None = Field(
+    webhook_format: WebhookFormat = Field(
         default=None,
         description="Updated webhook format: 'scout', 'slack', or 'zapier'",
     )
@@ -248,7 +250,7 @@ class BrowsingTaskInput(BaseModel):
         default=None,
         description="HTTPS URL to receive webhook notification when task completes. Must use https://.",
     )
-    webhook_format: Literal["scout", "slack", "zapier"] | None = Field(
+    webhook_format: WebhookFormat = Field(
         default=None,
         description="Webhook payload format: 'scout' (default), 'slack', or 'zapier'",
     )
@@ -302,7 +304,7 @@ class ResearchTaskInput(BaseModel):
         default=None,
         description="HTTPS URL to receive webhook notification when research completes. Must use https://.",
     )
-    webhook_format: Literal["scout", "slack", "zapier"] | None = Field(
+    webhook_format: WebhookFormat = Field(
         default=None,
         description="Webhook payload format: 'scout' (default), 'slack', or 'zapier'",
     )


### PR DESCRIPTION
## Summary

The `Literal["scout", "slack", "zapier"] | None` type for `webhook_format` was repeated verbatim across 4 input models in `schemas.py` (`CreateScoutInput`, `EditScoutInput`, `BrowsingTaskInput`, `ResearchTaskInput`).

This PR hoists the literal into a `WebhookFormat` alias declared next to the existing `HttpsWebhookUrl` alias. The 4 fields now reference the alias instead of inlining the literal.

## Why this is an improvement

- Removes 4-way duplication of the same `Literal` definition.
- Mirrors the precedent already set in this exact file by `HttpsWebhookUrl` (which centralizes webhook URL validation across the same 4 models).
- Adding a new format (e.g. `"discord"`) now requires touching one line instead of four — and the type checker prevents one model from drifting out of sync with the others.

## Why this is safe

- Pure refactor: pydantic `Literal` semantics, defaults, and per-field descriptions are all unchanged.
- 1 file touched (`src/yutori_mcp/schemas.py`).
- Reviewer can verify correctness from the diff alone — every replacement is identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015Vb4NsiyBq6vpYLHpTMMv3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure type/duplication refactor in Pydantic schemas; runtime behavior should be unchanged aside from a shared alias definition.
> 
> **Overview**
> Refactors `schemas.py` to **centralize the `webhook_format` type** by introducing a `WebhookFormat = Literal["scout", "slack", "zapier"] | None` alias next to `HttpsWebhookUrl`.
> 
> All occurrences of the inlined `Literal[...] | None` on `webhook_format` fields are replaced to reference `WebhookFormat` (e.g., in `CreateScoutInput`, `EditScoutInput`, `BrowsingTaskInput`, and `ResearchTaskInput`), without changing defaults or field descriptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7429f57f58259c1a424eb098a9a593603c5a5994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->