### PR TITLE
Extract _get_first() helper for keyed fallback chains in formatters

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -22,6 +22,21 @@ def _has_value(value: Any) -> bool:
     return value is not None and value != ""
 
 
+def _get_first(obj: dict[str, Any], *keys: str, default: Any = None) -> Any:
+    """Return the first truthy value from ``obj`` for ``keys``, else ``default``.
+
+    Equivalent to ``obj.get(k1) or obj.get(k2) or ... or default``, but
+    expresses the "try these keys in order" intent more clearly. Used to
+    handle field-name aliases as the API evolves (e.g. ``navigator_*`` keys
+    superseding deprecated ``n1_*`` keys).
+    """
+    for key in keys:
+        value = obj.get(key)
+        if value:
+            return value
+    return default
+
+
 def _to_markdown_lines(obj: Any, level: int = 0) -> list[str]:
     """Recursively convert obj to markdown lines with indentation."""
     lines: list[str] = []
@@ -185,7 +200,7 @@ def _format_sources(
     Checks for both "sources" and "citations" keys. Each source can be
     a dict with url/title keys or a plain string.
     """
-    sources = response.get("sources") or response.get("citations")
+    sources = _get_first(response, "sources", "citations")
     if not sources:
         return []
 
@@ -239,7 +254,7 @@ def format_usage(response: dict[str, Any], **context: Any) -> str:
         lines.append(f"  Resets at: {rate_limits.get('reset_at', 'N/A')}")
 
     # Navigator rate limits (falls back to deprecated n1_rate_limits on older servers)
-    navigator_limits = response.get("navigator_rate_limits") or response.get("n1_rate_limits") or {}
+    navigator_limits = _get_first(response, "navigator_rate_limits", "n1_rate_limits", default={})
     if navigator_limits:
         lines.append("\nNavigator API Rate Limits:")
         lines.extend(_format_request_count_lines(navigator_limits))
@@ -381,17 +396,11 @@ def format_scout_updates(response: dict[str, Any], **context: Any) -> str:
         lines.append("")
         lines.append(f"--- Update #{i} ---")
 
-        timestamp = _format_datetime(
-            update.get("created_at") or update.get("timestamp")
-        )
+        timestamp = _format_datetime(_get_first(update, "created_at", "timestamp"))
         lines.append(f"Date: {timestamp}")
 
         # Handle different update formats
-        content = (
-            update.get("content")
-            or update.get("formatted_output")
-            or update.get("report")
-        )
+        content = _get_first(update, "content", "formatted_output", "report")
         if content:
             lines.append("")
             lines.append(_EXTERNAL_CONTENT_START)
@@ -596,7 +605,7 @@ def format_task_result(response: dict[str, Any], **context: Any) -> str:
 
     # Handle failed state
     if status == "failed":
-        error = response.get("error") or response.get("message") or "Unknown error"
+        error = _get_first(response, "error", "message", default="Unknown error")
         lines = _task_status_lines(
             "Task failed.",
             task_id=task_id,
@@ -613,7 +622,7 @@ def format_task_result(response: dict[str, Any], **context: Any) -> str:
     )
 
     # Add result content
-    result = response.get("result") or response.get("output") or response.get("content")
+    result = _get_first(response, "result", "output", "content")
     if result:
         lines.append("")
         lines.append("Result:")


### PR DESCRIPTION
## Summary

Six call sites in `src/yutori_mcp/formatters.py` used chained
`dict.get(k1) or dict.get(k2)` patterns to handle API field-name aliases
(e.g. `navigator_rate_limits` → deprecated `n1_rate_limits`,
`sources` → `citations`, `result` → `output` → `content`).

Extracted a `_get_first(obj, *keys, default)` helper that documents the intent
("try these keys in order, return the first truthy value") and centralizes
the pattern, so adding/retiring an alias is a one-line change at the call site.

## Why this is safe

- Helper preserves the exact truthy semantics of `or` chains (`if value:`
  guard mirrors `or`'s short-circuit on falsy values).
- No public API or wire-format change — `formatters.py` produces the same
  strings.
- All 137 tests in `tests/` pass with the refactor in place.
- Touches a single file; the changed call sites are already covered by
  `tests/test_formatters.py`.

## Sites touched

- `_format_sources`: `sources` / `citations`
- `format_usage`: `navigator_rate_limits` / `n1_rate_limits`
- `format_scout_updates`: `created_at` / `timestamp`,
  and `content` / `formatted_output` / `report`
- `format_task_result`: `error` / `message` / `"Unknown error"`,
  and `result` / `output` / `content`

## Test plan

- [x] `python -m pytest -q` (137 passed)

https://claude.ai/code/session_01KMZnrtHMAUwxG1ZsyZRtJS

---
_Generated by [Claude Code](https://claude.ai/code/session_01KMZnrtHMAUwxG1ZsyZRtJS)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to `formatters.py` that should preserve existing output; main risk is subtle behavior changes if callers relied on falsy-but-meaningful values (e.g., `0`, `[]`) being treated as missing in fallback chains.
> 
> **Overview**
> Extracts a `_get_first(obj, *keys, default)` helper to replace repeated `dict.get(... ) or ...` fallback chains when formatting API responses with evolving field-name aliases.
> 
> Updates formatter call sites to use `_get_first` for sources/citations, navigator vs deprecated `n1_*` rate-limit fields, scout update timestamps/content variants, and task result error/result payload variants, keeping the fallback order explicit and centralized.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccc5471d3135aca1b1c9b9215155c2ede82d9e64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->