### PR TITLE
Cover all editable scout fields in format_scout_edited diff

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -649,11 +649,17 @@ def format_task_result(response: dict[str, Any], **context: Any) -> str:
 # Each tuple is (response_field, display_label, value_formatter). The formatter
 # is called on both old and new values to produce the per-side diff string, so
 # adding a new editable field is a single append here — no branching in the loop.
+#
+# This table must stay in sync with the editable fields of
+# ``yutori_mcp.schemas.EditScoutInput`` (excluding ``scout_id``). The drift
+# guard test in ``tests/test_schemas.py`` enforces that invariant.
 _SCOUT_EDIT_FIELDS = (
     ("status", "Status", _format_or_unset),
     ("query", "Query", _format_query_diff),
     ("output_interval", "Interval", _format_interval),
     ("webhook_url", "Webhook", _format_or_unset),
+    ("webhook_format", "Webhook format", _format_or_unset),
+    ("output_fields", "Output fields", _format_or_unset),
     ("skip_email", "Skip email", _format_yes_no),
     ("user_timezone", "Timezone", _format_or_unset),
     ("user_location", "Location", _format_or_unset),

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -3,6 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
+from yutori_mcp.formatters import _SCOUT_EDIT_FIELDS
 from yutori_mcp.schemas import (
     BrowsingTaskInput,
     CreateScoutInput,
@@ -184,6 +185,22 @@ class TestEditScoutInput:
             output_fields=["title", "description"],
         )
         assert data.output_fields == ["title", "description"]
+
+    def test_diff_fields_match_schema(self):
+        """_SCOUT_EDIT_FIELDS must list every editable field on EditScoutInput.
+
+        Drift guard: when a new field is added to EditScoutInput, it must
+        also be added to _SCOUT_EDIT_FIELDS in formatters.py so that edits
+        to it appear in the per-field diff that format_scout_edited returns
+        to the LLM client. Otherwise the change is silently invisible.
+        """
+        diff_fields = {field for field, _label, _fmt in _SCOUT_EDIT_FIELDS}
+        editable_fields = set(EditScoutInput.model_fields) - {"scout_id"}
+        assert diff_fields == editable_fields, (
+            "Mismatch between _SCOUT_EDIT_FIELDS and EditScoutInput. "
+            f"Missing from _SCOUT_EDIT_FIELDS: {editable_fields - diff_fields}. "
+            f"Extra in _SCOUT_EDIT_FIELDS: {diff_fields - editable_fields}."
+        )
 
 
 class TestBrowsingTaskInput:


### PR DESCRIPTION
## Summary

`_SCOUT_EDIT_FIELDS` (the diff-row table in `formatters.py` consumed by
`format_scout_edited`) and `EditScoutInput` (the Pydantic schema in
`schemas.py` for the `edit_scout` tool) had drifted. The schema accepts
`webhook_format` and `output_fields` as editable, but the diff table
omitted them — edits to those fields were silently accepted by the
server and never surfaced in the per-field diff that `format_scout_edited`
returns to the LLM client.

This PR closes the drift and adds a guard test so it cannot recur.

## Changes

- Add `webhook_format` and `output_fields` rows to `_SCOUT_EDIT_FIELDS`
  (both use `_format_or_unset`, matching the existing optional-field
  rendering convention).
- Add a drift-guard test `TestEditScoutInput.test_diff_fields_match_schema`
  asserting that the field names in `_SCOUT_EDIT_FIELDS` exactly match
  the editable fields in `EditScoutInput.model_fields` (excluding
  `scout_id`). Future field additions to `EditScoutInput` will fail
  this test until the diff table is updated.
- Add a comment on `_SCOUT_EDIT_FIELDS` cross-referencing the guard.

## Why this is a structural improvement

The input contract (schema) and output formatter (diff display) were
single-source-of-truth-violating: a developer adding a new editable
field could (and did) update only one of them. The drift-guard test
makes the relationship explicit and machine-checkable, which is exactly
the kind of invariant that should be enforced rather than relied on.

## Why it's safe

- Touches 2 files (one source, one test), well under the file-count cap.
- The `format_scout_edited` diff loop only emits a line when
  `old_val != new_val`, so unedited scouts produce no new output and
  unchanged callers see no behavior change.
- Only edits that actually touch `webhook_format`/`output_fields` gain
  new diff lines — strictly more faithful reporting of the change set.
- All existing tests in `test_formatters.py::TestFormatScoutEdited`
  continue to pass (those exercise `status`, `query`, `output_interval`,
  and the no-changes branch — none of the newly-added rows).
- The new guard test is purely additive and pinned to current behavior.

## Test plan

- [ ] `pytest tests/` passes (existing 60+ tests + 1 new drift guard).
- [ ] CI passes.

https://claude.ai/code/session_01BhcgMyFtQdtq5RbNP2nxXv

---
_Generated by [Claude Code](https://claude.ai/code/session_01BhcgMyFtQdtq5RbNP2nxXv)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only extends `format_scout_edited` to report two previously-accepted fields and adds a schema/formatter drift-guard test; no API behavior or data handling changes.
> 
> **Overview**
> `format_scout_edited` now reports changes to `webhook_format` and `output_fields` in its per-field diff output (bringing the diff table in line with what `EditScoutInput` actually accepts).
> 
> Adds a guard test asserting `_SCOUT_EDIT_FIELDS` exactly matches the editable fields on `EditScoutInput` (excluding `scout_id`), preventing future schema/formatter drift from hiding edits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d1129ead740d36973ae267f7a69cdd76fe7d440. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->