### PR TITLE
refactor(formatters): consolidate '... and N more' into shared helper

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -132,6 +132,21 @@ def _truncate(text: str, max_len: int = 60) -> str:
     return text[: max_len - 3] + "..."
 
 
+def _append_more_indicator(
+    lines: list[str], total: int, shown: int, *, indent: str = "  "
+) -> None:
+    """Append a ``{indent}... and N more`` line when ``total`` exceeds ``shown``.
+
+    Centralizes the "iterate first N items, then summarize the remainder"
+    truncation message used by ``_format_sources``, ``format_usage``'s active
+    scout list, and ``format_scout_updates``'s findings block. No-op when
+    nothing was truncated.
+    """
+    remaining = total - shown
+    if remaining > 0:
+        lines.append(f"{indent}... and {remaining} more")
+
+
 def _format_yes_no(value: Any) -> str:
     """Render a boolean-ish value as ``yes``/``no`` for diff display."""
     return "yes" if value else "no"
@@ -212,8 +227,7 @@ def _format_sources(
             lines.append(f"{indent}- {title}: {url}")
         else:
             lines.append(f"{indent}- {source}")
-    if len(sources) > max_items:
-        lines.append(f"{indent}... and {len(sources) - max_items} more")
+    _append_more_indicator(lines, len(sources), max_items, indent=indent)
     return lines
 
 
@@ -241,8 +255,7 @@ def format_usage(response: dict[str, Any], **context: Any) -> str:
     if active_ids:
         for sid in active_ids[:5]:
             lines.append(f"  - {sid}")
-        if len(active_ids) > 5:
-            lines.append(f"  ... and {len(active_ids) - 5} more")
+        _append_more_indicator(lines, len(active_ids), 5)
 
     # Rate limits
     rate_limits = response.get("rate_limits", {})
@@ -424,8 +437,7 @@ def format_scout_updates(response: dict[str, Any], **context: Any) -> str:
                     lines.append(f"  • {_truncate(title, 80)}")
                 else:
                     lines.append(f"  • {_truncate(str(finding), 80)}")
-            if len(findings) > 5:
-                lines.append(f"  ... and {len(findings) - 5} more")
+            _append_more_indicator(lines, len(findings), 5)
             lines.append(_EXTERNAL_CONTENT_END)
 
         lines.extend(_format_sources(update))


### PR DESCRIPTION
## Summary

The same `if len(items) > N: lines.append(f"... and {len(items)-N} more")` pattern was duplicated across three formatters:

- `_format_sources` — sources/citations list (custom indent)
- `format_usage` — active scout IDs (hardcoded `indent="  "`)
- `format_scout_updates` — findings list (hardcoded `indent="  "`)

Extract `_append_more_indicator(lines, total, shown, *, indent="  ")` next to the existing `_truncate` helper and route all three call sites through it.

## Why this is safe

- Output strings are byte-identical — same f-string, same arithmetic.
- Existing tests (`test_truncation_at_max_items`, `test_many_active_scouts_truncated`) cover both branches and all 47 formatter tests pass locally.
- Single file change; no public API surface affected.

## Test plan

- [x] `python -m pytest tests/test_formatters.py -q` → 47 passed
- [ ] CI

https://claude.ai/code/session_01GCBYcKrMB6Ard9JYe4Sux1

---
_Generated by [Claude Code](https://claude.ai/code/session_01GCBYcKrMB6Ard9JYe4Sux1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to `formatters.py` that consolidates duplicated string-appending logic; behavior should remain the same aside from potential edge-case differences in counts/indent.
> 
> **Overview**
> Introduces a small shared helper, `_append_more_indicator`, to standardize how formatters append the `... and N more` truncation line.
> 
> Updates `_format_sources`, `format_usage` (active scout IDs), and `format_scout_updates` (findings) to call this helper instead of duplicating the conditional append logic, preserving existing indentation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da5a3c4b7709f341a77bb09d20db9ae3cad280d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->