### PR TITLE
refactor(formatters): route remaining or-chain through _get_first

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -433,7 +433,7 @@ def format_scout_updates(response: dict[str, Any], **context: Any) -> str:
             lines.append(_EXTERNAL_CONTENT_START)
             for finding in findings[:5]:  # Limit to 5
                 if isinstance(finding, dict):
-                    title = finding.get("title") or finding.get("summary", "")
+                    title = _get_first(finding, "title", "summary", default="")
                     lines.append(f"  • {_truncate(title, 80)}")
                 else:
                     lines.append(f"  • {_truncate(str(finding), 80)}")


### PR DESCRIPTION
## Summary

- Replace `finding.get("title") or finding.get("summary", "")` with `_get_first(finding, "title", "summary", default="")` in `format_scout_updates`
- This was the one call site missed when `_get_first()` was extracted in PR #85 (commit c7ea5ea)
- All 138 tests pass

No behavior change — `_get_first` implements the same truthy-or-chain semantics.

cc @dhruvbatra

## Test plan

- [x] All 138 existing tests pass
- [ ] Verify `format_scout_updates` output unchanged for findings with title, summary, both, or neither

https://claude.ai/code/session_01HZD8H1TTSLaSp8pYqyApkg

---
_Generated by [Claude Code](https://claude.ai/code/session_01HZD8H1TTSLaSp8pYqyApkg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to text formatting; it only centralizes the existing title/summary fallback logic via `_get_first` without changing control flow or data handling.
> 
> **Overview**
> Updates `format_scout_updates` in `formatters.py` to fetch finding titles via `_get_first(finding, "title", "summary", default="")` instead of an inline `or` chain, aligning the last remaining call site with the shared helper and keeping behavior consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c596e936ccbbe666f825b5541fe5ba3e6076f3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->