### PR TITLE
refactor(schemas): hoist duplicated field descriptions to constants

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -20,6 +20,13 @@ WebhookFormat = Literal["scout", "slack", "zapier"] | None
 
 ScoutStatus = Literal["active", "paused", "done"] | None
 
+# Shared field descriptions. Defined once so the three CreateScout/Browsing/Research
+# (and 3x ScoutId) call sites cannot drift out of sync as the schemas evolve.
+_SCOUT_ID_DESCRIPTION = "The scout's unique identifier (UUID)"
+_WEBHOOK_FORMAT_DESCRIPTION = (
+    "Webhook payload format: 'scout' (default), 'slack', or 'zapier'"
+)
+
 
 class UsageInput(BaseModel):
     """Input for retrieving API usage statistics."""
@@ -63,7 +70,7 @@ class CreateScoutInput(BaseModel):
     )
     webhook_format: WebhookFormat = Field(
         default=None,
-        description="Webhook payload format: 'scout' (default), 'slack', or 'zapier'",
+        description=_WEBHOOK_FORMAT_DESCRIPTION,
     )
     output_fields: list[str] | None = Field(
         default=None,
@@ -100,7 +107,7 @@ class CreateScoutInput(BaseModel):
 class EditScoutInput(BaseModel):
     """Input for editing an existing scout or changing its status."""
 
-    scout_id: str = Field(..., description="The scout's unique identifier (UUID)")
+    scout_id: str = Field(..., description=_SCOUT_ID_DESCRIPTION)
     status: ScoutStatus = Field(
         default=None,
         description=(
@@ -162,7 +169,7 @@ class EditScoutInput(BaseModel):
 class ScoutIdInput(BaseModel):
     """Input for operations on a specific scout."""
 
-    scout_id: str = Field(..., description="The scout's unique identifier (UUID)")
+    scout_id: str = Field(..., description=_SCOUT_ID_DESCRIPTION)
 
 
 class ListScoutsInput(BaseModel):
@@ -183,7 +190,7 @@ class ListScoutsInput(BaseModel):
 class GetUpdatesInput(BaseModel):
     """Input for retrieving scout updates."""
 
-    scout_id: str = Field(..., description="The scout's unique identifier (UUID)")
+    scout_id: str = Field(..., description=_SCOUT_ID_DESCRIPTION)
     cursor: str | None = Field(
         default=None,
         description="Pagination cursor from a previous response",
@@ -254,7 +261,7 @@ class BrowsingTaskInput(BaseModel):
     )
     webhook_format: WebhookFormat = Field(
         default=None,
-        description="Webhook payload format: 'scout' (default), 'slack', or 'zapier'",
+        description=_WEBHOOK_FORMAT_DESCRIPTION,
     )
 
 
@@ -308,5 +315,5 @@ class ResearchTaskInput(BaseModel):
     )
     webhook_format: WebhookFormat = Field(
         default=None,
-        description="Webhook payload format: 'scout' (default), 'slack', or 'zapier'",
+        description=_WEBHOOK_FORMAT_DESCRIPTION,
     )


### PR DESCRIPTION
## Summary

Two field descriptions were inlined verbatim across multiple input schemas:

- `"The scout's unique identifier (UUID)"` — `scout_id` description on `EditScoutInput`, `ScoutIdInput`, and `GetUpdatesInput`.
- `"Webhook payload format: 'scout' (default), 'slack', or 'zapier'"` — `webhook_format` description on `CreateScoutInput`, `BrowsingTaskInput`, and `ResearchTaskInput`.

Hoist both to module-level constants (`_SCOUT_ID_DESCRIPTION` / `_WEBHOOK_FORMAT_DESCRIPTION`) so the descriptions cannot drift when one site is updated without the others.

`EditScoutInput.webhook_format` keeps its distinct `"Updated webhook format..."` phrasing — only the strictly identical descriptions are consolidated.

## Why it's safe

- No behavior change. Pydantic embeds the field's `description` text into the JSON Schema returned by `get_simplified_schema(...)`; replacing the string literal with a constant of the same value yields byte-identical schema output.
- Existing test suite still passes (138 tests).

## Test plan

- [x] `uv run pytest` — all 138 tests pass.
- [x] Smoke-checked `model_json_schema()` for each affected input — descriptions resolve to the constant value.

https://claude.ai/code/session_01E534qqE9ShTNuXaUZQLMMF

---
_Generated by [Claude Code](https://claude.ai/code/session_01E534qqE9ShTNuXaUZQLMMF)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only centralizes repeated `Field(description=...)` strings; schema text should remain identical aside from intentional deduping, with no runtime behavior changes.
> 
> **Overview**
> Consolidates repeated Pydantic `Field` description strings in `schemas.py` by introducing `_SCOUT_ID_DESCRIPTION` and `_WEBHOOK_FORMAT_DESCRIPTION` and reusing them across the relevant `scout_id` and `webhook_format` inputs.
> 
> This is a documentation/schema-maintenance refactor intended to keep generated JSON schema descriptions consistent as the models evolve.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bd56c614734f2c969bdf58b230715c648b58a33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->