### PR TITLE
refactor(schemas): hoist duplicated is_public description to constant

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -26,6 +26,7 @@ _SCOUT_ID_DESCRIPTION = "The scout's unique identifier (UUID)"
 _WEBHOOK_FORMAT_DESCRIPTION = (
     "Webhook payload format: 'scout' (default), 'slack', or 'zapier'"
 )
+_IS_PUBLIC_DESCRIPTION = "Whether scout results are publicly accessible"
 
 
 class UsageInput(BaseModel):
@@ -100,7 +101,7 @@ class CreateScoutInput(BaseModel):
     )
     is_public: bool | None = Field(
         default=None,
-        description="Whether scout results are publicly accessible",
+        description=_IS_PUBLIC_DESCRIPTION,
     )
 
 
@@ -155,7 +156,7 @@ class EditScoutInput(BaseModel):
     )
     is_public: bool | None = Field(
         default=None,
-        description="Whether scout results are publicly accessible",
+        description=_IS_PUBLIC_DESCRIPTION,
     )
 
     @model_validator(mode="after")


### PR DESCRIPTION
## Summary

- Extract `_IS_PUBLIC_DESCRIPTION` constant for the duplicated `"Whether scout results are publicly accessible"` string on `CreateScoutInput.is_public` and `EditScoutInput.is_public`
- Follows the pattern established in PR #90 which hoisted `_SCOUT_ID_DESCRIPTION` and `_WEBHOOK_FORMAT_DESCRIPTION` but missed `is_public` (both sites used the identical string)

## Test plan

- [ ] Existing test suite passes (138 tests)
- [ ] JSON schema output is unchanged (same enum values, same description strings)

No behavior change.

cc @dhruvbatra (authored PR #90 that this continues)

---
_Generated by [Claude Code](https://claude.ai/code/session_017KHSZhwHd54hWXFapoBnfi)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how the Pydantic field description is referenced, not schema shape or validation behavior.
> 
> **Overview**
> Refactors `CreateScoutInput.is_public` and `EditScoutInput.is_public` to reuse a new shared `_IS_PUBLIC_DESCRIPTION` constant instead of repeating the same description string.
> 
> No functional changes are introduced; this is purely a schema-maintenance cleanup to prevent description drift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4c4be0185b2f271271831c54ee25d9be6865f6c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->