### PR TITLE
refactor(server): collapse get_*_task_result handlers into factory

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -272,13 +272,6 @@ def _handle_run_browsing_task(
     }
 
 
-def _handle_get_browsing_task_result(
-    client: MCPClientAdapter, arguments: dict[str, Any]
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    params = TaskIdInput(**arguments)
-    return client.get_browsing_task(params.task_id), {"task_type": "Browsing"}
-
-
 def _handle_run_research_task(
     client: MCPClientAdapter, arguments: dict[str, Any]
 ) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -288,11 +281,23 @@ def _handle_run_research_task(
     }
 
 
-def _handle_get_research_task_result(
-    client: MCPClientAdapter, arguments: dict[str, Any]
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    params = TaskIdInput(**arguments)
-    return client.get_research_task(params.task_id), {"task_type": "Research"}
+def _make_get_task_result_handler(task_type: str, client_method: str) -> ToolHandler:
+    """Build a ``get_*_task_result`` handler that defers only by adapter method + task_type.
+
+    The browsing and research variants previously had two near-identical
+    handlers; both parse :class:`TaskIdInput`, call a single-argument
+    adapter method, and stamp the matching ``task_type`` into the formatter
+    context. Generating both from one factory keeps the registry as the
+    single place that pairs the tool name with its task type.
+    """
+
+    def handler(
+        client: MCPClientAdapter, arguments: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        params = TaskIdInput(**arguments)
+        return getattr(client, client_method)(params.task_id), {"task_type": task_type}
+
+    return handler
 
 
 # Tool-name -> handler registry, consulted by _handle_tool() above. Mirrors
@@ -307,9 +312,9 @@ _TOOL_HANDLERS: dict[str, ToolHandler] = {
     "edit_scout": _handle_edit_scout,
     "delete_scout": _handle_delete_scout,
     "run_browsing_task": _handle_run_browsing_task,
-    "get_browsing_task_result": _handle_get_browsing_task_result,
+    "get_browsing_task_result": _make_get_task_result_handler("Browsing", "get_browsing_task"),
     "run_research_task": _handle_run_research_task,
-    "get_research_task_result": _handle_get_research_task_result,
+    "get_research_task_result": _make_get_task_result_handler("Research", "get_research_task"),
 }
 
 


### PR DESCRIPTION
## Summary

The browsing and research `get_*_task_result` handlers had near-identical 4-line bodies — same `TaskIdInput(**arguments)` parse, same single-argument adapter call, and a `{"task_type": ...}` stamp that just toggled the literal. Replace both with a single `_make_get_task_result_handler(task_type, client_method)` factory and instantiate the two handlers directly in the `_TOOL_HANDLERS` registry, matching the dispatch-table style already used for `_AUTH_SUBCOMMANDS` and `_TOOL_FORMATTERS`.

```python
"get_browsing_task_result": _make_get_task_result_handler("Browsing", "get_browsing_task"),
"get_research_task_result": _make_get_task_result_handler("Research", "get_research_task"),
```

## Why this is safe

- The closure captures the same `task_type` / adapter method per registry entry.
- The factory's emitted handler matches the `ToolHandler` signature exactly.
- `getattr(client, client_method)` resolves to the same `MCPClientAdapter.get_browsing_task` / `get_research_task` methods the old hand-rolled handlers called directly.
- The two `run_*_task` handlers are intentionally left untouched: their `BrowsingTaskInput` / `ResearchTaskInput` schemas and metadata payloads (`browser` is browsing-only) differ enough that a factory wouldn't be a net win.

## Test plan

- [x] `_TOOL_HANDLERS` keys/values structurally validated.
- [ ] Existing test_server / test_formatters coverage is unaffected (no handler-name string assertions broken — `format_task_result` registry already keys by tool name in formatters.py).

https://claude.ai/code/session_019nWZEaJmmzuiCsrU7JK1j8

---
_Generated by [Claude Code](https://claude.ai/code/session_019nWZEaJmmzuiCsrU7JK1j8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how the two task-result polling tools are dispatched, with identical inputs/outputs expected. Main risk is a typo/mismatch in the method name string passed to `getattr`, which would surface at runtime when polling task results.
> 
> **Overview**
> **Refactors task-result polling dispatch** by removing the bespoke `get_browsing_task_result`/`get_research_task_result` handlers and generating them via a shared `_make_get_task_result_handler(task_type, client_method)` closure.
> 
> The `_TOOL_HANDLERS` registry now instantiates these handlers with the appropriate `task_type` and adapter method name, keeping behavior centralized in the dispatch table while preserving the same `TaskIdInput` parsing and formatter context shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 238a4910acda43a21ef55452225d64c477fdad3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->