### PR TITLE
docs: align edit_scout is_public description with code

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -234,7 +234,7 @@ Changes applied:
 | `output_fields` | No | List of field names for structured output |
 | `user_timezone` | No | Timezone for scheduling |
 | `user_location` | No | Location for geo-relevant searches |
-| `is_public` | No | Whether results are public |
+| `is_public` | No | Whether scout results are publicly accessible |
 | `skip_email` | No | Skip email notifications |
 
 ### delete_scout


### PR DESCRIPTION
## Summary
- Fix `TOOLS.md` `edit_scout` parameter table: `is_public` description said "Whether results are public" but should say "Whether scout results are publicly accessible" to match the canonical `_IS_PUBLIC_DESCRIPTION` constant hoisted in commit `8cd188e1`

## Context
Daily documentation drift review for May 5-6, 2026 commits. The `refactor(schemas): hoist duplicated is_public description to constant` commit (PR #91) established a single canonical description string but TOOLS.md was not updated for the `edit_scout` table (the `create_scout` table already matched).

## Test plan
- [x] Verified the canonical constant value in `schemas.py`
- [x] Confirmed `create_scout` table already uses the correct wording
- [x] No code changes, documentation-only fix

https://claude.ai/code/session_01M3QerJ8pY6sGJoSXKHjsdj

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3QerJ8pY6sGJoSXKHjsdj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no runtime behavior is affected.
> 
> **Overview**
> Updates `TOOLS.md` to clarify the `edit_scout` `is_public` parameter description, changing it from “Whether results are public” to “Whether scout results are publicly accessible” to match the canonical wording used elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d3595f9dfcde2fecc41f5ef28615168e2b625d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->