### PR TITLE
refactor(schemas): extract output_fields description helper

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -29,6 +29,30 @@ _WEBHOOK_FORMAT_DESCRIPTION = (
 _IS_PUBLIC_DESCRIPTION = "Whether scout results are publicly accessible"
 
 
+def _output_fields_description(example: list[str], docs_slug: str | None = None) -> str:
+    """Build the shared `output_fields` field description.
+
+    Four input schemas (CreateScout, EditScout, BrowsingTask, ResearchTask)
+    expose the same `output_fields` shape with the same boilerplate prose;
+    only the example field names and the optional docs link differ. This
+    helper keeps the wording in one place so the four call sites cannot
+    drift as we tweak the description over time.
+
+    `docs_slug` is the per-tool fragment after `https://docs.yutori.com/reference/`.
+    Pass ``None`` to omit the trailing "(see example at: ...)" link, matching
+    the existing EditScoutInput description which has no docs link today.
+    """
+    base = (
+        "Optional: Extract structured data as an array of objects with these field names. "
+        f"Example: {example!r}. "
+        "If omitted, returns human-readable text. "
+        "For complex schemas, call the Yutori REST API directly"
+    )
+    if docs_slug is None:
+        return base
+    return base + f" (see example at: https://docs.yutori.com/reference/{docs_slug})."
+
+
 class UsageInput(BaseModel):
     """Input for retrieving API usage statistics."""
 
@@ -75,12 +99,9 @@ class CreateScoutInput(BaseModel):
     )
     output_fields: list[str] | None = Field(
         default=None,
-        description=(
-            "Optional: Extract structured data as an array of objects with these field names. "
-            "Example: ['headline', 'summary', 'url']. "
-            "If omitted, returns human-readable text. "
-            "For complex schemas, call the Yutori REST API directly (see example at: "
-            "https://docs.yutori.com/reference/scouts-create#using-scheduling-webhooks-and-a-structured-output-schema)."
+        description=_output_fields_description(
+            ["headline", "summary", "url"],
+            docs_slug="scouts-create#using-scheduling-webhooks-and-a-structured-output-schema",
         ),
     )
     user_timezone: str | None = Field(
@@ -135,12 +156,7 @@ class EditScoutInput(BaseModel):
     )
     output_fields: list[str] | None = Field(
         default=None,
-        description=(
-            "Optional: Extract structured data as an array of objects with these field names. "
-            "Example: ['headline', 'summary', 'url']. "
-            "If omitted, returns human-readable text. "
-            "For complex schemas, call the Yutori REST API directly"
-        ),
+        description=_output_fields_description(["headline", "summary", "url"]),
     )
     skip_email: bool | None = Field(
         default=None,
@@ -248,12 +264,9 @@ class BrowsingTaskInput(BaseModel):
     )
     output_fields: list[str] | None = Field(
         default=None,
-        description=(
-            "Optional: Extract structured data as an array of objects with these field names. "
-            "Example: ['name', 'title', 'email']. "
-            "If omitted, returns human-readable text. "
-            "For complex schemas, call the Yutori REST API directly (see example at: "
-            "https://docs.yutori.com/reference/browsing-create#using-webhooks-and-a-structured-output-schema)."
+        description=_output_fields_description(
+            ["name", "title", "email"],
+            docs_slug="browsing-create#using-webhooks-and-a-structured-output-schema",
         ),
     )
     webhook_url: HttpsWebhookUrl = Field(
@@ -302,12 +315,9 @@ class ResearchTaskInput(BaseModel):
     )
     output_fields: list[str] | None = Field(
         default=None,
-        description=(
-            "Optional: Extract structured data as an array of objects with these field names. "
-            "Example: ['title', 'summary', 'source_url']. "
-            "If omitted, returns human-readable text. "
-            "For complex schemas, call the Yutori REST API directly (see example at: "
-            "https://docs.yutori.com/reference/research-create#using-webhooks-and-a-structured-output-schema)."
+        description=_output_fields_description(
+            ["title", "summary", "source_url"],
+            docs_slug="research-create#using-webhooks-and-a-structured-output-schema",
         ),
     )
     webhook_url: HttpsWebhookUrl = Field(


### PR DESCRIPTION
## What

The four input schemas in `src/yutori_mcp/schemas.py` (`CreateScoutInput`, `EditScoutInput`, `BrowsingTaskInput`, `ResearchTaskInput`) each defined the same `output_fields` description prose, with only two pieces actually varying per call site:

- the example field names (`['headline', 'summary', 'url']`, `['name', 'title', 'email']`, `['title', 'summary', 'source_url']`)
- the optional docs link (`scouts-create#…`, `browsing-create#…`, `research-create#…`; absent on edit)

This PR extracts a `_output_fields_description(example, docs_slug=None)` helper module-locally and routes all four call sites through it.

## Why this is an improvement

- Removes a 4-way drift surface: today, fixing a wording bug in this description requires editing four nearly-identical 5-line blocks. After this PR, one edit covers all four.
- Surfaces the structural shape of these descriptions (intro / example / fallback / docs link) as code instead of three near-clones of a string literal.
- Adding a fifth schema with `output_fields` becomes a one-line helper call instead of a copy-paste of boilerplate that's likely to drift on the next prose tweak.

## Why it's safe

No behavior change. Verified locally by reconstructing each description from the new helper and comparing to the previous string literal byte-for-byte:

```
OK CreateScoutInput
OK EditScoutInput
OK BrowsingTaskInput
OK ResearchTaskInput
All four output_fields descriptions match expected text byte-for-byte.
```

`EditScoutInput`'s description has historically had no docs link; the helper preserves that exactly via `docs_slug=None` (which short-circuits before appending the `(see example at: …)` suffix and the trailing period). The `f"Example: {example!r}"` formatting produces single-quoted Python list reprs (`['headline', 'summary', 'url']`), matching the existing inline literals.

## Test plan

- [x] `python -m pytest tests/` — all 138 tests pass (no description-text assertions, but the existing schema/serialization coverage exercises every field).
- [x] `ruff check src/yutori_mcp/schemas.py` — passes.
- [x] `ruff format --check src/yutori_mcp/schemas.py` — passes.
- [x] Programmatic comparison of each `model_fields['output_fields'].description` to the previous literal — all four match exactly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1YyrQbRY5BeZxt8qyPeVD)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that only changes how schema field description strings are constructed, with no functional or data-flow impact. Primary risk is unintended wording/format drift in generated descriptions.
> 
> **Overview**
> **Refactors schema docs text** by introducing `_output_fields_description()` and using it for the `output_fields` `Field(description=...)` in `CreateScoutInput`, `EditScoutInput`, `BrowsingTaskInput`, and `ResearchTaskInput`.
> 
> The helper centralizes the shared prose, varies only the example list and optional docs link, and preserves the no-link behavior for `EditScoutInput` via `docs_slug=None`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4ba12c0c04fd4b021c878dcf26b1ea7b04c5994. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->