### PR TITLE
refactor(formatters): route navigator_calls through _get_first helper

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -278,8 +278,7 @@ def format_usage(response: dict[str, Any], **context: Any) -> str:
     activity = response.get("activity", {})
     if activity:
         period = activity.get("period", "24h")
-        # `navigator_calls` is the primary key; `n1_calls` is the deprecated alias.
-        navigator_calls = activity.get("navigator_calls", activity.get("n1_calls", 0))
+        navigator_calls = _get_first(activity, "navigator_calls", "n1_calls", default=0)
         lines.append(f"\nActivity ({period}):")
         lines.append(f"  Scout runs: {activity.get('scout_runs', 0)}")
         lines.append(f"  Browsing tasks: {activity.get('browsing_tasks', 0)}")


### PR DESCRIPTION
## What

`format_usage()` was the lone holdout still using the hand-rolled fallback chain:

```python
navigator_calls = activity.get("navigator_calls", activity.get("n1_calls", 0))
```

Every other `navigator_*` / `n1_*` alias site in this file (lines 218, 270, 412, 416, 436, 620, 637) already routes through the dedicated `_get_first()` helper that was introduced in PR #85 specifically for this pattern. The helper's docstring explicitly cites `navigator_*` / `n1_*` aliasing as its motivating use case.

After:

```python
navigator_calls = _get_first(activity, "navigator_calls", "n1_calls", default=0)
```

## Why this is an improvement

- Removes a documented inconsistency: one site silently broke the convention that the file (lines 25-37) already declares as the standard idiom for navigator/n1 alias fallback.
- The inline-comment justifying the special case ("`navigator_calls` is the primary key…") is now redundant — the helper itself encodes that intent — so it goes away.
- Future-proof: when `n1_calls` is finally retired, all alias call sites can be cleaned up by editing one helper or grepping for `_get_first(..., "navigator_`, not by hunting for inconsistent `dict.get(...)` chains.

## Why it's safe

- 1 file, 2 lines deleted, 1 line added.
- Existing tests (`tests/test_formatters.py:111-124`) cover the fallback path: `test_activity_falls_back_to_deprecated_n1_calls_key` removes `navigator_calls` entirely from the activity dict and asserts the formatted output uses `n1_calls`. Both `_get_first` and the previous `dict.get` chain produce the same output here.
- `test_format_usage` (line 72-73) covers the present-key path.
- All 138 tests pass locally.

There is one subtle semantic nuance worth flagging: `_get_first` falls back when the primary key is *falsy* (e.g. `0`), whereas `dict.get(a, dict.get(b, ...))` only falls back when the key is *absent*. In practice servers emit either `navigator_calls` or `n1_calls`, never both — and the helper's documented behavior is exactly what we want for `navigator_*` / `n1_*` aliasing across API generations.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018pmZogAT3nBVaRE3sEPFjf)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor in output formatting only; behavior should remain equivalent aside from the helper’s existing truthy-based fallback semantics for `navigator_calls`/`n1_calls`.
> 
> **Overview**
> Routes `format_usage()`’s activity `navigator_calls`/deprecated `n1_calls` fallback through the shared `_get_first()` helper, removing the last hand-rolled `dict.get(...)` chain and its inline comment.
> 
> This makes alias handling consistent with the rest of `formatters.py` and centralizes future cleanup of deprecated `n1_*` keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dda6d7ddf34a55fe1e643e84c5748a7d4b99fa0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->