### PR TITLE
test: add coverage for _output_fields_description helper

### DIFF
--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -377,6 +377,52 @@ class TestResearchTaskInput:
         data = ResearchTaskInput(query="Research AI")
         assert data.output_fields is None
 
+class TestOutputFieldsDescription:
+    """Tests for the _output_fields_description helper extracted in PR #94."""
+
+    def test_without_docs_slug(self):
+        """Output omits the trailing docs link when docs_slug is None."""
+        from yutori_mcp.schemas import _output_fields_description
+
+        result = _output_fields_description(["headline", "summary", "url"])
+        assert "Optional: Extract structured data" in result
+        assert "['headline', 'summary', 'url']" in result
+        assert "https://docs.yutori.com" not in result
+        assert not result.endswith(".")
+
+    def test_with_docs_slug(self):
+        """Output includes the full docs URL when docs_slug is provided."""
+        from yutori_mcp.schemas import _output_fields_description
+
+        result = _output_fields_description(
+            ["name", "title", "email"],
+            docs_slug="browsing-create#using-webhooks-and-a-structured-output-schema",
+        )
+        assert "['name', 'title', 'email']" in result
+        assert (
+            "https://docs.yutori.com/reference/browsing-create#using-webhooks-and-a-structured-output-schema"
+            in result
+        )
+        assert result.endswith(".")
+
+    def test_all_schemas_use_helper(self):
+        """All four output_fields descriptions are produced by the helper."""
+        from yutori_mcp.schemas import (
+            BrowsingTaskInput,
+            CreateScoutInput,
+            EditScoutInput,
+            ResearchTaskInput,
+            _output_fields_description,
+        )
+
+        for model_cls in (CreateScoutInput, EditScoutInput, BrowsingTaskInput, ResearchTaskInput):
+            desc = model_cls.model_fields["output_fields"].description
+            assert desc is not None
+            assert "Optional: Extract structured data" in desc, (
+                f"{model_cls.__name__}.output_fields description does not use _output_fields_description"
+            )
+
+
 class TestInvalidBrowserRejected:
     """Verify that invalid browser values are rejected."""
 


### PR DESCRIPTION
## Summary

- Add tests for the `_output_fields_description` helper introduced in PR #94
- Tests verify: output without docs_slug omits the link, output with docs_slug includes full URL, and all four schemas (CreateScout, EditScout, BrowsingTask, ResearchTask) use the helper
- The third test acts as a drift guard to catch new schemas that forget to use the shared helper

## Context

Daily documentation/test drift check across all repos. PR #94 extracted the helper but added no test coverage for it. All 54 tests pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeBDRCsFxqKTyL9KzzYyww)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that add coverage and a drift guard for schema field descriptions without modifying runtime behavior.
> 
> **Overview**
> Adds new unit tests for the shared `yutori_mcp.schemas._output_fields_description` helper, verifying behavior with and without `docs_slug` (including URL formatting and trailing punctuation).
> 
> Also adds a drift-guard test that asserts `output_fields` descriptions on `CreateScoutInput`, `EditScoutInput`, `BrowsingTaskInput`, and `ResearchTaskInput` are generated via the shared helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04e0df6654cccdfec789b978925ef7e5b9d2ef82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->