### PR TITLE
refactor(server): extract _make_run_task_handler factory

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -262,23 +262,32 @@ def _handle_delete_scout(
     return result, {"scout_id": params.scout_id}
 
 
-def _handle_run_browsing_task(
-    client: MCPClientAdapter, arguments: dict[str, Any]
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    params = BrowsingTaskInput(**arguments)
-    return client.run_browsing_task(**_scout_kwargs(params)), {
-        "task_type": "Browsing",
-        "browser": params.browser,
-    }
+def _make_run_task_handler(
+    task_type: str,
+    input_class: type[BaseModel],
+    client_method: str,
+    include_browser: bool = False,
+) -> ToolHandler:
+    """Build a ``run_*_task`` handler that defers only by input schema + adapter method + task_type.
 
+    The browsing and research variants previously had two near-identical
+    handlers; both parse a task-input schema, call ``_scout_kwargs(params)``
+    on the adapter, and stamp the matching ``task_type`` into the formatter
+    context. ``include_browser=True`` additionally surfaces ``params.browser``
+    so ``format_task_started`` can annotate the local/cloud distinction
+    (research has no browser knob, so it omits the field).
+    """
 
-def _handle_run_research_task(
-    client: MCPClientAdapter, arguments: dict[str, Any]
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    params = ResearchTaskInput(**arguments)
-    return client.run_research_task(**_scout_kwargs(params)), {
-        "task_type": "Research",
-    }
+    def handler(
+        client: MCPClientAdapter, arguments: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        params = input_class(**arguments)
+        context: dict[str, Any] = {"task_type": task_type}
+        if include_browser:
+            context["browser"] = params.browser  # type: ignore[attr-defined]
+        return getattr(client, client_method)(**_scout_kwargs(params)), context
+
+    return handler
 
 
 def _make_get_task_result_handler(task_type: str, client_method: str) -> ToolHandler:
@@ -311,9 +320,13 @@ _TOOL_HANDLERS: dict[str, ToolHandler] = {
     "create_scout": _handle_create_scout,
     "edit_scout": _handle_edit_scout,
     "delete_scout": _handle_delete_scout,
-    "run_browsing_task": _handle_run_browsing_task,
+    "run_browsing_task": _make_run_task_handler(
+        "Browsing", BrowsingTaskInput, "run_browsing_task", include_browser=True
+    ),
     "get_browsing_task_result": _make_get_task_result_handler("Browsing", "get_browsing_task"),
-    "run_research_task": _handle_run_research_task,
+    "run_research_task": _make_run_task_handler(
+        "Research", ResearchTaskInput, "run_research_task"
+    ),
     "get_research_task_result": _make_get_task_result_handler("Research", "get_research_task"),
 }
 


### PR DESCRIPTION
## What

Extract `_make_run_task_handler` factory that produces the `run_browsing_task` and `run_research_task` handlers, mirroring the existing `_make_get_task_result_handler` pattern below it.

## Why

The two run-task handlers were near-identical:

- Both parse a task-input schema (`BrowsingTaskInput` / `ResearchTaskInput`)
- Both call `_scout_kwargs(params)` and the matching adapter method
- Both stamp the matching `task_type` into the formatter context
- The only knob that differs is whether to also surface `params.browser` (browsing-only)

`_make_get_task_result_handler` was already extracted with the same shape for the `get_*_task_result` handlers; now both halves of the `run/get` pair are structured the same way, and the `_TOOL_HANDLERS` registry is the single place that pairs each tool with its task type.

## Safety

- No behavior change. All 141 tests pass.
- `format_task_started` reads `browser` via `context.get("browser")`, so omitting the field from the research context is unchanged.
- Single-file diff; downstream formatter routing is untouched.


---
_Generated by [Claude Code](https://claude.ai/code/session_016iJMHEEt9Kz2UMtPMm1QcX)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor confined to server tool dispatch; behavior should be unchanged aside from potential miswiring of adapter method names or `browser` context propagation.
> 
> **Overview**
> **Refactors task-run tool dispatch** by replacing the bespoke `run_browsing_task` and `run_research_task` handlers with a new `_make_run_task_handler` factory.
> 
> The factory centralizes argument parsing, adapter method invocation (via `getattr`), and formatter context creation, with an `include_browser` switch to keep `browser` context only for browsing tasks; `_TOOL_HANDLERS` is updated to register the generated handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f140a35bec78373ca9693761a34008fe9fbe86b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->