### PR TITLE
refactor(server): consolidate scout-kwargs handlers behind one factory

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -202,11 +202,24 @@ def _handle_list_api_usage(
     return result, {}
 
 
-def _handle_list_scouts(
-    client: MCPClientAdapter, arguments: dict[str, Any]
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    params = ListScoutsInput(**arguments)
-    return client.list_scouts(**_scout_kwargs(params)), {}
+def _make_scout_kwargs_handler(
+    input_class: type[BaseModel], client_method: str
+) -> ToolHandler:
+    """Build a handler that parses an input schema and forwards it as scout kwargs.
+
+    Used for tools whose handler body is the one-liner
+    ``client.METHOD(**_scout_kwargs(params))``. Generating these from one
+    factory keeps the registry as the single place that pairs the tool name
+    with its input schema and adapter method.
+    """
+
+    def handler(
+        client: MCPClientAdapter, arguments: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        params = input_class(**arguments)
+        return getattr(client, client_method)(**_scout_kwargs(params)), {}
+
+    return handler
 
 
 def _handle_get_scout_detail(
@@ -214,20 +227,6 @@ def _handle_get_scout_detail(
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     params = ScoutIdInput(**arguments)
     return client.get_scout_detail(params.scout_id), {}
-
-
-def _handle_get_scout_updates(
-    client: MCPClientAdapter, arguments: dict[str, Any]
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    params = GetUpdatesInput(**arguments)
-    return client.get_scout_updates(**_scout_kwargs(params)), {}
-
-
-def _handle_create_scout(
-    client: MCPClientAdapter, arguments: dict[str, Any]
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    params = CreateScoutInput(**arguments)
-    return client.create_scout(**_scout_kwargs(params)), {}
 
 
 def _handle_edit_scout(
@@ -314,10 +313,10 @@ def _make_get_task_result_handler(task_type: str, client_method: str) -> ToolHan
 # of the MCP tool lifecycle is structured the same way as the format side.
 _TOOL_HANDLERS: dict[str, ToolHandler] = {
     "list_api_usage": _handle_list_api_usage,
-    "list_scouts": _handle_list_scouts,
+    "list_scouts": _make_scout_kwargs_handler(ListScoutsInput, "list_scouts"),
     "get_scout_detail": _handle_get_scout_detail,
-    "get_scout_updates": _handle_get_scout_updates,
-    "create_scout": _handle_create_scout,
+    "get_scout_updates": _make_scout_kwargs_handler(GetUpdatesInput, "get_scout_updates"),
+    "create_scout": _make_scout_kwargs_handler(CreateScoutInput, "create_scout"),
     "edit_scout": _handle_edit_scout,
     "delete_scout": _handle_delete_scout,
     "run_browsing_task": _make_run_task_handler(


### PR DESCRIPTION
## Summary

Three per-tool handlers in `server.py` (`_handle_list_scouts`, `_handle_get_scout_updates`, `_handle_create_scout`) had bodies that were identical except for the input class and adapter method:

```python
def _handle_X(client, arguments):
    params = SomeInput(**arguments)
    return client.X(**_scout_kwargs(params)), {}
```

This PR extracts `_make_scout_kwargs_handler(input_class, client_method)` so the `_TOOL_HANDLERS` registry pairs each tool name with its input schema and adapter method in a single line — mirroring the existing `_make_run_task_handler` / `_make_get_task_result_handler` factories.

## Why

- **Single source of truth.** The registry already pairs tool name with task-type + input schema + adapter method via factories for the browsing/research families. The three scout helpers were the last hand-rolled exception that followed the exact same "parse → call with `_scout_kwargs` → return (result, {})" shape.
- **Less to drift.** Adding a new scout-kwargs tool now takes one registry line instead of a fresh 5-line stub function.

## Safety

- **No behavior change.** Registry keys still resolve to handlers that parse arguments via the same input class, call the same adapter method via `_scout_kwargs`, and return `(result, {})`.
- `_handle_get_scout_detail` (calls `client.get_scout_detail(params.scout_id)`, not `**_scout_kwargs(...)`) and `_handle_edit_scout` / `_handle_delete_scout` (have extra logic) are left as standalone handlers — the factory only covers the three that match exactly.
- All 141 existing tests pass.

## Test plan

- [x] `python -m pytest tests/` — 141 passed
- [x] Import smoke check confirms all 11 tool keys still resolve in `_TOOL_HANDLERS`


---
_Generated by [Claude Code](https://claude.ai/code/session_015mFdzX9AX2vLpJ8uWQzHfP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor limited to MCP tool dispatch wiring; behavior should remain the same but a wrong `client_method` string or schema pairing would route scout tools incorrectly at runtime.
> 
> **Overview**
> Refactors `server.py` to remove three duplicated scout tool handlers (`list_scouts`, `get_scout_updates`, `create_scout`) and replace them with a single `_make_scout_kwargs_handler(input_class, client_method)` factory that parses the tool’s input model and forwards `**_scout_kwargs(...)` into the appropriate `MCPClientAdapter` method.
> 
> Updates the `_TOOL_HANDLERS` registry to use this factory for those tools, keeping `_handle_get_scout_detail` and the more complex edit/delete handlers unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c97ae74f0826619c7099a968becc63d58ab7e41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->