### PR TITLE
docs: add AI agent quickstart callout to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ MCP tools and skills for web monitoring, deep research, and browser automation â
 
 You can use it with Claude Code, Codex, Cursor, VS Code, ChatGPT, OpenClaw, and other MCP hosts.
 
+## AI Agent Quickstart
+
+Paste this into Claude Code, Codex, Cursor, Windsurf, or another coding agent:
+
+```text
+Use https://yutori.com/api/llms.txt to set up Yutori for this project: install the CLI, authenticate through Yutori Platform, install the Yutori MCP server and workflow skills, then show me one Scout, Research, and Browsing demo.
+```
+
 ## Features
 
 **Capabilities:**


### PR DESCRIPTION
## Summary

- Adds an **AI Agent Quickstart** section near the top of the README pointing at the canonical agent setup URL: https://yutori.com/api/llms.txt.
- Mirrors the same callout in [`yutori-ai/yutori-sdk-python`](https://github.com/yutori-ai/yutori-sdk-python) so users discovering Yutori through either package see the one-liner.

## Test plan

- [ ] Confirm the README renders correctly on GitHub.
- [ ] Paste the one-liner into a coding agent (Claude Code, Codex, Cursor) and confirm setup runs end-to-end — installs the MCP server, registers skills, and demos a workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; no code paths, configs, or dependencies are modified.
> 
> **Overview**
> Adds an **AI Agent Quickstart** section near the top of `README.md` with a copy-paste prompt that points agents to `https://yutori.com/api/llms.txt` for canonical setup and a quick demo of Scout/Research/Browsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 909b7c8d62ae6573175313566d8e1461f4856cf9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->