### PR TITLE
Remove .claude/CLEANUP_LOG.md — consolidate in yutori monorepo

### DIFF
--- a/.claude/CLEANUP_LOG.md
+++ b/.claude/CLEANUP_LOG.md
@@ -1,5 +1,0 @@
-# Cleanup Log
-
-| Date | Action | Details |
-|------|--------|---------|
-| 2026-04-03 | Changed | Removed unused `DEFAULT_LIMIT = 10` from `src/yutori_mcp/formatters.py` — dead code, never referenced anywhere in the codebase |


### PR DESCRIPTION
## Summary\n\n- Removes `.claude/CLEANUP_LOG.md` from this repo\n- Cleanup tracking is centralized in `yutori-ai/yutori/.claude/CLEANUP.md` as the single source of truth\n- The removed file contained one historical entry (2026-04-03: removed unused `DEFAULT_LIMIT` from formatters.py) which is already captured in git history\n\n## Test plan\n\n- [x] No code changes — only removing a documentation/tracking file\n- [x] Verified the centralized CLEANUP.md in yutori monorepo exists and is maintained

---
_Generated by [Claude Code](https://claude.ai/code/session_012PkG7xcrPiC1D5tTjLLmfT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because it only deletes a documentation/tracking file and does not affect runtime code or build behavior.
> 
> **Overview**
> Removes `.claude/CLEANUP_LOG.md`, eliminating the local cleanup-tracking log so this repo no longer maintains that record here.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eeeaf37161f305ce5ac065bed350b9377a5a4708. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->