### PR TITLE
docs: tighten quickstart prompt and move under Installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,6 @@ MCP tools and skills for web monitoring, deep research, and browser automation â
 
 You can use it with Claude Code, Codex, Cursor, VS Code, ChatGPT, OpenClaw, and other MCP hosts.
 
-## AI Agent Quickstart
-
-Paste this into Claude Code, Codex, Cursor, Windsurf, or another coding agent:
-
-```text
-Use https://yutori.com/api/llms.txt to set up Yutori for this project: install the CLI, authenticate through Yutori Platform, install the Yutori MCP server and workflow skills, then show me one Scout, Research, and Browsing demo.
-```
-
 ## Features
 
 **Capabilities:**
@@ -47,6 +39,14 @@ Python 3.10 or higher is required (`uv` manages this automatically for most inst
 
 For the quickstart below, Node.js is also required (for `npx`).
 </details>
+
+### AI Agent Quickstart
+
+Paste this into Claude Code, Codex, Cursor, Windsurf, or another coding agent:
+
+```text
+Use https://yutori.com/api/llms.txt and set up Yutori for me.
+```
 
 ### Quick install (recommended)
 


### PR DESCRIPTION
## Summary

- Collapse the agent quickstart prompt to one line. The previous version re-stated everything `llms.txt` itself covers (install CLI, auth, MCP, skills, demos), wasting tokens on every paste.
- Move the AI Agent Quickstart section into the Installation section, after the Requirements `<details>`. The prompt is one of several install paths; it belongs alongside them, not as a top-level fragment.

## Before / after

**Prompt — before** (~360 chars):
> Use https://yutori.com/api/llms.txt to set up Yutori for this project: install the CLI, authenticate through Yutori Platform, install the Yutori MCP server and workflow skills, then show me one Scout, Research, and Browsing demo.

**Prompt — after** (~70 chars):
> Use https://yutori.com/api/llms.txt and set up Yutori for me.

Same prompt now byte-identical across SDK README, MCP README, and the Mintlify mdx page.

## Test plan

- [ ] README renders correctly on GitHub.
- [ ] Paste the one-liner into a coding agent (Claude Code, Codex, Cursor) and confirm it fetches `llms.txt` and walks through install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that only affects README wording and section placement.
> 
> **Overview**
> Moves **AI Agent Quickstart** into the `Installation` section (after requirements) instead of being a top-level block.
> 
> Tightens the pasted agent prompt to a single line (`Use https://yutori.com/api/llms.txt and set up Yutori for me.`), removing the longer, step-by-step instruction text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 610079b5c1e3986cae96f7a6c736b9b4ab40aa3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->