### PR TITLE
docs: relabel quickstart sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Python 3.10 or higher is required (`uv` manages this automatically for most inst
 For the quickstart below, Node.js is also required (for `npx`).
 </details>
 
-### AI Agent Quickstart
+### AI Agent Quickstart (recommended)
 
 Paste this into Claude Code, Codex, Cursor, Windsurf, or another coding agent:
 
@@ -48,7 +48,7 @@ Paste this into Claude Code, Codex, Cursor, Windsurf, or another coding agent:
 Use https://yutori.com/api/llms.txt and set up Yutori for me.
 ```
 
-### Quick install (recommended)
+### Manual quick install
 
 ![MCP server installation](assets/mcp-server-install.gif)
 


### PR DESCRIPTION
## Summary

Promote the AI Agent Quickstart to the recommended path. The one-line prompt → `llms.txt` flow is the lowest-friction install for any user already inside a coding agent; the manual `uvx login` / `npx add-mcp` / `npx skills add` sequence is the fallback when an agent isn't on hand.

- `### AI Agent Quickstart` → `### AI Agent Quickstart (recommended)`
- `### Quick install (recommended)` → `### Manual quick install`

## Test plan

- [ ] README renders correctly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that renames headings to steer users toward the agent-based quickstart; no runtime code paths are affected.
> 
> **Overview**
> Updates `README.md` section headings to make **`AI Agent Quickstart` the recommended path** and reframe the prior recommended quick install as **`Manual quick install`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e713308cb266100bab40384f6af369acf5b06e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->