### PR TITLE
docs: make install section headers consistent in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Python 3.10 or higher is required (`uv` manages this automatically for most inst
 For the quickstart below, Node.js is also required (for `npx`).
 </details>
 
-### AI Agent Quickstart (recommended)
+### AI agent install (recommended)
 
 Paste this into Claude Code, Codex, Cursor, Windsurf, or another coding agent:
 
@@ -102,7 +102,7 @@ Use https://yutori.com/api/llms.txt and set up Yutori for me.
 4. Restart the tool you are using.
 
 
-### Manual per-client setup
+### Manual per-client install
 
 <details>
 <summary>Claude Code</summary>


### PR DESCRIPTION
## Summary
- Renames the three Installation subsection headers to a consistent "[scope] install" pattern:
  - `AI Agent Quickstart (recommended)` → `AI agent install (recommended)`
  - `Manual quick install` (unchanged)
  - `Manual per-client setup` → `Manual per-client install`

## Test plan
- [x] Render README on GitHub and confirm the three Installation subsection headers read consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that renames README installation subsection headings; no runtime behavior is affected.
> 
> **Overview**
> Updates the README Installation section to use consistent *“[scope] install”* wording by renaming `AI Agent Quickstart (recommended)` to `AI agent install (recommended)` and `Manual per-client setup` to `Manual per-client install`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a23d822b768ccda36c9159925da865d3ad67623. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->