### PR TITLE
Async client, isError contract, strict inputs, formatter robustness, CI

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -5,9 +5,16 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+
   publish:
     runs-on: ubuntu-latest
+    needs: test
     steps:
       - uses: actions/checkout@v4
 
@@ -21,6 +28,9 @@ jobs:
       - name: Build package
         run: python -m build
 
+      # TODO: switch to PyPI Trusted Publishing (OIDC via
+      # pypa/gh-action-pypi-publish) once configured on PyPI, so the
+      # long-lived PYPI_API_TOKEN secret can be removed.
       - name: Publish to PyPI
         run: twine upload dist/*
         env:

--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v6
 
       - name: Run tests
         run: uv run --python ${{ matrix.python-version }} --extra dev pytest -q

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  # Reused as the gate in publish_to_pypi.yml so releases run the same matrix.
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+
+      - name: Run tests
+        run: uv run --python ${{ matrix.python-version }} --extra dev pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.2.9"
+version = "0.3.0"
 description = "MCP server for Yutori - web monitoring, deep research, and browser automation"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,11 +21,14 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
     "mcp>=1.0.0",
     "pydantic>=2.0.0",
-    "yutori>=0.4.0",
+    # 0.8.0 adds scouts.update(is_public=...) on both sync and async clients
+    "yutori>=0.8.0",
 ]
 
 [project.optional-dependencies]
@@ -48,3 +51,4 @@ packages = ["src/yutori_mcp"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 pythonpath = ["src"]
+asyncio_mode = "auto"

--- a/src/yutori_mcp/__init__.py
+++ b/src/yutori_mcp/__init__.py
@@ -1,5 +1,10 @@
 """Yutori MCP Server - Web monitoring and browsing automation."""
 
-from importlib.metadata import version
+from importlib.metadata import PackageNotFoundError, version
 
-__version__ = version("yutori-mcp")
+try:
+    __version__ = version("yutori-mcp")
+except PackageNotFoundError:
+    # Running from a source checkout without the package installed
+    # (e.g. `pytest` via pythonpath, or PYTHONPATH=src).
+    __version__ = "0.0.0+unknown"

--- a/src/yutori_mcp/adapter.py
+++ b/src/yutori_mcp/adapter.py
@@ -1,17 +1,21 @@
-"""Thin adapter mapping MCP tool calls to the Yutori SDK client.
+"""Thin adapter mapping MCP tool calls to the Yutori SDK async client.
 
-Wraps YutoriClient namespace methods, preserving the same interface that
+Wraps AsyncYutoriClient namespace methods, preserving the same interface that
 server.py's _handle_tool() expects. Catches SDK APIError and re-raises
-as YutoriAPIError for consistent MCP error formatting.
+as YutoriAPIError for consistent MCP error formatting. The async client is
+used so slow Yutori API calls never block the MCP server's event loop.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
+from yutori import AsyncYutoriClient
 from yutori.auth.credentials import resolve_api_key
-from yutori.client import YutoriClient
-from yutori.exceptions import APIError, AuthenticationError
+from yutori.exceptions import APIConnectionError, APIError, AuthenticationError
+
+logger = logging.getLogger(__name__)
 
 ERROR_NO_API_KEY = "API key required. Run 'uvx yutori-mcp login' or set YUTORI_API_KEY."
 
@@ -37,83 +41,94 @@ class MCPClientAdapter:
         api_key = resolve_api_key()
         if not api_key:
             raise ValueError(ERROR_NO_API_KEY)
-        self._client = YutoriClient(api_key=api_key)
+        self._client = AsyncYutoriClient(api_key=api_key)
 
-    def close(self) -> None:
-        self._client.close()
+    async def close(self) -> None:
+        await self._client.close()
 
-    def __enter__(self) -> MCPClientAdapter:
+    async def __aenter__(self) -> MCPClientAdapter:
         return self
 
-    def __exit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
-        self.close()
+    async def __aexit__(self, exc_type: Any, exc: Any, traceback: Any) -> None:
+        try:
+            await self.close()
+        except Exception:
+            # A close failure must not replace an in-flight handler error —
+            # that would mask the real failure in the tool result.
+            if exc_type is None:
+                raise
+            logger.warning("Failed to close Yutori client", exc_info=True)
 
     # -------------------------------------------------------------------------
     # Usage
     # -------------------------------------------------------------------------
 
-    def get_usage(self, **kwargs: Any) -> dict[str, Any]:
-        return self._call(self._client.get_usage, **kwargs)
+    async def get_usage(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._call(self._client.get_usage, **kwargs)
 
     # -------------------------------------------------------------------------
     # Scout operations
     # -------------------------------------------------------------------------
 
-    def list_scouts(self, **kwargs: Any) -> dict[str, Any]:
-        return self._call(self._client.scouts.list, **kwargs)
+    async def list_scouts(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._call(self._client.scouts.list, **kwargs)
 
-    def get_scout_detail(self, scout_id: str) -> dict[str, Any]:
-        return self._call(self._client.scouts.get, scout_id)
+    async def get_scout_detail(self, scout_id: str) -> dict[str, Any]:
+        return await self._call(self._client.scouts.get, scout_id)
 
-    def create_scout(self, query: str, **kwargs: Any) -> dict[str, Any]:
-        return self._call(self._client.scouts.create, query, **kwargs)
+    async def create_scout(self, query: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._call(self._client.scouts.create, query, **kwargs)
 
-    def edit_scout(self, scout_id: str, **kwargs: Any) -> dict[str, Any]:
-        return self._call(self._client.scouts.update, scout_id, **kwargs)
+    async def edit_scout(self, scout_id: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._call(self._client.scouts.update, scout_id, **kwargs)
 
-    def delete_scout(self, scout_id: str) -> dict[str, Any]:
-        return self._call(self._client.scouts.delete, scout_id)
+    async def delete_scout(self, scout_id: str) -> dict[str, Any]:
+        return await self._call(self._client.scouts.delete, scout_id)
 
-    def get_scout_updates(self, scout_id: str, **kwargs: Any) -> dict[str, Any]:
-        return self._call(self._client.scouts.get_updates, scout_id, **kwargs)
+    async def get_scout_updates(self, scout_id: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._call(self._client.scouts.get_updates, scout_id, **kwargs)
 
     # -------------------------------------------------------------------------
     # Browsing operations
     # -------------------------------------------------------------------------
 
-    def run_browsing_task(self, task: str, start_url: str, **kwargs: Any) -> dict[str, Any]:
-        return self._call(self._client.browsing.create, task, start_url, **kwargs)
+    async def run_browsing_task(self, task: str, start_url: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._call(self._client.browsing.create, task, start_url, **kwargs)
 
-    def get_browsing_task(self, task_id: str) -> dict[str, Any]:
-        return self._call(self._client.browsing.get, task_id)
+    async def get_browsing_task(self, task_id: str) -> dict[str, Any]:
+        return await self._call(self._client.browsing.get, task_id)
 
     # -------------------------------------------------------------------------
     # Research operations
     # -------------------------------------------------------------------------
 
-    def run_research_task(self, query: str, **kwargs: Any) -> dict[str, Any]:
-        return self._call(self._client.research.create, query, **kwargs)
+    async def run_research_task(self, query: str, **kwargs: Any) -> dict[str, Any]:
+        return await self._call(self._client.research.create, query, **kwargs)
 
-    def get_research_task(self, task_id: str) -> dict[str, Any]:
-        return self._call(self._client.research.get, task_id)
+    async def get_research_task(self, task_id: str) -> dict[str, Any]:
+        return await self._call(self._client.research.get, task_id)
 
     # -------------------------------------------------------------------------
     # Internal
     # -------------------------------------------------------------------------
 
     @staticmethod
-    def _call(fn: Any, *args: Any, **kwargs: Any) -> dict[str, Any]:
-        """Call an SDK method, converting SDK APIError to MCP YutoriAPIError.
+    async def _call(fn: Any, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        """Await an SDK method, converting SDK APIError to MCP YutoriAPIError.
 
         Filters None-valued kwargs before forwarding so callers can pass
         optional fields unconditionally without overriding SDK defaults.
         """
         try:
-            return fn(*args, **_strip_none(kwargs))
+            return await fn(*args, **_strip_none(kwargs))
         except AuthenticationError as e:
             raise YutoriAPIError(message=str(e), status_code=401) from e
         except APIError as e:
             raise YutoriAPIError(message=e.message, status_code=e.status_code) from e
+        except APIConnectionError as e:
+            # Transport failures (timeouts, DNS/connect errors) carry no HTTP
+            # status; surface as 503 so the MCP error format stays uniform.
+            raise YutoriAPIError(message=str(e), status_code=503) from e
 
 
 def _strip_none(d: dict[str, Any]) -> dict[str, Any]:

--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -79,12 +79,11 @@ def format_response(tool_name: str, response: dict[str, Any], **context: Any) ->
 
 
 def _format_scout_name(scout: dict[str, Any], *, fallback: str = "") -> str:
-    """Return ``display_name`` if set, else ``query[:40]``.
+    """Return ``display_name`` if set, else ``query[:40]``, else ``fallback[:40]``.
 
-    ``fallback`` is used only when the ``query`` key is missing from ``scout``,
-    matching the historical pattern ``scout.get("display_name") or scout.get("query", fallback)[:40]``.
+    Falls back to ``fallback`` whenever ``query`` is missing, null, or empty.
     """
-    return scout.get("display_name") or scout.get("query", fallback)[:40]
+    return scout.get("display_name") or (scout.get("query") or fallback)[:40]
 
 
 def _format_interval(seconds: int | None) -> str:
@@ -102,23 +101,33 @@ def _format_interval(seconds: int | None) -> str:
     return f"every {days} days"
 
 
-def _format_date(iso_string: str | None) -> str:
-    """Format ISO date string to readable format."""
-    if not iso_string:
+def _timestamp_to_utc(timestamp: int | float) -> datetime:
+    """Convert a Unix timestamp in seconds or milliseconds to a UTC datetime.
+
+    Values >= 1e12 are treated as milliseconds (1e12 seconds is the year
+    33658, while 1e12 ms is September 2001 — well before any Yutori data).
+    """
+    if timestamp >= 1_000_000_000_000:
+        timestamp /= 1000
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc)
+
+
+def _format_date(value: str | int | float | None) -> str:
+    """Format an ISO date string or Unix timestamp (s or ms) as YYYY-MM-DD."""
+    if not value:
         return "not set"
+    if isinstance(value, (int, float)):
+        return _timestamp_to_utc(value).strftime("%Y-%m-%d")
     # Extract date portion (YYYY-MM-DD)
-    return iso_string[:10] if len(iso_string) >= 10 else iso_string
+    return value[:10] if len(value) >= 10 else value
 
 
-def _format_datetime(timestamp: str | int | None) -> str:
-    """Format timestamp to readable format. Accepts ISO string or Unix timestamp (ms)."""
+def _format_datetime(timestamp: str | int | float | None) -> str:
+    """Format an ISO datetime string or Unix timestamp (s or ms) as readable UTC."""
     if not timestamp:
         return "not set"
-    # Handle Unix timestamp in milliseconds (integer)
-    if isinstance(timestamp, int):
-        # Convert milliseconds to seconds
-        dt = datetime.fromtimestamp(timestamp / 1000, tz=timezone.utc)
-        return dt.strftime("%Y-%m-%d %H:%M UTC")
+    if isinstance(timestamp, (int, float)):
+        return _timestamp_to_utc(timestamp).strftime("%Y-%m-%d %H:%M UTC")
     # Handle ISO datetime string
     if len(timestamp) >= 16:
         return f"{timestamp[:10]} {timestamp[11:16]} UTC"
@@ -162,6 +171,26 @@ def _format_or_unset(value: Any) -> Any:
     return value or "(not set)"
 
 
+def _format_output_fields_diff(value: Any) -> Any:
+    """Render an ``output_schema`` dict as its field names for diff display.
+
+    Lists the property names for array-of-objects schemas (the shape
+    ``output_fields_to_output_schema`` produces) and top-level object
+    schemas. The API accepts any JSON Schema dict, so anything else — set
+    via the REST API directly — is summarized as ``(custom schema)`` rather
+    than crashing or rendering as unset.
+    """
+    if isinstance(value, dict):
+        items = value.get("items")
+        container = items if isinstance(items, dict) else value
+        properties = container.get("properties")
+        if isinstance(properties, dict) and properties:
+            value = ", ".join(properties)
+        else:
+            value = "(custom schema)"
+    return _format_or_unset(value)
+
+
 def _scout_platform_url(scout_id: str) -> str:
     """Build the platform URL for viewing a scout."""
     return f"https://platform.yutori.com/scouting/tasks/{scout_id}"
@@ -180,11 +209,10 @@ def _scout_identity_lines(
     """Build the shared `{name_label}: ...` / `ID: ...` / `URL: ...` (+ `Status: ...`) header block.
 
     The ``Status:`` line is appended whenever the caller passes a ``status``
-    argument, including when the value is ``None`` — this preserves the
-    pre-refactor behavior where ``response.get("status", "unknown")`` returning
-    a literal ``None`` (explicit null) would still render as ``Status: None``.
-    Callers that want to omit the line entirely (e.g. the diff path of
-    ``format_scout_edited``) simply don't pass ``status``.
+    argument, including when the value is ``None`` — an explicit null in the
+    payload still renders as ``Status: None``. Callers that want to omit the
+    line entirely (e.g. the diff path of ``format_scout_edited``) simply
+    don't pass ``status``.
 
     Used by the top-level scout detail / created / edited formatters. The list-scouts
     formatter uses its own indented variant and doesn't call this helper.
@@ -213,13 +241,15 @@ def _format_sources(
     """Format sources/citations from a response dict.
 
     Checks for both "sources" and "citations" keys. Each source can be
-    a dict with url/title keys or a plain string.
+    a dict with url/title keys or a plain string. Source titles and URLs
+    come from the open web, so the entries are wrapped in the same
+    external-content markers as result bodies.
     """
     sources = _get_first(response, "sources", "citations")
     if not sources:
         return []
 
-    lines = ["", "Sources:"]
+    lines = ["", "Sources:", _EXTERNAL_CONTENT_START]
     for source in sources[:max_items]:
         if isinstance(source, dict):
             url = source.get("url", "")
@@ -228,6 +258,7 @@ def _format_sources(
         else:
             lines.append(f"{indent}- {source}")
     _append_more_indicator(lines, len(sources), max_items, indent=indent)
+    lines.append(_EXTERNAL_CONTENT_END)
     return lines
 
 
@@ -325,7 +356,7 @@ def format_list_scouts(response: dict[str, Any], **context: Any) -> str:
     for i, scout in enumerate(scouts, 1):
         name = _format_scout_name(scout, fallback="Untitled")
         status = scout.get("status", "unknown")
-        query = scout.get("query", "")
+        query = scout.get("query") or ""
         scout_id = scout.get("id", "")
         interval = _format_interval(scout.get("output_interval"))
         next_run = _format_date(scout.get("next_output_timestamp"))
@@ -352,7 +383,7 @@ def format_scout_detail(response: dict[str, Any], **context: Any) -> str:
     name = response.get("display_name") or "Untitled"
     scout_id = response.get("id", "")
     status = response.get("status", "unknown")
-    query = response.get("query", "")
+    query = response.get("query") or ""
     created = _format_date(response.get("created_at"))
 
     lines = _scout_identity_lines(
@@ -458,7 +489,7 @@ def format_scout_created(response: dict[str, Any], **context: Any) -> str:
     name = _format_scout_name(response)
     scout_id = response.get("id", "")
     status = response.get("status", "active")
-    query = response.get("query", "")
+    query = response.get("query") or ""
     interval = _format_interval(response.get("output_interval"))
     next_run = _format_datetime(response.get("next_output_timestamp"))
 
@@ -480,25 +511,39 @@ def format_scout_created(response: dict[str, Any], **context: Any) -> str:
 def format_scout_edited(response: dict[str, Any], **context: Any) -> str:
     """Format edit_scout response showing changes."""
     old = response.get("old", {})
-    new = response.get("new", response)  # Fallback to response if no old/new structure
+    new = response.get("new") or {}
+    if not old:
+        # Legacy shape: the scout fields sit at the top level of the response.
+        new = new or response
+
+    subject = new or old
+    lines = ["Scout updated successfully.", ""]
+    identity = {"name": _format_scout_name(subject), "scout_id": subject.get("id", "")}
 
     # If we don't have old state, just show current state
     if not old:
-        name = _format_scout_name(new)
-        scout_id = new.get("id", "")
-        status = new.get("status", "unknown")
-        lines = ["Scout updated successfully.", ""]
-        lines.extend(_scout_identity_lines(name=name, scout_id=scout_id, status=status))
+        lines.extend(
+            _scout_identity_lines(**identity, status=new.get("status", "unknown"))
+        )
         _append_rejection_reason(lines, new.get("rejection_reason"))
         lines.extend(["", "Use get_scout_detail(scout_id) for full details."])
         return "\n".join(lines)
 
-    # Show diff
-    name = _format_scout_name(new)
-    scout_id = new.get("id", "")
+    # Edit succeeded but the post-edit read-back failed: report success
+    # without a diff rather than implying the edit itself failed.
+    if not new:
+        lines.extend(_scout_identity_lines(**identity))
+        lines.extend(
+            [
+                "",
+                "Could not fetch the updated scout state to show what changed.",
+                "Use get_scout_detail(scout_id) to verify the changes.",
+            ]
+        )
+        return "\n".join(lines)
 
-    lines = ["Scout updated successfully.", ""]
-    lines.extend(_scout_identity_lines(name=name, scout_id=scout_id))
+    # Show diff
+    lines.extend(_scout_identity_lines(**identity))
     lines.extend(["", "Changes applied:"])
 
     changes_found = False
@@ -629,13 +674,32 @@ def format_task_result(response: dict[str, Any], **context: Any) -> str:
         return "\n".join(lines)
 
     # Handle completed state
+    if status in ("succeeded", "completed"):
+        lines = _task_status_lines(
+            "Task completed.",
+            task_id=task_id,
+            footer=f"Status: {status}",
+        )
+        _append_result_content(lines, response)
+        return "\n".join(lines)
+
+    # Unrecognized status (e.g. cancelled, expired, or a new API status):
+    # don't claim completion, but surface whatever the response carried.
     lines = _task_status_lines(
-        "Task completed.",
+        f"Task ended with unrecognized status '{status}' (not completed).",
         task_id=task_id,
         footer=f"Status: {status}",
     )
+    _append_rejection_reason(lines, response.get("rejection_reason"))
+    error = _get_first(response, "error", "message")
+    if error:
+        lines.append(f"Error: {error}")
+    _append_result_content(lines, response)
+    return "\n".join(lines)
 
-    # Add result content
+
+def _append_result_content(lines: list[str], response: dict[str, Any]) -> None:
+    """Append the task's result body (marker-wrapped) and sources, if any."""
     result = _get_first(response, "result", "output", "content")
     if result:
         lines.append("")
@@ -656,8 +720,6 @@ def format_task_result(response: dict[str, Any], **context: Any) -> str:
 
     lines.extend(_format_sources(response, indent=""))
 
-    return "\n".join(lines)
-
 
 # Scout-edit field comparison list, used by format_scout_edited().
 # Each tuple is (response_field, display_label, value_formatter). The formatter
@@ -673,7 +735,12 @@ _SCOUT_EDIT_FIELDS = (
     ("output_interval", "Interval", _format_interval),
     ("webhook_url", "Webhook", _format_or_unset),
     ("webhook_format", "Webhook format", _format_or_unset),
-    ("output_fields", "Output fields", _format_or_unset),
+    # output_schema is the response-side name of the output_fields input: the
+    # MCP exposes `output_fields` (a list of names) as a simplified input, and
+    # the API stores and returns it as `output_schema`. Requires API versions
+    # that surface top-level `output_schema` on scout detail responses; older
+    # servers omit the key and the diff line is skipped.
+    ("output_schema", "Output fields", _format_output_fields_diff),
     ("skip_email", "Skip email", _format_yes_no),
     ("user_timezone", "Timezone", _format_or_unset),
     ("user_location", "Location", _format_or_unset),

--- a/src/yutori_mcp/schema_utils.py
+++ b/src/yutori_mcp/schema_utils.py
@@ -67,6 +67,8 @@ def output_fields_to_output_schema(
     """
     if output_fields is None:
         return None
+    if not output_fields:
+        raise ValueError("output_fields must contain at least one field name")
 
     properties = {field: {"type": "string"} for field in output_fields}
 

--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -3,25 +3,43 @@
 from __future__ import annotations
 
 from typing import Annotated, Literal
+from urllib.parse import urlparse
 
-from pydantic import AfterValidator, BaseModel, Field, model_validator
+from pydantic import AfterValidator, BaseModel, ConfigDict, Field, model_validator
 
 
 def _check_webhook_https(v: str | None) -> str | None:
-    """Validate that webhook_url uses HTTPS."""
-    if v is not None and not v.startswith("https://"):
-        raise ValueError("webhook_url must use HTTPS (https://)")
+    """Validate that webhook_url is an HTTPS URL with a host."""
+    if v is None:
+        return v
+    parsed = urlparse(v)
+    if parsed.scheme != "https" or not parsed.netloc:
+        raise ValueError("webhook_url must use HTTPS (https://) and include a host")
     return v
 
 
 HttpsWebhookUrl = Annotated[str | None, AfterValidator(_check_webhook_https)]
 
+
+class ToolInput(BaseModel):
+    """Base class for all tool input schemas.
+
+    Forbids unknown fields so a misspelled or unsupported argument fails with
+    a clear validation error instead of being silently dropped. This also
+    emits ``additionalProperties: false`` in the generated JSON Schema, so
+    the MCP server framework's input validation (and any client that
+    pre-validates) rejects bad arguments before they reach the handler.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+
 WebhookFormat = Literal["scout", "slack", "zapier"] | None
 
 ScoutStatus = Literal["active", "paused", "done"] | None
 
-# Shared field descriptions. Defined once so the three CreateScout/Browsing/Research
-# (and 3x ScoutId) call sites cannot drift out of sync as the schemas evolve.
+# Shared field descriptions, defined once so the call sites cannot drift out
+# of sync as the schemas evolve.
 _SCOUT_ID_DESCRIPTION = "The scout's unique identifier (UUID)"
 _WEBHOOK_FORMAT_DESCRIPTION = (
     "Webhook payload format: 'scout' (default), 'slack', or 'zapier'"
@@ -53,7 +71,7 @@ def _output_fields_description(example: list[str], docs_slug: str | None = None)
     return base + f" (see example at: https://docs.yutori.com/reference/{docs_slug})."
 
 
-class UsageInput(BaseModel):
+class UsageInput(ToolInput):
     """Input for retrieving API usage statistics."""
 
     period: Literal["24h", "7d", "30d", "90d"] | None = Field(
@@ -62,7 +80,7 @@ class UsageInput(BaseModel):
     )
 
 
-class CreateScoutInput(BaseModel):
+class CreateScoutInput(ToolInput):
     """Input for creating a new monitoring scout.
 
     Scouts enable continuous monitoring of the web at a configurable schedule
@@ -99,6 +117,7 @@ class CreateScoutInput(BaseModel):
     )
     output_fields: list[str] | None = Field(
         default=None,
+        min_length=1,
         description=_output_fields_description(
             ["headline", "summary", "url"],
             docs_slug="scouts-create#using-scheduling-webhooks-and-a-structured-output-schema",
@@ -126,7 +145,7 @@ class CreateScoutInput(BaseModel):
     )
 
 
-class EditScoutInput(BaseModel):
+class EditScoutInput(ToolInput):
     """Input for editing an existing scout or changing its status."""
 
     scout_id: str = Field(..., description=_SCOUT_ID_DESCRIPTION)
@@ -156,6 +175,7 @@ class EditScoutInput(BaseModel):
     )
     output_fields: list[str] | None = Field(
         default=None,
+        min_length=1,
         description=_output_fields_description(["headline", "summary", "url"]),
     )
     skip_email: bool | None = Field(
@@ -183,13 +203,13 @@ class EditScoutInput(BaseModel):
         return self
 
 
-class ScoutIdInput(BaseModel):
+class ScoutIdInput(ToolInput):
     """Input for operations on a specific scout."""
 
     scout_id: str = Field(..., description=_SCOUT_ID_DESCRIPTION)
 
 
-class ListScoutsInput(BaseModel):
+class ListScoutsInput(ToolInput):
     """Input for listing scouts with optional limit and filtering."""
 
     limit: int | None = Field(
@@ -204,7 +224,7 @@ class ListScoutsInput(BaseModel):
     )
 
 
-class GetUpdatesInput(BaseModel):
+class GetUpdatesInput(ToolInput):
     """Input for retrieving scout updates."""
 
     scout_id: str = Field(..., description=_SCOUT_ID_DESCRIPTION)
@@ -220,7 +240,7 @@ class GetUpdatesInput(BaseModel):
     )
 
 
-class BrowsingTaskInput(BaseModel):
+class BrowsingTaskInput(ToolInput):
     """Input for running a one-time browsing task.
 
     The Browsing API enables automation of browser-based workflows.
@@ -264,6 +284,7 @@ class BrowsingTaskInput(BaseModel):
     )
     output_fields: list[str] | None = Field(
         default=None,
+        min_length=1,
         description=_output_fields_description(
             ["name", "title", "email"],
             docs_slug="browsing-create#using-webhooks-and-a-structured-output-schema",
@@ -279,13 +300,13 @@ class BrowsingTaskInput(BaseModel):
     )
 
 
-class TaskIdInput(BaseModel):
+class TaskIdInput(ToolInput):
     """Input for retrieving a browsing or research task result."""
 
     task_id: str = Field(..., description="The task's unique identifier")
 
 
-class ResearchTaskInput(BaseModel):
+class ResearchTaskInput(ToolInput):
     """Input for running a one-time research task.
 
     The Research API executes deep web research on any topic.
@@ -315,6 +336,7 @@ class ResearchTaskInput(BaseModel):
     )
     output_fields: list[str] | None = Field(
         default=None,
+        min_length=1,
         description=_output_fields_description(
             ["title", "summary", "source_url"],
             docs_slug="research-create#using-webhooks-and-a-structured-output-schema",

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import Any, NoReturn
 
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
 from mcp.types import TextContent, Tool
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 
 from . import __version__
 from .adapter import MCPClientAdapter, YutoriAPIError
@@ -132,31 +132,34 @@ def create_server() -> Server:
 
     @server.call_tool()
     async def call_tool(name: str, arguments: dict[str, Any]) -> list[TextContent]:
+        # Errors are raised (not returned as text) so the MCP framework marks
+        # the result with isError=True; it uses str(exception) as the message.
         try:
-            with MCPClientAdapter() as client:
-                result, context = _handle_tool(client, name, arguments)
-                formatted = format_response(name, result, **context)
-                return [TextContent(type="text", text=formatted)]
+            async with MCPClientAdapter() as client:
+                result, context = await _handle_tool(client, name, arguments)
+            formatted = format_response(name, result, **context)
+            return [TextContent(type="text", text=formatted)]
         except YutoriAPIError as e:
-            return [
-                TextContent(
-                    type="text", text=f"API Error ({e.status_code}): {e.message}"
-                )
-            ]
-        except Exception as e:
+            raise RuntimeError(f"API Error ({e.status_code}): {e.message}") from e
+        except ValidationError:
+            # Routine bad-arguments case; str(e) is already actionable for the
+            # client. Don't pollute logs with an ERROR-level traceback.
+            raise
+        except Exception:
             logger.exception(f"Error handling tool {name}")
-            return [TextContent(type="text", text=f"Error: {e!s}")]
+            raise
 
     return server
 
 
 # Signature for tool handlers registered in _TOOL_HANDLERS.
 ToolHandler = Callable[
-    [MCPClientAdapter, dict[str, Any]], tuple[dict[str, Any], dict[str, Any]]
+    [MCPClientAdapter, dict[str, Any]],
+    Awaitable[tuple[dict[str, Any], dict[str, Any]]],
 ]
 
 
-def _handle_tool(
+async def _handle_tool(
     client: MCPClientAdapter, name: str, arguments: dict[str, Any]
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     """Route tool calls to the appropriate handler.
@@ -167,7 +170,7 @@ def _handle_tool(
     handler = _TOOL_HANDLERS.get(name)
     if handler is None:
         raise ValueError(f"Unknown tool: {name}")
-    return handler(client, arguments)
+    return await handler(client, arguments)
 
 
 def _scout_kwargs(
@@ -175,7 +178,8 @@ def _scout_kwargs(
 ) -> dict[str, Any]:
     """Convert a Pydantic input model into adapter kwargs.
 
-    Drops None fields (matches adapter._strip_none centralization) and
+    Drops None fields — _handle_edit_scout relies on the result being empty
+    when no config fields were provided — and
     transforms `output_fields` into the API's `output_schema` format.
     Callers can pass `extra_exclude` to drop additional fields (e.g. control
     fields that are not part of the scout config payload).
@@ -194,11 +198,11 @@ def _scout_kwargs(
 # -----------------------------------------------------------------------------
 
 
-def _handle_list_api_usage(
+async def _handle_list_api_usage(
     client: MCPClientAdapter, arguments: dict[str, Any]
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     params = UsageInput(**arguments)
-    result = client.get_usage(period=params.period)
+    result = await client.get_usage(period=params.period)
     return result, {}
 
 
@@ -213,51 +217,71 @@ def _make_scout_kwargs_handler(
     with its input schema and adapter method.
     """
 
-    def handler(
+    async def handler(
         client: MCPClientAdapter, arguments: dict[str, Any]
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         params = input_class(**arguments)
-        return getattr(client, client_method)(**_scout_kwargs(params)), {}
+        return await getattr(client, client_method)(**_scout_kwargs(params)), {}
 
     return handler
 
 
-def _handle_get_scout_detail(
+async def _handle_get_scout_detail(
     client: MCPClientAdapter, arguments: dict[str, Any]
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     params = ScoutIdInput(**arguments)
-    return client.get_scout_detail(params.scout_id), {}
+    return await client.get_scout_detail(params.scout_id), {}
 
 
-def _handle_edit_scout(
+async def _handle_edit_scout(
     client: MCPClientAdapter, arguments: dict[str, Any]
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     params = EditScoutInput(**arguments)
 
     # Fetch current state for diff (also validates scout exists)
-    old_scout = client.get_scout_detail(params.scout_id)
+    old_scout = await client.get_scout_detail(params.scout_id)
 
     # Build config kwargs, excluding control fields (scout_id is passed
     # explicitly below; status is applied separately after config updates).
     config_kwargs = _scout_kwargs(params, extra_exclude={"scout_id", "status"})
 
     if config_kwargs:
-        client.edit_scout(scout_id=params.scout_id, **config_kwargs)
+        await client.edit_scout(scout_id=params.scout_id, **config_kwargs)
 
-    # Apply status change after config updates
+    # Apply status change after config updates. The API requires status and
+    # config to be updated in separate calls, so the operation is not atomic:
+    # if the status call fails after a config update succeeded, say so
+    # explicitly instead of reporting a plain failure.
     if params.status is not None:
-        client.edit_scout(scout_id=params.scout_id, status=params.status)
+        try:
+            await client.edit_scout(scout_id=params.scout_id, status=params.status)
+        except YutoriAPIError as e:
+            if config_kwargs:
+                raise YutoriAPIError(
+                    message=(
+                        "Scout config changes were applied, but the status "
+                        f"change to '{params.status}' failed: {e.message}. "
+                        "Retry with edit_scout(scout_id, status=...) only."
+                    ),
+                    status_code=e.status_code,
+                ) from e
+            raise
 
-    # Return old and new state for diff
-    new_scout = client.get_scout_detail(params.scout_id)
+    # Return old and new state for diff. Every mutation already succeeded at
+    # this point, so a failed read-back must not surface as a failed edit —
+    # the formatter renders a success message without the diff instead.
+    try:
+        new_scout = await client.get_scout_detail(params.scout_id)
+    except YutoriAPIError:
+        new_scout = {}
     return {"old": old_scout, "new": new_scout}, {}
 
 
-def _handle_delete_scout(
+async def _handle_delete_scout(
     client: MCPClientAdapter, arguments: dict[str, Any]
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     params = ScoutIdInput(**arguments)
-    result = client.delete_scout(params.scout_id)
+    result = await client.delete_scout(params.scout_id)
     return result, {"scout_id": params.scout_id}
 
 
@@ -267,43 +291,43 @@ def _make_run_task_handler(
     client_method: str,
     include_browser: bool = False,
 ) -> ToolHandler:
-    """Build a ``run_*_task`` handler that defers only by input schema + adapter method + task_type.
+    """Build a ``run_*_task`` handler that differs only by input schema + adapter method + task_type.
 
-    The browsing and research variants previously had two near-identical
-    handlers; both parse a task-input schema, call ``_scout_kwargs(params)``
-    on the adapter, and stamp the matching ``task_type`` into the formatter
-    context. ``include_browser=True`` additionally surfaces ``params.browser``
-    so ``format_task_started`` can annotate the local/cloud distinction
+    The browsing and research variants share one shape: parse a task-input
+    schema, call the adapter method with ``_scout_kwargs(params)``, and stamp
+    the matching ``task_type`` into the formatter context.
+    ``include_browser=True`` additionally surfaces ``params.browser`` so
+    ``format_task_started`` can annotate the local/cloud distinction
     (research has no browser knob, so it omits the field).
     """
 
-    def handler(
+    async def handler(
         client: MCPClientAdapter, arguments: dict[str, Any]
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         params = input_class(**arguments)
         context: dict[str, Any] = {"task_type": task_type}
         if include_browser:
             context["browser"] = params.browser  # type: ignore[attr-defined]
-        return getattr(client, client_method)(**_scout_kwargs(params)), context
+        return await getattr(client, client_method)(**_scout_kwargs(params)), context
 
     return handler
 
 
 def _make_get_task_result_handler(task_type: str, client_method: str) -> ToolHandler:
-    """Build a ``get_*_task_result`` handler that defers only by adapter method + task_type.
+    """Build a ``get_*_task_result`` handler that differs only by adapter method + task_type.
 
-    The browsing and research variants previously had two near-identical
-    handlers; both parse :class:`TaskIdInput`, call a single-argument
-    adapter method, and stamp the matching ``task_type`` into the formatter
-    context. Generating both from one factory keeps the registry as the
-    single place that pairs the tool name with its task type.
+    The browsing and research variants share one shape: parse
+    :class:`TaskIdInput`, call a single-argument adapter method, and stamp
+    the matching ``task_type`` into the formatter context. Generating both
+    from one factory keeps the registry as the single place that pairs the
+    tool name with its task type.
     """
 
-    def handler(
+    async def handler(
         client: MCPClientAdapter, arguments: dict[str, Any]
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         params = TaskIdInput(**arguments)
-        return getattr(client, client_method)(params.task_id), {"task_type": task_type}
+        return await getattr(client, client_method)(params.task_id), {"task_type": task_type}
 
     return handler
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,7 @@
 """Pytest configuration for yutori-mcp tests.
 
-This file exists to prevent pytest from loading the root-level conftest.py
-which contains fixtures for the full Yutori project (e.g., PostgresContainer).
+Import paths are configured in pyproject.toml via
+``tool.pytest.ini_options.pythonpath = ["src"]``, so the suite runs from a
+source checkout without installing the package. This file is kept as a
+placeholder for future shared fixtures.
 """
-
-import sys
-from pathlib import Path
-
-# Add src to path for imports
-src_path = Path(__file__).parent.parent / "src"
-sys.path.insert(0, str(src_path))

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -1,17 +1,17 @@
 """Tests for the MCP adapter error mapping and argument forwarding."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from yutori.exceptions import APIError, AuthenticationError
+from yutori.exceptions import APIConnectionError, APIError, AuthenticationError
 from yutori_mcp.adapter import MCPClientAdapter, YutoriAPIError, _strip_none
 
 
 @pytest.fixture()
 def adapter():
     with patch("yutori_mcp.adapter.resolve_api_key", return_value="yt-test-key"), \
-         patch("yutori_mcp.adapter.YutoriClient"):
+         patch("yutori_mcp.adapter.AsyncYutoriClient"):
         return MCPClientAdapter()
 
 
@@ -23,56 +23,56 @@ def adapter():
 class TestErrorMapping:
     """Ensure SDK errors are mapped to stable MCP YutoriAPIError shape."""
 
-    def test_api_error_maps_to_yutori_api_error(self, adapter):
+    async def test_api_error_maps_to_yutori_api_error(self, adapter):
         sdk_error = APIError(message="Scout not found", status_code=404)
-        adapter._client.scouts.get = MagicMock(side_effect=sdk_error)
+        adapter._client.scouts.get = AsyncMock(side_effect=sdk_error)
 
         with pytest.raises(YutoriAPIError) as exc_info:
-            adapter.get_scout_detail("nonexistent-id")
+            await adapter.get_scout_detail("nonexistent-id")
 
         assert exc_info.value.status_code == 404
         assert exc_info.value.message == "Scout not found"
 
-    def test_authentication_error_maps_to_401(self, adapter):
+    async def test_authentication_error_maps_to_401(self, adapter):
         sdk_error = AuthenticationError("Invalid API key")
-        adapter._client.scouts.list = MagicMock(side_effect=sdk_error)
+        adapter._client.scouts.list = AsyncMock(side_effect=sdk_error)
 
         with pytest.raises(YutoriAPIError) as exc_info:
-            adapter.list_scouts()
+            await adapter.list_scouts()
 
         assert exc_info.value.status_code == 401
         assert "Invalid API key" in exc_info.value.message
 
-    def test_authentication_handler_preferred_if_auth_error_becomes_api_subclass(self):
+    async def test_authentication_handler_preferred_if_auth_error_becomes_api_subclass(self):
         class AuthAsApiError(APIError):
             pass
 
-        def raise_auth_as_api_error():
+        async def raise_auth_as_api_error():
             raise AuthAsApiError("Invalid API key", status_code=403)
 
         with patch("yutori_mcp.adapter.AuthenticationError", AuthAsApiError):
             with pytest.raises(YutoriAPIError) as exc_info:
-                MCPClientAdapter._call(raise_auth_as_api_error)
+                await MCPClientAdapter._call(raise_auth_as_api_error)
 
         assert exc_info.value.status_code == 401
         assert "Invalid API key" in exc_info.value.message
 
-    def test_api_error_preserves_status_code(self, adapter):
+    async def test_api_error_preserves_status_code(self, adapter):
         for code in [400, 403, 429, 500, 503]:
             sdk_error = APIError(message=f"Error {code}", status_code=code)
-            adapter._client.scouts.list = MagicMock(side_effect=sdk_error)
+            adapter._client.scouts.list = AsyncMock(side_effect=sdk_error)
 
             with pytest.raises(YutoriAPIError) as exc_info:
-                adapter.list_scouts()
+                await adapter.list_scouts()
 
             assert exc_info.value.status_code == code
 
-    def test_api_error_chains_original_exception(self, adapter):
+    async def test_api_error_chains_original_exception(self, adapter):
         sdk_error = APIError(message="Rate limited", status_code=429)
-        adapter._client.scouts.list = MagicMock(side_effect=sdk_error)
+        adapter._client.scouts.list = AsyncMock(side_effect=sdk_error)
 
         with pytest.raises(YutoriAPIError) as exc_info:
-            adapter.list_scouts()
+            await adapter.list_scouts()
 
         assert exc_info.value.__cause__ is sdk_error
 
@@ -104,9 +104,15 @@ class TestAdapterInit:
 
     def test_creates_client_with_resolved_key(self):
         with patch("yutori_mcp.adapter.resolve_api_key", return_value="yt-key"), \
-             patch("yutori_mcp.adapter.YutoriClient") as mock_client_cls:
+             patch("yutori_mcp.adapter.AsyncYutoriClient") as mock_client_cls:
             MCPClientAdapter()
             mock_client_cls.assert_called_once_with(api_key="yt-key")
+
+    async def test_context_manager_closes_client(self, adapter):
+        adapter._client.close = AsyncMock()
+        async with adapter:
+            pass
+        adapter._client.close.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------------
@@ -136,16 +142,16 @@ class TestStripNone:
 class TestGetUsageForwarding:
     """get_usage must forward period and strip None values."""
 
-    def test_period_forwarded(self, adapter):
-        adapter._client.get_usage = MagicMock(return_value={"num_active_scouts": 1})
-        adapter.get_usage(period="7d")
+    async def test_period_forwarded(self, adapter):
+        adapter._client.get_usage = AsyncMock(return_value={"num_active_scouts": 1})
+        await adapter.get_usage(period="7d")
 
         _, kwargs = adapter._client.get_usage.call_args
         assert kwargs["period"] == "7d"
 
-    def test_none_period_not_forwarded(self, adapter):
-        adapter._client.get_usage = MagicMock(return_value={"num_active_scouts": 0})
-        adapter.get_usage(period=None)
+    async def test_none_period_not_forwarded(self, adapter):
+        adapter._client.get_usage = AsyncMock(return_value={"num_active_scouts": 0})
+        await adapter.get_usage(period=None)
 
         _, kwargs = adapter._client.get_usage.call_args
         assert "period" not in kwargs
@@ -154,17 +160,17 @@ class TestGetUsageForwarding:
 class TestCreateScoutForwarding:
     """create_scout must not send None for optional fields (SDK has non-optional defaults)."""
 
-    def test_none_output_interval_not_forwarded(self, adapter):
-        adapter._client.scouts.create = MagicMock(return_value={"id": "s1"})
-        adapter.create_scout("test query", output_interval=None, webhook_url=None)
+    async def test_none_output_interval_not_forwarded(self, adapter):
+        adapter._client.scouts.create = AsyncMock(return_value={"id": "s1"})
+        await adapter.create_scout("test query", output_interval=None, webhook_url=None)
 
         _, kwargs = adapter._client.scouts.create.call_args
         assert "output_interval" not in kwargs
         assert "webhook_url" not in kwargs
 
-    def test_set_values_are_forwarded(self, adapter):
-        adapter._client.scouts.create = MagicMock(return_value={"id": "s1"})
-        adapter.create_scout("test query", output_interval=3600, webhook_url="https://example.com")
+    async def test_set_values_are_forwarded(self, adapter):
+        adapter._client.scouts.create = AsyncMock(return_value={"id": "s1"})
+        await adapter.create_scout("test query", output_interval=3600, webhook_url="https://example.com")
 
         _, kwargs = adapter._client.scouts.create.call_args
         assert kwargs["output_interval"] == 3600
@@ -174,30 +180,37 @@ class TestCreateScoutForwarding:
 class TestEditScoutForwarding:
     """edit_scout must filter None kwargs and not forward unsupported fields."""
 
-    def test_none_values_not_forwarded(self, adapter):
-        adapter._client.scouts.update = MagicMock(return_value={"id": "s1"})
-        adapter.edit_scout("s1", query=None, output_interval=None, status="paused")
+    async def test_none_values_not_forwarded(self, adapter):
+        adapter._client.scouts.update = AsyncMock(return_value={"id": "s1"})
+        await adapter.edit_scout("s1", query=None, output_interval=None, status="paused")
 
         _, kwargs = adapter._client.scouts.update.call_args
         assert "query" not in kwargs
         assert "output_interval" not in kwargs
         assert kwargs["status"] == "paused"
 
-    def test_config_values_forwarded(self, adapter):
-        adapter._client.scouts.update = MagicMock(return_value={"id": "s1"})
-        adapter.edit_scout("s1", query="updated query", skip_email=True)
+    async def test_config_values_forwarded(self, adapter):
+        adapter._client.scouts.update = AsyncMock(return_value={"id": "s1"})
+        await adapter.edit_scout("s1", query="updated query", skip_email=True)
 
         _, kwargs = adapter._client.scouts.update.call_args
         assert kwargs["query"] == "updated query"
         assert kwargs["skip_email"] is True
 
+    async def test_is_public_forwarded(self, adapter):
+        adapter._client.scouts.update = AsyncMock(return_value={"id": "s1"})
+        await adapter.edit_scout("s1", is_public=False)
+
+        _, kwargs = adapter._client.scouts.update.call_args
+        assert kwargs["is_public"] is False
+
 
 class TestBrowsingAndResearchForwarding:
     """Browsing and research should forward newly supported developer API fields."""
 
-    def test_browsing_forwards_require_auth_browser_and_zapier(self, adapter):
-        adapter._client.browsing.create = MagicMock(return_value={"task_id": "t1"})
-        adapter.run_browsing_task(
+    async def test_browsing_forwards_require_auth_browser_and_zapier(self, adapter):
+        adapter._client.browsing.create = AsyncMock(return_value={"task_id": "t1"})
+        await adapter.run_browsing_task(
             "Log in and export data",
             "https://example.com/login",
             require_auth=True,
@@ -210,3 +223,45 @@ class TestBrowsingAndResearchForwarding:
         assert kwargs["browser"] == "local"
         assert kwargs["webhook_format"] == "zapier"
 
+
+class TestContextManagerErrorPaths:
+    """__aexit__ must close the client on error paths without masking the
+    in-flight exception."""
+
+    async def test_client_closed_when_body_raises(self, adapter):
+        adapter._client.close = AsyncMock()
+        with pytest.raises(YutoriAPIError):
+            async with adapter:
+                raise YutoriAPIError(message="boom", status_code=500)
+        adapter._client.close.assert_awaited_once()
+
+    async def test_close_failure_does_not_mask_handler_error(self, adapter):
+        adapter._client.close = AsyncMock(side_effect=RuntimeError("close failed"))
+        with pytest.raises(YutoriAPIError, match="boom"):
+            async with adapter:
+                raise YutoriAPIError(message="boom", status_code=500)
+
+    async def test_close_failure_on_clean_exit_propagates(self, adapter):
+        adapter._client.close = AsyncMock(side_effect=RuntimeError("close failed"))
+        with pytest.raises(RuntimeError, match="close failed"):
+            async with adapter:
+                pass
+
+
+class TestTransportErrorMapping:
+    """SDK APIConnectionError (transport failures) maps to YutoriAPIError(503).
+
+    The SDK guarantees the message is never blank (it always includes the
+    underlying httpx exception type); the adapter only adds the status code.
+    """
+
+    async def test_connection_error_mapped(self, adapter):
+        adapter._client.scouts.list = AsyncMock(
+            side_effect=APIConnectionError(
+                "Network error calling the Yutori API (ConnectError): connection refused"
+            )
+        )
+        with pytest.raises(YutoriAPIError) as exc_info:
+            await adapter.list_scouts()
+        assert exc_info.value.status_code == 503
+        assert "ConnectError" in exc_info.value.message

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,6 +1,11 @@
 """Tests for output formatters."""
 
 from yutori_mcp.formatters import (
+    _EXTERNAL_CONTENT_END,
+    _EXTERNAL_CONTENT_START,
+    _format_date,
+    _format_datetime,
+    _format_output_fields_diff,
     _format_sources,
     dict_to_markdown,
     format_list_scouts,
@@ -537,3 +542,144 @@ class TestFormatSources:
         result = format_task_result(response)
         assert "Sources:" in result
         assert "- Src: https://src.com" in result
+
+
+class TestFormatterNullSafety:
+    """Regression tests for present-but-null fields in API responses."""
+
+    def test_list_scouts_with_explicit_null_query(self):
+        response = {
+            "scouts": [{"id": "abc", "query": None, "status": "active"}],
+            "total": 1,
+            "summary": {"active": 1, "paused": 0, "done": 0},
+        }
+        result = format_list_scouts(response)
+        assert "Untitled" in result
+
+    def test_scout_created_with_explicit_null_query(self):
+        response = {"id": "s1", "query": None, "status": "active"}
+        result = format_scout_created(response)
+        assert "Scout created successfully" in result
+
+
+class TestTimestampFormatting:
+    """_format_date/_format_datetime accept ISO strings and Unix s/ms ints."""
+
+    def test_list_scouts_with_unix_ms_next_run(self):
+        assert _format_date(1769997854699) == "2026-02-02"
+        response = {
+            "scouts": [
+                {
+                    "id": "abc",
+                    "query": "q",
+                    "status": "active",
+                    "next_output_timestamp": 1769997854699,
+                }
+            ],
+            "total": 1,
+            "summary": {"active": 1, "paused": 0, "done": 0},
+        }
+        result = format_list_scouts(response)
+        assert "Next: 2026-02-02" in result
+
+    def test_format_datetime_unix_seconds(self):
+        # Same instant as the millisecond value used elsewhere in this suite.
+        assert _format_datetime(1769997854) == "2026-02-02 02:04 UTC"
+
+    def test_format_datetime_unix_milliseconds(self):
+        assert _format_datetime(1769997854699) == "2026-02-02 02:04 UTC"
+
+
+class TestFormatTaskResultUnrecognizedStatus:
+    """Statuses outside the known set must not be reported as completed."""
+
+    def test_cancelled_not_reported_completed(self):
+        response = {"task_id": "t1", "status": "cancelled"}
+        result = format_task_result(response)
+        assert "Task completed" not in result
+        assert "unrecognized status 'cancelled'" in result
+
+    def test_unrecognized_status_still_surfaces_result(self):
+        response = {"task_id": "t1", "status": "cancelled", "result": "partial data"}
+        result = format_task_result(response)
+        assert "Task completed" not in result
+        assert "partial data" in result
+
+
+class TestSourcesExternalContentMarkers:
+    """Source titles/URLs are web-derived and must sit inside the markers."""
+
+    def test_sources_wrapped_in_markers(self):
+        lines = _format_sources(
+            {"sources": [{"url": "https://x.com", "title": "Injected Title"}]}
+        )
+        start = lines.index(_EXTERNAL_CONTENT_START)
+        end = lines.index(_EXTERNAL_CONTENT_END)
+        assert start < lines.index("  - Injected Title: https://x.com") < end
+
+
+class TestFormatScoutEditedOutputFields:
+    """output_fields edits are echoed back by the API as output_schema."""
+
+    @staticmethod
+    def _schema(fields):
+        return {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {f: {"type": "string"} for f in fields},
+            },
+        }
+
+    def test_output_schema_change_appears_in_diff(self):
+        response = {
+            "old": {"id": "s1", "query": "q", "output_schema": self._schema(["headline"])},
+            "new": {"id": "s1", "query": "q", "output_schema": self._schema(["headline", "url"])},
+        }
+        result = format_scout_edited(response)
+        assert "Output fields: headline → headline, url" in result
+        assert "no changes detected" not in result
+
+
+class TestFormatTaskResultUnrecognizedStatusDetails:
+    """The unrecognized-status branch surfaces all diagnostic fields."""
+
+    def test_rejection_reason_and_error_shown(self):
+        response = {
+            "task_id": "t1",
+            "status": "expired",
+            "rejection_reason": "billing_limit_reached",
+            "error": "task expired after 24h",
+        }
+        result = format_task_result(response)
+        assert "unrecognized status 'expired'" in result
+        assert "Rejection reason: billing_limit_reached" in result
+        assert "Error: task expired after 24h" in result
+
+    def test_message_key_used_as_error_fallback(self):
+        response = {"task_id": "t1", "status": "expired", "message": "gone"}
+        result = format_task_result(response)
+        assert "Error: gone" in result
+
+
+class TestFormatOutputFieldsDiffShapes:
+    """The diff formatter tolerates schemas not produced by this MCP."""
+
+    def test_unset_to_schema_transition(self):
+        schema = {
+            "type": "array",
+            "items": {"type": "object", "properties": {"headline": {"type": "string"}}},
+        }
+        response = {
+            "old": {"id": "s1", "query": "q"},
+            "new": {"id": "s1", "query": "q", "output_schema": schema},
+        }
+        result = format_scout_edited(response)
+        assert "Output fields: (not set) → headline" in result
+
+    def test_custom_schema_shapes_do_not_crash(self):
+        # JSON Schema tuple-form items (a list, not a dict)
+        assert _format_output_fields_diff({"items": [{"type": "string"}]}) == "(custom schema)"
+        # Object-form schema without items
+        assert _format_output_fields_diff({"type": "object", "properties": {}}) == "(custom schema)"
+        assert _format_output_fields_diff(None) == "(not set)"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -197,6 +197,9 @@ class TestEditScoutInput:
         """
         diff_fields = {field for field, _label, _fmt in _SCOUT_EDIT_FIELDS}
         editable_fields = set(EditScoutInput.model_fields) - {"scout_id"}
+        # The output_fields input is sent to (and returned by) the API as
+        # output_schema; the diff table uses the response-side name.
+        editable_fields = (editable_fields - {"output_fields"}) | {"output_schema"}
         assert diff_fields == editable_fields, (
             "Mismatch between _SCOUT_EDIT_FIELDS and EditScoutInput. "
             f"Missing from _SCOUT_EDIT_FIELDS: {editable_fields - diff_fields}. "
@@ -460,4 +463,69 @@ class TestInvalidWebhookFormatRejected:
             EditScoutInput(
                 scout_id="abc-123",
                 webhook_format="discord",
+            )
+
+
+class TestExtraFieldsRejected:
+    """Unknown arguments must fail validation instead of being silently dropped."""
+
+    def test_create_scout_rejects_unknown_field(self):
+        with pytest.raises(ValidationError):
+            CreateScoutInput(query="Test", frequency="daily")
+
+    def test_schema_marks_additional_properties_false(self):
+        from yutori_mcp.schema_utils import get_simplified_schema
+
+        schema = get_simplified_schema(EditScoutInput)
+        assert schema["additionalProperties"] is False
+
+
+class TestOutputFieldsMinLength:
+    """An empty output_fields list would produce a degenerate output schema."""
+
+    def test_empty_rejected_create_scout(self):
+        with pytest.raises(ValidationError):
+            CreateScoutInput(query="Test", output_fields=[])
+
+    def test_empty_rejected_edit_scout(self):
+        with pytest.raises(ValidationError):
+            EditScoutInput(scout_id="abc-123", output_fields=[])
+
+    def test_empty_rejected_browsing_task(self):
+        with pytest.raises(ValidationError):
+            BrowsingTaskInput(task="Test", start_url="https://example.com", output_fields=[])
+
+    def test_empty_rejected_research_task(self):
+        with pytest.raises(ValidationError):
+            ResearchTaskInput(query="Test", output_fields=[])
+
+
+class TestWebhookUrlRequiresHost:
+    def test_https_without_host_rejected(self):
+        with pytest.raises(ValidationError, match="webhook_url must use HTTPS"):
+            CreateScoutInput(query="Test", webhook_url="https://")
+
+    def test_https_with_host_accepted(self):
+        data = CreateScoutInput(query="Test", webhook_url="https://example.com")
+        assert data.webhook_url == "https://example.com"
+
+
+class TestEditScoutIsPublic:
+    def test_is_public_accepted(self):
+        """is_public is editable (SDK >=0.8.0 forwards it to the PATCH route)."""
+        data = EditScoutInput(scout_id="abc-123", is_public=False)
+        assert data.is_public is False
+
+
+class TestSimplifiedSchemaConstraints:
+    """Constraints must survive simplify_schema into the published inputSchema."""
+
+    def test_min_items_survives_simplification(self):
+        from yutori_mcp.schema_utils import get_simplified_schema
+
+        for model_cls in (CreateScoutInput, EditScoutInput, BrowsingTaskInput, ResearchTaskInput):
+            schema = get_simplified_schema(model_cls)
+            field = schema["properties"]["output_fields"]
+            assert field.get("minItems") == 1, (
+                f"{model_cls.__name__}.output_fields lost minItems in the simplified schema"
             )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,13 +1,17 @@
 """Tests for server helper functions."""
 
-from unittest.mock import patch
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, patch
 
 import pytest
+from mcp.types import CallToolRequest, CallToolRequestParams
 
 from yutori.auth.types import AuthStatus, LoginResult
 from yutori_mcp import __version__
+from yutori_mcp.adapter import YutoriAPIError
+from yutori_mcp.formatters import format_scout_edited
 from yutori_mcp.schema_utils import output_fields_to_output_schema, simplify_schema, get_simplified_schema
-from yutori_mcp.server import main
+from yutori_mcp.server import _handle_edit_scout, create_server, main
 from yutori_mcp.schemas import ListScoutsInput, CreateScoutInput
 
 
@@ -146,16 +150,10 @@ class TestOutputFieldsToOutputSchema:
         """None input returns None."""
         assert output_fields_to_output_schema(None) is None
 
-    def test_empty_list(self):
-        """Empty list produces empty properties."""
-        result = output_fields_to_output_schema([])
-        assert result == {
-            "type": "array",
-            "items": {
-                "type": "object",
-                "properties": {},
-            },
-        }
+    def test_empty_list_rejected(self):
+        """Empty list would produce a degenerate schema, so reject it."""
+        with pytest.raises(ValueError, match="at least one field"):
+            output_fields_to_output_schema([])
 
     def test_single_field(self):
         """Single field is converted correctly."""
@@ -247,3 +245,112 @@ class TestMainVersionFlag:
             assert exc_info.value.code == 0
         output = capsys.readouterr().out.strip()
         assert output == f"yutori-mcp {__version__}"
+
+
+class TestEditScoutPartialFailure:
+    """The API needs separate config/status calls, so a mid-sequence failure
+    must report that the config portion was already applied."""
+
+    async def test_status_failure_after_config_update_reports_partial_application(self):
+        client = AsyncMock()
+        client.get_scout_detail.return_value = {"id": "s1", "status": "active", "query": "q"}
+        client.edit_scout.side_effect = [
+            {"id": "s1"},  # config update succeeds
+            YutoriAPIError(message="server error", status_code=500),  # status fails
+        ]
+
+        with pytest.raises(YutoriAPIError) as exc_info:
+            await _handle_edit_scout(client, {"scout_id": "s1", "query": "new q", "status": "paused"})
+
+        assert "config changes were applied" in exc_info.value.message.lower()
+        assert "server error" in exc_info.value.message
+        assert exc_info.value.status_code == 500
+
+    async def test_status_only_failure_propagates_unwrapped(self):
+        client = AsyncMock()
+        client.get_scout_detail.return_value = {"id": "s1", "status": "active"}
+        client.edit_scout.side_effect = YutoriAPIError(message="server error", status_code=500)
+
+        with pytest.raises(YutoriAPIError) as exc_info:
+            await _handle_edit_scout(client, {"scout_id": "s1", "status": "paused"})
+
+        assert exc_info.value.message == "server error"
+
+
+def _call_tool_handler():
+    """Return the registered tools/call request handler from a fresh server."""
+    return create_server().request_handlers[CallToolRequest]
+
+
+def _call_tool_request(name, arguments):
+    return CallToolRequest(
+        method="tools/call",
+        params=CallToolRequestParams(name=name, arguments=arguments),
+    )
+
+
+@contextmanager
+def _patched_adapter():
+    """Patch MCPClientAdapter and yield the mock used as the async-with client."""
+    with patch("yutori_mcp.server.MCPClientAdapter") as adapter_cls:
+        instance = AsyncMock()
+        adapter_cls.return_value = instance
+        instance.__aenter__.return_value = instance
+        yield instance
+
+
+class TestCallToolErrorContract:
+    """The MCP framework converts exceptions raised from call_tool into
+    CallToolResult(isError=True, content=[str(exception)]). These tests pin
+    that contract end-to-end through the registered request handler."""
+
+    async def test_api_error_returns_iserror_with_formatted_message(self):
+        handler = _call_tool_handler()
+        with _patched_adapter() as client:
+            client.list_scouts.side_effect = YutoriAPIError(message="boom", status_code=500)
+            result = await handler(_call_tool_request("list_scouts", {}))
+
+        assert result.root.isError is True
+        assert result.root.content[0].text == "API Error (500): boom"
+
+    async def test_success_returns_formatted_text_without_error_flag(self):
+        handler = _call_tool_handler()
+        with _patched_adapter() as client:
+            client.list_scouts.return_value = {
+                "scouts": [],
+                "total": 0,
+                "summary": {"active": 0, "paused": 0, "done": 0},
+            }
+            result = await handler(_call_tool_request("list_scouts", {}))
+
+        assert result.root.isError is False
+        assert "Found 0 scouts" in result.root.content[0].text
+
+    async def test_unknown_argument_rejected_before_handler_runs(self):
+        # No adapter patch: additionalProperties=false must fail jsonschema
+        # validation in the framework before any handler/API code runs.
+        result = await _call_tool_handler()(_call_tool_request("list_scouts", {"bogus": 1}))
+
+        assert result.root.isError is True
+        assert "Input validation error" in result.root.content[0].text
+
+
+class TestEditScoutReadBackFailure:
+    """A failed post-edit state fetch must not report the edit as failed."""
+
+    async def test_read_back_failure_returns_success_without_diff(self):
+        client = AsyncMock()
+        client.get_scout_detail.side_effect = [
+            {"id": "s1", "status": "active", "query": "q"},  # pre-edit fetch
+            YutoriAPIError(message="rate limited", status_code=429),  # read-back
+        ]
+        client.edit_scout.return_value = {"id": "s1"}
+
+        result, context = await _handle_edit_scout(
+            client, {"scout_id": "s1", "query": "new q"}
+        )
+        assert result["new"] == {}
+
+        rendered = format_scout_edited(result, **context)
+        assert "Scout updated successfully" in rendered
+        assert "Could not fetch the updated scout state" in rendered


### PR DESCRIPTION
> **Draft until [yutori-sdk-python#131](https://github.com/yutori-ai/yutori-sdk-python/pull/131) is published as 0.8.0** — this PR pins `yutori>=0.8.0`, so CI dependency resolution fails until the SDK release lands on PyPI. Release order: deploy [yutori#10031](https://github.com/yutori-ai/yutori/pull/10031) → publish SDK 0.8.0 → land this.

Comprehensive hardening pass from a full code review (Claude + Codex cross-review), with upstream fixes landed separately in the API and SDK where the root cause lived.

## Fixes

**Server / adapter**
- Adapter runs on `AsyncYutoriClient` — slow API calls no longer block the event loop; all handlers async.
- Errors are **raised** from `call_tool` so the framework returns `isError=true` (previously API failures were returned as successful tool text). `YutoriAPIError` keeps the `API Error (status): message` shape; SDK `APIConnectionError` maps to 503 with a never-blank message.
- `edit_scout`: explicit partial-application error when the status call fails after a config update succeeded; a failed post-edit read-back renders as success-without-diff instead of reporting a successful edit as failed; a `close()` failure can't mask the in-flight error.
- `__version__` no longer crashes on import from a source checkout.

**Schemas**
- `extra="forbid"` on all inputs (and `additionalProperties:false` in the published inputSchema) — unknown arguments fail loudly instead of being silently dropped.
- `is_public` is editable again (SDK 0.8.0 forwards it; previously a guaranteed `TypeError`).
- `output_fields` requires ≥1 entry; webhook URLs must be HTTPS with a host.

**Formatters**
- Null-safe `query` handling and s/ms Unix-timestamp dates (both previously crashed *after* the API call succeeded).
- Unrecognized task statuses (`cancelled`, `expired`, …) no longer render as "Task completed."
- Sources/citations wrapped in the external-content markers like the bodies they accompany.
- Edit diff reads the response-side `output_schema` (older servers omit the key and the line is skipped — degrades to today's behavior until yutori#10031 deploys).

**CI**
- New test workflow (Python 3.10–3.14 matrix) reused as the publish gate, with read-only token permissions and a trusted-publishing TODO.

## Verification

- 176 unit tests (was 141), including isError-contract tests through the real registered request handler.
- **Live end-to-end against production**: 16/16 — usage/list, 404→isError contract, framework rejection of unknown args, full scout lifecycle (create → edit incl. `is_public` round-trip via the new SDK → delete → 404), and a browsing task completing with the result inside external-content markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior changes for MCP clients (errors as isError, stricter validation) and a hard dependency on yutori 0.8.0; edit_scout’s split config/status calls can leave partial state on failure.
> 
> **Overview**
> **0.3.0** release that moves the Yutori integration to **`AsyncYutoriClient`**, tightens tool inputs and output formatting, and gates PyPI publish on a multi-Python test matrix (requires **`yutori>=0.8.0`**).
> 
> The adapter and all tool handlers are **async** so API I/O does not block the MCP event loop; transport failures map to **503**. **`call_tool`** now **raises** on failures (including `RuntimeError` for API errors) so clients get **`isError=true`** instead of success text. **`edit_scout`** reports partial success when config applies but status fails, and treats a failed post-edit read-back as success without a diff.
> 
> Inputs inherit **`ToolInput`** with **`extra="forbid"`** / **`additionalProperties: false`**, stricter **`webhook_url`** and non-empty **`output_fields`**, and editable **`is_public`**. Formatters handle null queries, Unix s/ms timestamps, **`output_schema`** edit diffs, unrecognized task statuses, and external-content markers on sources.
> 
> CI adds **`test.yml`** (3.10–3.14) as the publish prerequisite; publish workflow bumps action versions and read-only permissions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d55cb4ab837a122e7264eda28089915b30f837a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->