### PR TITLE
docs: add missing params, strict validation note, HTTPS requirement

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -2,6 +2,8 @@
 
 All tool outputs are formatted as human-readable text optimized for LLM consumption.
 
+All tool inputs enforce strict validation: unknown fields are rejected, webhook URLs must use HTTPS, and `output_fields` (where supported) must contain at least one entry.
+
 ## Usage
 
 ### list_api_usage
@@ -167,7 +169,7 @@ First run: 2026-01-07 03:10 UTC
 |-----------|----------|-------------|
 | `query` | Yes | Natural language description of what to monitor |
 | `output_interval` | No | Seconds between runs (min: 1800). Default: 86400 |
-| `webhook_url` | No | URL for webhook notifications |
+| `webhook_url` | No | HTTPS URL for webhook notifications |
 | `webhook_format` | No | `scout` (default), `slack`, or `zapier` |
 | `output_fields` | No | List of field names for structured output as array of objects |
 | `user_timezone` | No | Timezone for scheduling |
@@ -229,7 +231,7 @@ Changes applied:
 | `status` | No | `active` (resume), `paused` (pause), or `done` (archive) |
 | `query` | No | Updated monitoring query |
 | `output_interval` | No | Seconds between runs (min 1800) |
-| `webhook_url` | No | Webhook notification URL |
+| `webhook_url` | No | HTTPS URL for webhook notifications |
 | `webhook_format` | No | `scout`, `slack`, or `zapier` |
 | `output_fields` | No | List of field names for structured output |
 | `user_timezone` | No | Timezone for scheduling |
@@ -267,6 +269,12 @@ Get paginated updates from a scout.
   "limit": 2
 }
 ```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `scout_id` | Yes | The scout's unique identifier (UUID) |
+| `cursor` | No | Pagination cursor from a previous response |
+| `limit` | No | Maximum number of updates to return (1-100) |
 
 Example response:
 
@@ -329,7 +337,7 @@ Poll with get_research_task_result(task_id="ae27a17c-a4ed-4c69-8b2a-4bec330fc935
 | `user_timezone` | No | Timezone for context. Default: 'America/Los_Angeles' |
 | `user_location` | No | Location for context. Default: 'San Francisco, CA, US' |
 | `output_fields` | No | List of field names for structured output as array of objects |
-| `webhook_url` | No | URL for completion notification |
+| `webhook_url` | No | HTTPS URL for completion notification |
 | `webhook_format` | No | `scout` (default), `slack`, or `zapier` |
 
 ### get_research_task_result
@@ -421,7 +429,7 @@ Poll with get_browsing_task_result(task_id="54fb19fd-277e-4098-ab72-5a9f8a4347fc
 | `require_auth` | No | If true, use an auth-optimized cloud browser provider for login flows. Only applies when browser is `cloud` (default) |
 | `browser` | No | `cloud` (default) or `local` to use Yutori Local with the user's logged-in desktop browser |
 | `output_fields` | No | List of field names for structured output as array of objects |
-| `webhook_url` | No | URL for completion notification |
+| `webhook_url` | No | HTTPS URL for completion notification |
 | `webhook_format` | No | `scout` (default), `slack`, or `zapier` |
 
 ### get_browsing_task_result


### PR DESCRIPTION
## Summary

- Add `get_scout_updates` parameter table — `cursor` param was completely undocumented
- Add strict input validation note at top of TOOLS.md (extra fields rejected, HTTPS-only webhooks, min-length output_fields)
- Update 4 `webhook_url` descriptions to note HTTPS requirement

## Context

PR #105 added strict input validation (`extra="forbid"`, HTTPS-only webhooks, `min_length=1` for output_fields) but TOOLS.md was not updated to reflect these constraints. Clients sending `http://` webhook URLs or unknown fields now get validation errors with no documentation explaining why.

## Test plan

- [ ] Documentation-only change
- [ ] Verify `_check_webhook_https` exists in `schemas.py`
- [ ] Verify `extra="forbid"` on input schemas

https://claude.ai/code/session_017tT6zLgHsBWT8er2aBf4Bz

---
_Generated by [Claude Code](https://claude.ai/code/session_017tT6zLgHsBWT8er2aBf4Bz)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to TOOLS.md with no runtime or API behavior impact.
> 
> **Overview**
> Updates **TOOLS.md** so tool docs match the stricter input validation clients now hit (e.g. after PR #105).
> 
> Adds a top-level note that inputs reject unknown fields, require **HTTPS** for `webhook_url`, and require at least one entry in `output_fields` when that field is used. **`webhook_url`** descriptions in `create_scout`, `edit_scout`, `run_research_task`, and `run_browsing_task` now explicitly say HTTPS.
> 
> Documents **`get_scout_updates`** with a parameter table for `scout_id`, `cursor`, and `limit` (including the previously missing pagination cursor and limit bounds).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bd5528bec7fd6d4267edadb88a3df6ad295c743. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->