### PR TITLE
feat: list_browsing_tasks & list_research_tasks MCP tools

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -65,6 +65,7 @@ List scouts for the user with optional filtering.
 |-----------|----------|-------------|
 | `limit` | No | Max scouts to return (1-100). Default: 10 |
 | `status` | No | Filter by `active`, `paused`, or `done` |
+| `cursor` | No | Pagination cursor from a previous response's `next_cursor` |
 
 Example response:
 
@@ -296,6 +297,40 @@ No new findings since last update.
 
 ## Research Tools
 
+### list_research_tasks
+
+List one-time research tasks for the user with optional filtering and cursor pagination.
+
+```json
+{
+  "limit": 10,
+  "status": "succeeded"
+}
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `limit` | No | Max tasks to return (1-100). Default: 10 |
+| `status` | No | Filter by `running`, `succeeded`, or `failed` |
+| `cursor` | No | Cursor from a previous response |
+
+Example response:
+
+```
+Found 248 research tasks: 0 running, 245 succeeded, 3 failed.
+
+Showing 10 of 245 matching tasks (248 total):
+
+1. Competitive landscape for AI code assistants (succeeded)
+   ID: ae27a17c-a4ed-4c69-8b2a-4bec330fc935
+   URL: https://platform.yutori.com/research/tasks/ae27a17c-a4ed-4c69-8b2a-4bec330fc935
+   Created: 2026-06-25
+
+More tasks available. Use list_research_tasks(cursor="eyJjcmVhdGVkX2F0...") to load more.
+Use list_research_tasks(status="succeeded") to list tasks with retrievable results.
+Use get_research_task_result(task_id) for full details.
+```
+
 ### run_research_task
 
 Execute a one-time deep web research task. The research agent searches, reads, and synthesizes information from across the web.
@@ -382,6 +417,40 @@ and an industry appearance from January 12–19, 2026.
 ```
 
 ## Browsing Tools
+
+### list_browsing_tasks
+
+List one-time browsing tasks for the user with optional filtering and cursor pagination.
+
+```json
+{
+  "limit": 10,
+  "status": "succeeded"
+}
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `limit` | No | Max tasks to return (1-100). Default: 10 |
+| `status` | No | Filter by `running`, `succeeded`, or `failed` |
+| `cursor` | No | Cursor from a previous response |
+
+Example response:
+
+```
+Found 42 browsing tasks: 1 running, 39 succeeded, 2 failed.
+
+Showing 10 of 39 matching tasks (42 total):
+
+1. Give me a list of all employees of Yutori. (succeeded)
+   ID: 54fb19fd-277e-4098-ab72-5a9f8a4347fc
+   URL: https://platform.yutori.com/browsing/tasks/54fb19fd-277e-4098-ab72-5a9f8a4347fc
+   Created: 2026-06-25
+
+More tasks available. Use list_browsing_tasks(cursor="eyJjcmVhdGVkX2F0...") to load more.
+Use list_browsing_tasks(status="succeeded") to list tasks with retrievable results.
+Use get_browsing_task_result(task_id) for full details.
+```
 
 ### run_browsing_task
 
@@ -488,6 +557,6 @@ Tools include hints for client behavior:
 
 | Tool | Annotation |
 |------|------------|
-| `list_api_usage`, `list_scouts`, `get_scout_detail`, `get_scout_updates`, `get_browsing_task_result`, `get_research_task_result` | `readOnlyHint: true` |
+| `list_api_usage`, `list_scouts`, `get_scout_detail`, `get_scout_updates`, `list_browsing_tasks`, `get_browsing_task_result`, `list_research_tasks`, `get_research_task_result` | `readOnlyHint: true` |
 | `edit_scout` | `idempotentHint: true` |
 | `delete_scout` | `destructiveHint: true` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.3.0"
+version = "0.3.1"
 description = "MCP server for Yutori - web monitoring, deep research, and browser automation"
 readme = "README.md"
 license = "Apache-2.0"
@@ -27,8 +27,8 @@ classifiers = [
 dependencies = [
     "mcp>=1.0.0",
     "pydantic>=2.0.0",
-    # 0.8.0 adds scouts.update(is_public=...) on both sync and async clients
-    "yutori>=0.8.0",
+    # 0.8.1 adds browsing/research task list methods on both sync and async clients
+    "yutori>=0.8.1",
 ]
 
 [project.optional-dependencies]

--- a/src/yutori_mcp/adapter.py
+++ b/src/yutori_mcp/adapter.py
@@ -92,7 +92,12 @@ class MCPClientAdapter:
     # Browsing operations
     # -------------------------------------------------------------------------
 
-    async def run_browsing_task(self, task: str, start_url: str, **kwargs: Any) -> dict[str, Any]:
+    async def list_browsing_tasks(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._call(self._client.browsing.list, **kwargs)
+
+    async def run_browsing_task(
+        self, task: str, start_url: str, **kwargs: Any
+    ) -> dict[str, Any]:
         return await self._call(self._client.browsing.create, task, start_url, **kwargs)
 
     async def get_browsing_task(self, task_id: str) -> dict[str, Any]:
@@ -101,6 +106,9 @@ class MCPClientAdapter:
     # -------------------------------------------------------------------------
     # Research operations
     # -------------------------------------------------------------------------
+
+    async def list_research_tasks(self, **kwargs: Any) -> dict[str, Any]:
+        return await self._call(self._client.research.list, **kwargs)
 
     async def run_research_task(self, query: str, **kwargs: Any) -> dict[str, Any]:
         return await self._call(self._client.research.create, query, **kwargs)

--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -298,11 +298,15 @@ def format_usage(response: dict[str, Any], **context: Any) -> str:
         lines.append(f"  Resets at: {rate_limits.get('reset_at', 'N/A')}")
 
     # Navigator rate limits (falls back to deprecated n1_rate_limits on older servers)
-    navigator_limits = _get_first(response, "navigator_rate_limits", "n1_rate_limits", default={})
+    navigator_limits = _get_first(
+        response, "navigator_rate_limits", "n1_rate_limits", default={}
+    )
     if navigator_limits:
         lines.append("\nNavigator API Rate Limits:")
         lines.extend(_format_request_count_lines(navigator_limits))
-        lines.append(f"  Per-second limit: {navigator_limits.get('per_second_limit', 'N/A')}")
+        lines.append(
+            f"  Per-second limit: {navigator_limits.get('per_second_limit', 'N/A')}"
+        )
         lines.append(f"  Resets at: {navigator_limits.get('reset_at', 'N/A')}")
 
     # Activity
@@ -331,7 +335,8 @@ def format_list_scouts(response: dict[str, Any], **context: Any) -> str:
     """Format list_scouts response as readable text."""
     scouts = response.get("scouts", [])
     total = response.get("total", len(scouts))
-    summary = response.get("summary", {})
+    # `or {}` guards an explicit `summary: null` (a missing key already defaults).
+    summary = response.get("summary") or {}
     has_more = response.get("has_more", False)
 
     # Build summary line
@@ -370,7 +375,10 @@ def format_list_scouts(response: dict[str, Any], **context: Any) -> str:
 
     # Add hints
     lines.append("")
-    if has_more:
+    next_cursor = response.get("next_cursor")
+    if has_more and next_cursor:
+        lines.append(f'Use list_scouts(cursor="{next_cursor}") to see more.')
+    elif has_more:
         lines.append("Use list_scouts(limit=50) to see more.")
     lines.append('Use list_scouts(status="active") to filter by status.')
     lines.append("Use get_scout_detail(scout_id) for full details.")
@@ -698,6 +706,79 @@ def format_task_result(response: dict[str, Any], **context: Any) -> str:
     return "\n".join(lines)
 
 
+def format_task_list(response: dict[str, Any], **context: Any) -> str:
+    """Format list_*_tasks response as readable text.
+
+    The list endpoints always return total/summary, but this tolerates their
+    absence (older/partial payloads): fall back to the task count and drop the
+    per-status breakdown rather than printing "0 running, 0 succeeded, 0 failed"
+    over real rows. ``summary or {}`` also keeps an explicit ``summary: null``
+    (the field is nullable) from crashing the .get() calls below; total/
+    filtered_total are non-nullable ints, so a plain default suffices.
+    """
+    task_type = context["task_type"]
+    task_label = task_type.lower()
+    tasks = response.get("tasks", [])
+    total = response.get("total", len(tasks))
+    filtered_total = response.get("filtered_total", total)
+    summary = response.get("summary") or {}
+    has_more = response.get("has_more", False)
+    next_cursor = response.get("next_cursor")
+    list_tool, get_tool = _TASK_LIST_TOOLS[task_type]
+
+    if summary:
+        lines = [
+            f"Found {total} {task_label} tasks: "
+            f"{summary.get('running', 0)} running, "
+            f"{summary.get('succeeded', 0)} succeeded, "
+            f"{summary.get('failed', 0)} failed."
+        ]
+    else:
+        lines = [f"Found {total} {task_label} tasks."]
+
+    if not tasks:
+        lines.append(f"\nNo {task_label} tasks to display.")
+        return "\n".join(lines)
+
+    showing = len(tasks)
+    if filtered_total != total:
+        lines.append(
+            f"\nShowing {showing} of {filtered_total} matching tasks ({total} total):"
+        )
+    elif has_more:
+        lines.append(f"\nShowing {showing} of {total}:")
+    else:
+        lines.append(f"\nShowing all {showing}:")
+
+    for i, task in enumerate(tasks, 1):
+        task_id = task.get("task_id", "")
+        # The list endpoint returns the prompt under `query` for both task types
+        # (browsing create takes it as `task`); read `query` for either.
+        query = task.get("query") or ""
+        status = task.get("status", "unknown")
+        created = _format_date(task.get("created_at"))
+        view_url = task.get("view_url")
+
+        lines.append(f"\n{i}. {_truncate(query, 80)} ({status})")
+        lines.append(f"   ID: {task_id}")
+        if view_url:
+            lines.append(f"   URL: {view_url}")
+        lines.append(f"   Created: {created}")
+        _append_rejection_reason(lines, task.get("rejection_reason"), indent="   ")
+
+    lines.append("")
+    if has_more and next_cursor:
+        lines.append(
+            f'More tasks available. Use {list_tool}(cursor="{next_cursor}") to load more.'
+        )
+    lines.append(
+        f'Use {list_tool}(status="succeeded") to list tasks with retrievable results.'
+    )
+    lines.append(f"Use {get_tool}(task_id) for full details.")
+
+    return "\n".join(lines)
+
+
 def _append_result_content(lines: list[str], response: dict[str, Any]) -> None:
     """Append the task's result body (marker-wrapped) and sources, if any."""
     result = _get_first(response, "result", "output", "content")
@@ -755,6 +836,11 @@ _TASK_POLL_FNS: dict[str, str] = {
     "Browsing": "get_browsing_task_result",
 }
 
+_TASK_LIST_TOOLS: dict[str, tuple[str, str]] = {
+    "Research": ("list_research_tasks", "get_research_task_result"),
+    "Browsing": ("list_browsing_tasks", "get_browsing_task_result"),
+}
+
 # Tool-name -> formatter registry, referenced by format_response() above.
 # Defined at module scope (after all formatters) so the dict is built once at
 # import time rather than rebuilt on every call.
@@ -766,8 +852,10 @@ _TOOL_FORMATTERS = {
     "create_scout": format_scout_created,
     "edit_scout": format_scout_edited,
     "delete_scout": format_scout_deleted,
+    "list_browsing_tasks": format_task_list,
     "run_browsing_task": format_task_started,
     "get_browsing_task_result": format_task_result,
+    "list_research_tasks": format_task_list,
     "run_research_task": format_task_started,
     "get_research_task_result": format_task_result,
 }

--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -37,6 +37,7 @@ class ToolInput(BaseModel):
 WebhookFormat = Literal["scout", "slack", "zapier"] | None
 
 ScoutStatus = Literal["active", "paused", "done"] | None
+TaskListStatus = Literal["running", "succeeded", "failed"] | None
 
 # Shared field descriptions, defined once so the call sites cannot drift out
 # of sync as the schemas evolve.
@@ -221,6 +222,29 @@ class ListScoutsInput(ToolInput):
     status: ScoutStatus = Field(
         default=None,
         description="Filter by status: 'active', 'paused', or 'done'",
+    )
+    cursor: str | None = Field(
+        default=None,
+        description="Pagination cursor from a previous list response",
+    )
+
+
+class ListTasksInput(ToolInput):
+    """Input for listing one-time browsing or research tasks."""
+
+    limit: int | None = Field(
+        default=10,
+        ge=1,
+        le=100,
+        description="Maximum number of tasks to return (1-100). Default: 10",
+    )
+    status: TaskListStatus = Field(
+        default=None,
+        description="Filter by status: 'running', 'succeeded', or 'failed'",
+    )
+    cursor: str | None = Field(
+        default=None,
+        description="Pagination cursor from a previous list response",
     )
 
 

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -21,6 +21,7 @@ from .schemas import (
     EditScoutInput,
     GetUpdatesInput,
     ListScoutsInput,
+    ListTasksInput,
     ResearchTaskInput,
     ScoutIdInput,
     TaskIdInput,
@@ -98,6 +99,17 @@ TOOLS = [
         inputSchema=get_simplified_schema(BrowsingTaskInput),
     ),
     Tool(
+        name="list_browsing_tasks",
+        description=(
+            "List one-time browsing tasks for the authenticated user. "
+            "Supports cursor pagination and status filtering. List status is approximate "
+            "(running also covers queued and not-yet-reconciled tasks); call "
+            "get_browsing_task_result for a task's authoritative status."
+        ),
+        inputSchema=get_simplified_schema(ListTasksInput),
+        annotations={"readOnlyHint": True},
+    ),
+    Tool(
         name="get_browsing_task_result",
         description="Poll for browsing task status and result. Call until status is 'succeeded' or 'failed'.",
         inputSchema=get_simplified_schema(TaskIdInput),
@@ -112,6 +124,17 @@ TOOLS = [
             "Example: 'latest AI startup funding announcements'."
         ),
         inputSchema=get_simplified_schema(ResearchTaskInput),
+    ),
+    Tool(
+        name="list_research_tasks",
+        description=(
+            "List one-time research tasks for the authenticated user. "
+            "Supports cursor pagination and status filtering. List status is approximate "
+            "(running also covers queued and not-yet-reconciled tasks); call "
+            "get_research_task_result for a task's authoritative status."
+        ),
+        inputSchema=get_simplified_schema(ListTasksInput),
+        annotations={"readOnlyHint": True},
     ),
     Tool(
         name="get_research_task_result",
@@ -226,6 +249,27 @@ def _make_scout_kwargs_handler(
     return handler
 
 
+def _make_model_kwargs_handler(
+    input_class: type[BaseModel], client_method: str, context: dict[str, Any] | None = None
+) -> ToolHandler:
+    """Build a handler that forwards a simple input model as keyword arguments.
+
+    ``context`` is the formatter context stamped onto the result (e.g.
+    ``{"task_type": "Browsing"}`` for the list_*_tasks tools); it defaults to
+    an empty context for tools whose formatter needs none.
+    """
+
+    async def handler(
+        client: MCPClientAdapter, arguments: dict[str, Any]
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        params = input_class(**arguments)
+        return await getattr(client, client_method)(
+            **params.model_dump(exclude_none=True)
+        ), context or {}
+
+    return handler
+
+
 async def _handle_get_scout_detail(
     client: MCPClientAdapter, arguments: dict[str, Any]
 ) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -327,7 +371,9 @@ def _make_get_task_result_handler(task_type: str, client_method: str) -> ToolHan
         client: MCPClientAdapter, arguments: dict[str, Any]
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         params = TaskIdInput(**arguments)
-        return await getattr(client, client_method)(params.task_id), {"task_type": task_type}
+        return await getattr(client, client_method)(params.task_id), {
+            "task_type": task_type
+        }
 
     return handler
 
@@ -337,20 +383,32 @@ def _make_get_task_result_handler(task_type: str, client_method: str) -> ToolHan
 # of the MCP tool lifecycle is structured the same way as the format side.
 _TOOL_HANDLERS: dict[str, ToolHandler] = {
     "list_api_usage": _handle_list_api_usage,
-    "list_scouts": _make_scout_kwargs_handler(ListScoutsInput, "list_scouts"),
+    "list_scouts": _make_model_kwargs_handler(ListScoutsInput, "list_scouts"),
     "get_scout_detail": _handle_get_scout_detail,
-    "get_scout_updates": _make_scout_kwargs_handler(GetUpdatesInput, "get_scout_updates"),
+    "get_scout_updates": _make_model_kwargs_handler(
+        GetUpdatesInput, "get_scout_updates"
+    ),
     "create_scout": _make_scout_kwargs_handler(CreateScoutInput, "create_scout"),
     "edit_scout": _handle_edit_scout,
     "delete_scout": _handle_delete_scout,
+    "list_browsing_tasks": _make_model_kwargs_handler(
+        ListTasksInput, "list_browsing_tasks", {"task_type": "Browsing"}
+    ),
     "run_browsing_task": _make_run_task_handler(
         "Browsing", BrowsingTaskInput, "run_browsing_task", include_browser=True
     ),
-    "get_browsing_task_result": _make_get_task_result_handler("Browsing", "get_browsing_task"),
+    "get_browsing_task_result": _make_get_task_result_handler(
+        "Browsing", "get_browsing_task"
+    ),
+    "list_research_tasks": _make_model_kwargs_handler(
+        ListTasksInput, "list_research_tasks", {"task_type": "Research"}
+    ),
     "run_research_task": _make_run_task_handler(
         "Research", ResearchTaskInput, "run_research_task"
     ),
-    "get_research_task_result": _make_get_task_result_handler("Research", "get_research_task"),
+    "get_research_task_result": _make_get_task_result_handler(
+        "Research", "get_research_task"
+    ),
 }
 
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -10,8 +10,10 @@ from yutori_mcp.adapter import MCPClientAdapter, YutoriAPIError, _strip_none
 
 @pytest.fixture()
 def adapter():
-    with patch("yutori_mcp.adapter.resolve_api_key", return_value="yt-test-key"), \
-         patch("yutori_mcp.adapter.AsyncYutoriClient"):
+    with (
+        patch("yutori_mcp.adapter.resolve_api_key", return_value="yt-test-key"),
+        patch("yutori_mcp.adapter.AsyncYutoriClient"),
+    ):
         return MCPClientAdapter()
 
 
@@ -43,7 +45,9 @@ class TestErrorMapping:
         assert exc_info.value.status_code == 401
         assert "Invalid API key" in exc_info.value.message
 
-    async def test_authentication_handler_preferred_if_auth_error_becomes_api_subclass(self):
+    async def test_authentication_handler_preferred_if_auth_error_becomes_api_subclass(
+        self,
+    ):
         class AuthAsApiError(APIError):
             pass
 
@@ -103,8 +107,10 @@ class TestAdapterInit:
                 MCPClientAdapter()
 
     def test_creates_client_with_resolved_key(self):
-        with patch("yutori_mcp.adapter.resolve_api_key", return_value="yt-key"), \
-             patch("yutori_mcp.adapter.AsyncYutoriClient") as mock_client_cls:
+        with (
+            patch("yutori_mcp.adapter.resolve_api_key", return_value="yt-key"),
+            patch("yutori_mcp.adapter.AsyncYutoriClient") as mock_client_cls,
+        ):
             MCPClientAdapter()
             mock_client_cls.assert_called_once_with(api_key="yt-key")
 
@@ -125,7 +131,11 @@ class TestStripNone:
         assert _strip_none({"a": 1, "b": None, "c": "x"}) == {"a": 1, "c": "x"}
 
     def test_preserves_falsy_non_none(self):
-        assert _strip_none({"a": 0, "b": False, "c": ""}) == {"a": 0, "b": False, "c": ""}
+        assert _strip_none({"a": 0, "b": False, "c": ""}) == {
+            "a": 0,
+            "b": False,
+            "c": "",
+        }
 
     def test_empty_dict(self):
         assert _strip_none({}) == {}
@@ -170,7 +180,9 @@ class TestCreateScoutForwarding:
 
     async def test_set_values_are_forwarded(self, adapter):
         adapter._client.scouts.create = AsyncMock(return_value={"id": "s1"})
-        await adapter.create_scout("test query", output_interval=3600, webhook_url="https://example.com")
+        await adapter.create_scout(
+            "test query", output_interval=3600, webhook_url="https://example.com"
+        )
 
         _, kwargs = adapter._client.scouts.create.call_args
         assert kwargs["output_interval"] == 3600
@@ -182,7 +194,9 @@ class TestEditScoutForwarding:
 
     async def test_none_values_not_forwarded(self, adapter):
         adapter._client.scouts.update = AsyncMock(return_value={"id": "s1"})
-        await adapter.edit_scout("s1", query=None, output_interval=None, status="paused")
+        await adapter.edit_scout(
+            "s1", query=None, output_interval=None, status="paused"
+        )
 
         _, kwargs = adapter._client.scouts.update.call_args
         assert "query" not in kwargs
@@ -207,6 +221,27 @@ class TestEditScoutForwarding:
 
 class TestBrowsingAndResearchForwarding:
     """Browsing and research should forward newly supported developer API fields."""
+
+    async def test_list_browsing_tasks_forwards_pagination_filters(self, adapter):
+        adapter._client.browsing.list = AsyncMock(return_value={"tasks": []})
+        await adapter.list_browsing_tasks(limit=20, status="succeeded", cursor="cur-1")
+
+        _, kwargs = adapter._client.browsing.list.call_args
+        assert kwargs == {"limit": 20, "status": "succeeded", "cursor": "cur-1"}
+
+    async def test_list_browsing_tasks_strips_none_values(self, adapter):
+        adapter._client.browsing.list = AsyncMock(return_value={"tasks": []})
+        await adapter.list_browsing_tasks(limit=None, status=None, cursor=None)
+
+        _, kwargs = adapter._client.browsing.list.call_args
+        assert kwargs == {}
+
+    async def test_list_research_tasks_forwards_pagination_filters(self, adapter):
+        adapter._client.research.list = AsyncMock(return_value={"tasks": []})
+        await adapter.list_research_tasks(limit=20, status="failed", cursor="cur-2")
+
+        _, kwargs = adapter._client.research.list.call_args
+        assert kwargs == {"limit": 20, "status": "failed", "cursor": "cur-2"}
 
     async def test_browsing_forwards_require_auth_browser_and_zapier(self, adapter):
         adapter._client.browsing.create = AsyncMock(return_value={"task_id": "t1"})

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -15,6 +15,7 @@ from yutori_mcp.formatters import (
     format_scout_detail,
     format_scout_edited,
     format_scout_updates,
+    format_task_list,
     format_task_result,
     format_task_started,
     format_usage,
@@ -100,7 +101,9 @@ class TestFormatUsage:
 
     def test_navigator_rate_limits_fallback_to_deprecated_n1_key(self):
         """If only the deprecated n1_rate_limits field is present, still render the section."""
-        response = {k: v for k, v in self.USAGE_RESPONSE.items() if k != "navigator_rate_limits"}
+        response = {
+            k: v for k, v in self.USAGE_RESPONSE.items() if k != "navigator_rate_limits"
+        }
         result = format_usage(response)
         assert "Navigator API Rate Limits" in result
         assert "Requests today: 100" in result
@@ -165,7 +168,11 @@ class TestFormatUsage:
 class TestFormatListScouts:
     def test_empty_list(self):
         """Empty scouts list shows appropriate message."""
-        response = {"scouts": [], "total": 0, "summary": {"active": 0, "paused": 0, "done": 0}}
+        response = {
+            "scouts": [],
+            "total": 0,
+            "summary": {"active": 0, "paused": 0, "done": 0},
+        }
         result = format_list_scouts(response)
         assert "Found 0 scouts" in result
         assert "No scouts to display" in result
@@ -203,6 +210,18 @@ class TestFormatListScouts:
         }
         result = format_list_scouts(response)
         assert "limit=50" in result
+
+    def test_cursor_hint_when_next_cursor_present(self):
+        """has_more with a next_cursor surfaces a cursor-pagination hint."""
+        response = {
+            "scouts": [{"id": "abc", "query": "test", "status": "active"}],
+            "total": 50,
+            "summary": {"active": 50, "paused": 0, "done": 0},
+            "has_more": True,
+            "next_cursor": "scout-cur-2",
+        }
+        result = format_list_scouts(response)
+        assert 'list_scouts(cursor="scout-cur-2")' in result
 
     def test_shows_rejection_reason(self):
         """Scout list includes rejection reason when present."""
@@ -290,8 +309,18 @@ class TestFormatScoutEdited:
     def test_with_diff(self):
         """Shows changes when old and new state provided."""
         response = {
-            "old": {"id": "abc", "status": "active", "query": "old query", "output_interval": 86400},
-            "new": {"id": "abc", "status": "paused", "query": "new query", "output_interval": 86400},
+            "old": {
+                "id": "abc",
+                "status": "active",
+                "query": "old query",
+                "output_interval": 86400,
+            },
+            "new": {
+                "id": "abc",
+                "status": "paused",
+                "query": "new query",
+                "output_interval": 86400,
+            },
         }
         result = format_scout_edited(response)
         assert "Scout updated successfully" in result
@@ -365,7 +394,11 @@ class TestFormatTaskStarted:
 
     def test_browsing_task(self):
         """Browsing task shows ID and poll hint."""
-        response = {"task_id": "task-xyz", "status": "queued", "view_url": "https://yutori.com/tasks/xyz"}
+        response = {
+            "task_id": "task-xyz",
+            "status": "queued",
+            "view_url": "https://yutori.com/tasks/xyz",
+        }
         result = format_task_started(response, task_type="Browsing")
         assert "Browsing task started" in result
         assert "task-xyz" in result
@@ -385,6 +418,135 @@ class TestFormatTaskStarted:
         assert "Poll with" not in result
 
 
+class TestFormatTaskList:
+    def test_empty_browsing_task_list(self):
+        """Empty browsing task lists show the summary and empty message."""
+        response = {
+            "tasks": [],
+            "total": 0,
+            "filtered_total": 0,
+            "summary": {"running": 0, "succeeded": 0, "failed": 0},
+        }
+        result = format_task_list(response, task_type="Browsing")
+
+        assert "Found 0 browsing tasks" in result
+        assert "No browsing tasks to display" in result
+
+    def test_research_task_list_with_pagination(self):
+        """Research task lists include task metadata and cursor hint."""
+        response = {
+            "tasks": [
+                {
+                    "task_id": "task-1",
+                    "query": "Research GPU pricing",
+                    "status": "succeeded",
+                    "created_at": "2026-06-25T12:00:00Z",
+                    "view_url": "https://platform.yutori.com/research/tasks/task-1",
+                }
+            ],
+            "total": 12,
+            "filtered_total": 8,
+            "summary": {"running": 2, "succeeded": 8, "failed": 2},
+            "has_more": True,
+            "next_cursor": "cursor-2",
+        }
+        result = format_task_list(response, task_type="Research")
+
+        assert "Found 12 research tasks: 2 running, 8 succeeded, 2 failed." in result
+        assert "Showing 1 of 8 matching tasks (12 total):" in result
+        assert "Research GPU pricing" in result
+        assert "task-1" in result
+        assert "https://platform.yutori.com/research/tasks/task-1" in result
+        assert 'list_research_tasks(cursor="cursor-2")' in result
+        assert 'list_research_tasks(status="succeeded")' in result
+        assert "get_research_task_result(task_id)" in result
+
+    def test_task_list_shows_rejection_reason(self):
+        """Failed task list entries include rejection reason when available."""
+        response = {
+            "tasks": [
+                {
+                    "task_id": "task-2",
+                    "query": "Export invoice",
+                    "status": "failed",
+                    "created_at": "2026-06-25T12:00:00Z",
+                    "rejection_reason": "insufficient_prepaid_balance",
+                }
+            ],
+            "total": 1,
+            "summary": {"running": 0, "succeeded": 0, "failed": 1},
+        }
+        result = format_task_list(response, task_type="Browsing")
+
+        assert "Rejection reason: insufficient_prepaid_balance" in result
+
+    def test_showing_all_when_complete(self):
+        """No filter and no more pages -> 'Showing all N' with no pagination hint."""
+        response = {
+            "tasks": [
+                {"task_id": "t1", "query": "a", "status": "succeeded"},
+                {"task_id": "t2", "query": "b", "status": "succeeded"},
+            ],
+            "total": 2,
+            "filtered_total": 2,
+            "summary": {"running": 0, "succeeded": 2, "failed": 0},
+            "has_more": False,
+        }
+        result = format_task_list(response, task_type="Browsing")
+
+        assert "Showing all 2:" in result
+        assert "More tasks available" not in result
+
+    def test_has_more_without_filter(self):
+        """has_more with filtered_total == total -> unfiltered 'Showing N of T' + cursor hint."""
+        response = {
+            "tasks": [{"task_id": "t1", "query": "a", "status": "running"}],
+            "total": 20,
+            "filtered_total": 20,
+            "summary": {"running": 20, "succeeded": 0, "failed": 0},
+            "has_more": True,
+            "next_cursor": "cursor-2",
+        }
+        result = format_task_list(response, task_type="Browsing")
+
+        assert "Showing 1 of 20:" in result
+        assert "matching tasks" not in result
+        assert 'list_browsing_tasks(cursor="cursor-2")' in result
+
+    def test_no_cursor_hint_when_next_cursor_missing(self):
+        """has_more but no next_cursor -> no 'More tasks available' line (avoid cursor='None')."""
+        response = {
+            "tasks": [{"task_id": "t1", "query": "a", "status": "running"}],
+            "total": 5,
+            "filtered_total": 5,
+            "summary": {"running": 5, "succeeded": 0, "failed": 0},
+            "has_more": True,
+        }
+        result = format_task_list(response, task_type="Research")
+
+        assert "More tasks available" not in result
+        # Static hints are still present.
+        assert 'list_research_tasks(status="succeeded")' in result
+        assert "get_research_task_result(task_id)" in result
+
+    def test_minimal_response_without_total_or_summary(self):
+        """A payload with only `tasks` renders without crashing and omits a zeroed breakdown."""
+        response = {"tasks": [{"task_id": "t1", "query": "q", "status": "succeeded"}]}
+        result = format_task_list(response, task_type="Browsing")
+
+        # No summary -> count only, not a misleading "0 running, 0 succeeded, 0 failed".
+        assert "Found 1 browsing tasks." in result
+        assert "0 succeeded" not in result
+        assert "Showing all 1:" in result
+
+    def test_null_summary_does_not_crash(self):
+        """An explicit `summary: null` must not raise (regression guard for `or {}`)."""
+        response = {"tasks": [{"task_id": "t1", "query": "q", "status": "succeeded"}], "summary": None}
+        result = format_task_list(response, task_type="Research")
+
+        assert "Found 1 research tasks." in result
+
+
 class TestFormatTaskResult:
     def test_in_progress(self):
         """In-progress task shows status and poll hint."""
@@ -396,7 +558,11 @@ class TestFormatTaskResult:
 
     def test_completed(self):
         """Completed task shows result."""
-        response = {"task_id": "task-abc", "status": "succeeded", "result": "Here are the findings..."}
+        response = {
+            "task_id": "task-abc",
+            "status": "succeeded",
+            "result": "Here are the findings...",
+        }
         result = format_task_result(response)
         assert "Task completed" in result
         assert "succeeded" in result
@@ -416,7 +582,11 @@ class TestFormatTaskResult:
 
     def test_failed(self):
         """Failed task shows error."""
-        response = {"task_id": "task-abc", "status": "failed", "error": "Something went wrong"}
+        response = {
+            "task_id": "task-abc",
+            "status": "failed",
+            "error": "Something went wrong",
+        }
         result = format_task_result(response)
         assert "Task failed" in result
         assert "Something went wrong" in result
@@ -426,7 +596,11 @@ class TestFormatResponse:
     def test_routes_to_correct_formatter(self):
         """format_response routes to the right formatter."""
         # Test list_scouts routing
-        response = {"scouts": [], "total": 0, "summary": {"active": 0, "paused": 0, "done": 0}}
+        response = {
+            "scouts": [],
+            "total": 0,
+            "summary": {"active": 0, "paused": 0, "done": 0},
+        }
         result = format_response("list_scouts", response)
         assert "Found 0 scouts" in result
 
@@ -479,11 +653,15 @@ class TestFormatSources:
 
     def test_truncation_at_max_items(self):
         """Sources beyond max_items are truncated with count."""
-        response = {"sources": [{"url": f"https://{i}.com", "title": f"S{i}"} for i in range(15)]}
+        response = {
+            "sources": [
+                {"url": f"https://{i}.com", "title": f"S{i}"} for i in range(15)
+            ]
+        }
         lines = _format_sources(response, max_items=10)
         assert "  ... and 5 more" in lines
         # Should have header + 10 items + truncation line + blank line prefix
-        source_lines = [l for l in lines if l.startswith("  - ")]
+        source_lines = [line for line in lines if line.startswith("  - ")]
         assert len(source_lines) == 10
 
     def test_custom_indent(self):
@@ -633,8 +811,16 @@ class TestFormatScoutEditedOutputFields:
 
     def test_output_schema_change_appears_in_diff(self):
         response = {
-            "old": {"id": "s1", "query": "q", "output_schema": self._schema(["headline"])},
-            "new": {"id": "s1", "query": "q", "output_schema": self._schema(["headline", "url"])},
+            "old": {
+                "id": "s1",
+                "query": "q",
+                "output_schema": self._schema(["headline"]),
+            },
+            "new": {
+                "id": "s1",
+                "query": "q",
+                "output_schema": self._schema(["headline", "url"]),
+            },
         }
         result = format_scout_edited(response)
         assert "Output fields: headline → headline, url" in result
@@ -679,7 +865,13 @@ class TestFormatOutputFieldsDiffShapes:
 
     def test_custom_schema_shapes_do_not_crash(self):
         # JSON Schema tuple-form items (a list, not a dict)
-        assert _format_output_fields_diff({"items": [{"type": "string"}]}) == "(custom schema)"
+        assert (
+            _format_output_fields_diff({"items": [{"type": "string"}]})
+            == "(custom schema)"
+        )
         # Object-form schema without items
-        assert _format_output_fields_diff({"type": "object", "properties": {}}) == "(custom schema)"
+        assert (
+            _format_output_fields_diff({"type": "object", "properties": {}})
+            == "(custom schema)"
+        )
         assert _format_output_fields_diff(None) == "(not set)"

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -10,6 +10,7 @@ from yutori_mcp.schemas import (
     EditScoutInput,
     GetUpdatesInput,
     ListScoutsInput,
+    ListTasksInput,
     ResearchTaskInput,
     ScoutIdInput,
     TaskIdInput,
@@ -319,6 +320,47 @@ class TestListScoutsInput:
         assert data.limit == 20
         assert data.status == "active"
 
+    def test_cursor_defaults_none_and_is_settable(self):
+        """Cursor defaults to None and accepts a pagination token."""
+        assert ListScoutsInput().cursor is None
+        assert ListScoutsInput(cursor="next-page").cursor == "next-page"
+
+
+class TestListTasksInput:
+    def test_default_values(self):
+        """Default limit is 10, status and cursor are None."""
+        data = ListTasksInput()
+        assert data.limit == 10
+        assert data.status is None
+        assert data.cursor is None
+
+    def test_custom_limit_and_cursor(self):
+        """Limit and cursor can be set together."""
+        data = ListTasksInput(limit=50, cursor="next-page")
+        assert data.limit == 50
+        assert data.cursor == "next-page"
+
+    def test_limit_range(self):
+        """Limit must be between 1 and 100."""
+        assert ListTasksInput(limit=1).limit == 1
+        assert ListTasksInput(limit=100).limit == 100
+
+        with pytest.raises(ValidationError):
+            ListTasksInput(limit=0)
+
+        with pytest.raises(ValidationError):
+            ListTasksInput(limit=101)
+
+    def test_status_filter(self):
+        """Status filter accepts the task-list statuses from the REST API."""
+        for status in ("running", "succeeded", "failed"):
+            assert ListTasksInput(status=status).status == status
+
+    def test_status_invalid(self):
+        """Detail-only statuses are rejected for list filters."""
+        with pytest.raises(ValidationError):
+            ListTasksInput(status="queued")
+
 
 class TestTaskIdInput:
     def test_task_id_required(self):
@@ -404,7 +446,12 @@ class TestOutputFieldsDescription:
 
     def test_all_schemas_use_helper(self):
         """All four output_fields descriptions are produced by the helper."""
-        for model_cls in (CreateScoutInput, EditScoutInput, BrowsingTaskInput, ResearchTaskInput):
+        for model_cls in (
+            CreateScoutInput,
+            EditScoutInput,
+            BrowsingTaskInput,
+            ResearchTaskInput,
+        ):
             desc = model_cls.model_fields["output_fields"].description
             assert desc is not None
             assert "Optional: Extract structured data" in desc, (
@@ -476,7 +523,12 @@ class TestSimplifiedSchemaConstraints:
     def test_min_items_survives_simplification(self):
         from yutori_mcp.schema_utils import get_simplified_schema
 
-        for model_cls in (CreateScoutInput, EditScoutInput, BrowsingTaskInput, ResearchTaskInput):
+        for model_cls in (
+            CreateScoutInput,
+            EditScoutInput,
+            BrowsingTaskInput,
+            ResearchTaskInput,
+        ):
             schema = get_simplified_schema(model_cls)
             field = schema["properties"]["output_fields"]
             assert field.get("minItems") == 1, (

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,9 +10,13 @@ from yutori.auth.types import AuthStatus, LoginResult
 from yutori_mcp import __version__
 from yutori_mcp.adapter import YutoriAPIError
 from yutori_mcp.formatters import format_scout_edited
-from yutori_mcp.schema_utils import output_fields_to_output_schema, simplify_schema, get_simplified_schema
+from yutori_mcp.schema_utils import (
+    output_fields_to_output_schema,
+    simplify_schema,
+    get_simplified_schema,
+)
 from yutori_mcp.server import _handle_edit_scout, create_server, main
-from yutori_mcp.schemas import ListScoutsInput, CreateScoutInput
+from yutori_mcp.schemas import ListScoutsInput, CreateScoutInput, ListTasksInput
 
 
 class TestSimplifySchema:
@@ -136,6 +140,14 @@ class TestGetSimplifiedSchema:
         assert status_schema["enum"] == ["active", "paused", "done"]
         assert "anyOf" not in status_schema
 
+    def test_list_tasks_schema_has_task_status_enum(self):
+        """ListTasksInput.status should expose the REST task-list statuses."""
+        schema = get_simplified_schema(ListTasksInput)
+        status_schema = schema["properties"]["status"]
+        assert status_schema["type"] == "string"
+        assert status_schema["enum"] == ["running", "succeeded", "failed"]
+        assert "anyOf" not in status_schema
+
     def test_create_scout_schema_has_integer_output_interval(self):
         """CreateScoutInput.output_interval should be integer, not anyOf."""
         schema = get_simplified_schema(CreateScoutInput)
@@ -194,16 +206,25 @@ class TestMainStatusExitCode:
 
     def test_status_unauthenticated_exits_1(self):
         status = AuthStatus(authenticated=False, config_path="/tmp/.yutori/config.json")
-        with patch("sys.argv", ["yutori-mcp", "status"]), \
-             patch("yutori.auth.get_auth_status", return_value=status):
+        with (
+            patch("sys.argv", ["yutori-mcp", "status"]),
+            patch("yutori.auth.get_auth_status", return_value=status),
+        ):
             with pytest.raises(SystemExit) as exc_info:
                 main()
             assert exc_info.value.code == 1
 
     def test_status_authenticated_exits_0(self):
-        status = AuthStatus(authenticated=True, masked_key="yt-abc...xyz", source="config_file", config_path="/tmp")
-        with patch("sys.argv", ["yutori-mcp", "status"]), \
-             patch("yutori.auth.get_auth_status", return_value=status):
+        status = AuthStatus(
+            authenticated=True,
+            masked_key="yt-abc...xyz",
+            source="config_file",
+            config_path="/tmp",
+        )
+        with (
+            patch("sys.argv", ["yutori-mcp", "status"]),
+            patch("yutori.auth.get_auth_status", return_value=status),
+        ):
             with pytest.raises(SystemExit) as exc_info:
                 main()
             assert exc_info.value.code == 0
@@ -213,9 +234,17 @@ class TestMainLoginAuthUrl:
     """Ensure `yutori-mcp login` surfaces auth_url on failure."""
 
     def test_login_failure_prints_auth_url(self, capsys):
-        result = LoginResult(success=False, error="timed out", auth_url="https://clerk.example.com/oauth/authorize?x=1")
-        with patch("sys.argv", ["yutori-mcp", "login"]), \
-             patch("yutori.auth.run_login_flow", return_value=result) as mock_run_login_flow:
+        result = LoginResult(
+            success=False,
+            error="timed out",
+            auth_url="https://clerk.example.com/oauth/authorize?x=1",
+        )
+        with (
+            patch("sys.argv", ["yutori-mcp", "login"]),
+            patch(
+                "yutori.auth.run_login_flow", return_value=result
+            ) as mock_run_login_flow,
+        ):
             with pytest.raises(SystemExit) as exc_info:
                 main()
             assert exc_info.value.code == 1
@@ -225,8 +254,12 @@ class TestMainLoginAuthUrl:
 
     def test_login_failure_without_auth_url(self, capsys):
         result = LoginResult(success=False, error="port in use")
-        with patch("sys.argv", ["yutori-mcp", "login"]), \
-             patch("yutori.auth.run_login_flow", return_value=result) as mock_run_login_flow:
+        with (
+            patch("sys.argv", ["yutori-mcp", "login"]),
+            patch(
+                "yutori.auth.run_login_flow", return_value=result
+            ) as mock_run_login_flow,
+        ):
             with pytest.raises(SystemExit) as exc_info:
                 main()
             assert exc_info.value.code == 1
@@ -253,14 +286,20 @@ class TestEditScoutPartialFailure:
 
     async def test_status_failure_after_config_update_reports_partial_application(self):
         client = AsyncMock()
-        client.get_scout_detail.return_value = {"id": "s1", "status": "active", "query": "q"}
+        client.get_scout_detail.return_value = {
+            "id": "s1",
+            "status": "active",
+            "query": "q",
+        }
         client.edit_scout.side_effect = [
             {"id": "s1"},  # config update succeeds
             YutoriAPIError(message="server error", status_code=500),  # status fails
         ]
 
         with pytest.raises(YutoriAPIError) as exc_info:
-            await _handle_edit_scout(client, {"scout_id": "s1", "query": "new q", "status": "paused"})
+            await _handle_edit_scout(
+                client, {"scout_id": "s1", "query": "new q", "status": "paused"}
+            )
 
         assert "config changes were applied" in exc_info.value.message.lower()
         assert "server error" in exc_info.value.message
@@ -269,7 +308,9 @@ class TestEditScoutPartialFailure:
     async def test_status_only_failure_propagates_unwrapped(self):
         client = AsyncMock()
         client.get_scout_detail.return_value = {"id": "s1", "status": "active"}
-        client.edit_scout.side_effect = YutoriAPIError(message="server error", status_code=500)
+        client.edit_scout.side_effect = YutoriAPIError(
+            message="server error", status_code=500
+        )
 
         with pytest.raises(YutoriAPIError) as exc_info:
             await _handle_edit_scout(client, {"scout_id": "s1", "status": "paused"})
@@ -307,7 +348,9 @@ class TestCallToolErrorContract:
     async def test_api_error_returns_iserror_with_formatted_message(self):
         handler = _call_tool_handler()
         with _patched_adapter() as client:
-            client.list_scouts.side_effect = YutoriAPIError(message="boom", status_code=500)
+            client.list_scouts.side_effect = YutoriAPIError(
+                message="boom", status_code=500
+            )
             result = await handler(_call_tool_request("list_scouts", {}))
 
         assert result.root.isError is True
@@ -326,10 +369,51 @@ class TestCallToolErrorContract:
         assert result.root.isError is False
         assert "Found 0 scouts" in result.root.content[0].text
 
+    async def test_list_browsing_tasks_dispatches_with_filters(self):
+        handler = _call_tool_handler()
+        with _patched_adapter() as client:
+            client.list_browsing_tasks.return_value = {
+                "tasks": [],
+                "total": 0,
+                "filtered_total": 0,
+                "summary": {"running": 0, "succeeded": 0, "failed": 0},
+            }
+            result = await handler(
+                _call_tool_request(
+                    "list_browsing_tasks",
+                    {"limit": 20, "status": "succeeded", "cursor": "cur-1"},
+                )
+            )
+
+        client.list_browsing_tasks.assert_awaited_once_with(
+            limit=20, status="succeeded", cursor="cur-1"
+        )
+        assert result.root.isError is False
+        assert "Found 0 browsing tasks" in result.root.content[0].text
+
+    async def test_list_research_tasks_dispatches_with_filters(self):
+        handler = _call_tool_handler()
+        with _patched_adapter() as client:
+            client.list_research_tasks.return_value = {
+                "tasks": [],
+                "total": 0,
+                "filtered_total": 0,
+                "summary": {"running": 0, "succeeded": 0, "failed": 0},
+            }
+            result = await handler(
+                _call_tool_request("list_research_tasks", {"status": "failed"})
+            )
+
+        client.list_research_tasks.assert_awaited_once_with(limit=10, status="failed")
+        assert result.root.isError is False
+        assert "Found 0 research tasks" in result.root.content[0].text
+
     async def test_unknown_argument_rejected_before_handler_runs(self):
         # No adapter patch: additionalProperties=false must fail jsonschema
         # validation in the framework before any handler/API code runs.
-        result = await _call_tool_handler()(_call_tool_request("list_scouts", {"bogus": 1}))
+        result = await _call_tool_handler()(
+            _call_tool_request("list_scouts", {"bogus": 1})
+        )
 
         assert result.root.isError is True
         assert "Input validation error" in result.root.content[0].text


### PR DESCRIPTION
## What

Adds two read-only MCP tools for the new task-list endpoints, so agents can enumerate and recover one-time task IDs:

| Tool | |
|---|---|
| `list_browsing_tasks` | List browsing tasks (paginated, status filter) |
| `list_research_tasks` | List research tasks (paginated, status filter) |

- Shared `ListTasksInput` (`limit` 1–100, default 10; `status` running/succeeded/failed; `cursor`) and a `format_task_list` renderer with summary counts, dashboard URLs, and pagination hints.
- Adapter methods delegate to the SDK's `browsing.list()` / `research.list()`.
- `cursor` added to `list_scouts` so scout listings paginate as well.
- List status is approximate (derived without a live workflow lookup) — the tool descriptions point callers to `get_*_task_result` for a task's authoritative status.

## Tests & docs

- Schema, adapter, server-dispatch, and formatter tests; full suite green, ruff clean.
- `TOOLS.md` updated with both tools.
- Requires `yutori>=0.8.1` (version bump to 0.3.1).
- Verified end-to-end against the production API.

Co-developed with Codex.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Read-only API listing with no auth or data-mutation changes; dependency bump to yutori 0.8.1 is the main integration risk.
> 
> **Overview**
> Adds **read-only** MCP tools **`list_browsing_tasks`** and **`list_research_tasks`** so agents can enumerate past one-time tasks (with **`limit`**, **`status`**, and **`cursor`**) and recover task IDs without relying only on `run_*` responses.
> 
> Shared **`ListTasksInput`** / **`TaskListStatus`**, adapter calls to **`yutori>=0.8.1`** **`browsing.list`** / **`research.list`**, a generic **`_make_model_kwargs_handler`**, and **`format_task_list`** (summary counts, filtered totals, cursor hints, rejection reasons) wire both tools end-to-end. Tool descriptions note that list status is approximate and **`get_*_task_result`** is authoritative.
> 
> **`list_scouts`** gains optional **`cursor`** on the schema and clearer pagination hints when **`next_cursor`** is present; list formatters tolerate **`summary: null`**.
> 
> Release **0.3.1**, **`TOOLS.md`** updates, and tests cover schemas, adapter forwarding, dispatch, and formatters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04ff54d4ff8c3a4e608f82de8d9c58b426e5e652. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->