### PR TITLE
refactor(schema_utils): extract _is_null_schema predicate to avoid repetition

### DIFF
--- a/src/yutori_mcp/schema_utils.py
+++ b/src/yutori_mcp/schema_utils.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 from typing import Any
 
 
+def _is_null_schema(v: Any) -> bool:
+    return isinstance(v, dict) and v.get("type") == "null"
+
+
 def simplify_schema(schema: dict[str, Any]) -> dict[str, Any]:
     """Simplify JSON Schema for MCP clients by flattening anyOf with null.
 
@@ -20,14 +24,8 @@ def simplify_schema(schema: dict[str, Any]) -> dict[str, Any]:
     for key, value in schema.items():
         if key == "anyOf" and isinstance(value, list) and len(value) == 2:
             # Check if this is the pattern: [{actual_type}, {type: null}]
-            non_null = [
-                v
-                for v in value
-                if not (isinstance(v, dict) and v.get("type") == "null")
-            ]
-            null_types = [
-                v for v in value if isinstance(v, dict) and v.get("type") == "null"
-            ]
+            non_null = [v for v in value if not _is_null_schema(v)]
+            null_types = [v for v in value if _is_null_schema(v)]
 
             if len(non_null) == 1 and len(null_types) == 1:
                 # Flatten: merge the non-null type's properties into result


### PR DESCRIPTION
## Summary

The `isinstance(v, dict) and v.get("type") == "null"` predicate appeared twice in `simplify_schema` with opposite polarity (once to keep non-null items, once to collect null items). Extracting it as `_is_null_schema` removes the duplication and makes each comprehension's intent clearer at a glance.

**Before:**
```python
non_null = [
    v
    for v in value
    if not (isinstance(v, dict) and v.get("type") == "null")
]
null_types = [
    v for v in value if isinstance(v, dict) and v.get("type") == "null"
]
```

**After:**
```python
def _is_null_schema(v: Any) -> bool:
    return isinstance(v, dict) and v.get("type") == "null"

# in simplify_schema:
non_null = [v for v in value if not _is_null_schema(v)]
null_types = [v for v in value if _is_null_schema(v)]
```

No logic change — existing `simplify_schema` tests cover the behaviour.

---
_Generated by [Claude Code](https://claude.ai/code/session_016z7GMWfTRx5tQe8mVZeBay)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor in schema utility code with no logic change; existing tests cover behavior.
> 
> **Overview**
> Introduces a private **`_is_null_schema`** helper in `schema_utils.py` and uses it in the two `anyOf` list comprehensions inside **`simplify_schema`**, replacing duplicated `isinstance(v, dict) and v.get("type") == "null"` checks.
> 
> Behavior of optional-field flattening for MCP JSON Schema is unchanged; this is readability-only cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c67d1427a63116ecc9fd5aff9b51c351095cfb2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->