### PR TITLE
refactor(formatters): consolidate duplicate task-tool-name tables

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -641,10 +641,9 @@ def format_task_started(response: dict[str, Any], **context: Any) -> str:
     if view_url:
         lines.append(f"View progress: {view_url}")
 
+    _, get_tool = _TASK_TOOLS[task_type]
     lines.append("")
-    lines.append(
-        f'Poll with {_TASK_POLL_FNS[task_type]}(task_id="{task_id}") to check status.'
-    )
+    lines.append(f'Poll with {get_tool}(task_id="{task_id}") to check status.')
 
     return "\n".join(lines)
 
@@ -724,7 +723,7 @@ def format_task_list(response: dict[str, Any], **context: Any) -> str:
     summary = response.get("summary") or {}
     has_more = response.get("has_more", False)
     next_cursor = response.get("next_cursor")
-    list_tool, get_tool = _TASK_LIST_TOOLS[task_type]
+    list_tool, get_tool = _TASK_TOOLS[task_type]
 
     if summary:
         lines = [
@@ -828,15 +827,11 @@ _SCOUT_EDIT_FIELDS = (
     ("is_public", "Public", _format_yes_no),
 )
 
-# Map task_type (as stamped by run_browsing_task / run_research_task handlers
-# in server.py) to the polling tool name surfaced in the user-facing hint
-# emitted by format_task_started().
-_TASK_POLL_FNS: dict[str, str] = {
-    "Research": "get_research_task_result",
-    "Browsing": "get_browsing_task_result",
-}
-
-_TASK_LIST_TOOLS: dict[str, tuple[str, str]] = {
+# Map task_type (as stamped by the run_*_task / list_*_task handlers in
+# server.py) to its (list_tool, get_tool) names, surfaced in the user-facing
+# hints emitted by format_task_started() and format_task_list(). A single
+# table keeps the two formatters from drifting if a tool is ever renamed.
+_TASK_TOOLS: dict[str, tuple[str, str]] = {
     "Research": ("list_research_tasks", "get_research_task_result"),
     "Browsing": ("list_browsing_tasks", "get_browsing_task_result"),
 }


### PR DESCRIPTION
## What

`formatters.py` had two separate module-level dicts keyed by `task_type` (`"Browsing"` / `"Research"`):

```python
_TASK_POLL_FNS: dict[str, str] = {
    "Research": "get_research_task_result",
    "Browsing": "get_browsing_task_result",
}

_TASK_LIST_TOOLS: dict[str, tuple[str, str]] = {
    "Research": ("list_research_tasks", "get_research_task_result"),
    "Browsing": ("list_browsing_tasks", "get_browsing_task_result"),
}
```

The `get_*_task_result` tool name was duplicated verbatim across both tables — `format_task_started` read it from `_TASK_POLL_FNS`, while `format_task_list` read the same value out of `_TASK_LIST_TOOLS[task_type][1]`.

This PR merges them into a single `_TASK_TOOLS: dict[str, tuple[str, str]]` table that both formatters now read from.

## Why

Two registries holding the same mapping is exactly the kind of thing that can silently drift — e.g. if a tool were ever renamed and only one of the two dicts got updated, `format_task_started`'s "poll with ..." hint and `format_task_list`'s "use ... for full details" hint would disagree about the tool name, and nothing would catch it (both are free-form strings interpolated into user-facing text). Centralizing removes the possibility entirely.

## Why it's safe

- Pure consolidation, no behavior change: both call sites now read the exact same string values they read before.
- Single file touched (`src/yutori_mcp/formatters.py`).
- Full test suite passes locally: `uv run --extra dev pytest -q` → 197 passed.
- No test or other module referenced the old `_TASK_POLL_FNS` / `_TASK_LIST_TOOLS` names directly (verified via grep), so nothing else needed updating.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01X84NiHKi99rqtqo7jBmAXC)_