### PR TITLE
refactor(server): merge _make_scout_kwargs_handler into _make_run_task_handler

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -349,26 +349,6 @@ async def _handle_list_api_usage(
     return result, {}
 
 
-def _make_scout_kwargs_handler(
-    input_class: type[BaseModel], client_method: str
-) -> ToolHandler:
-    """Build a handler that parses an input schema and forwards it as scout kwargs.
-
-    Used for tools whose handler body is the one-liner
-    ``client.METHOD(**_scout_kwargs(params))``. Generating these from one
-    factory keeps the registry as the single place that pairs the tool name
-    with its input schema and adapter method.
-    """
-
-    async def handler(
-        client: MCPClientAdapter, arguments: dict[str, Any]
-    ) -> tuple[dict[str, Any], dict[str, Any]]:
-        params = input_class(**arguments)
-        return await getattr(client, client_method)(**_scout_kwargs(params)), {}
-
-    return handler
-
-
 def _make_model_kwargs_handler(
     input_class: type[BaseModel], client_method: str, context: dict[str, Any] | None = None
 ) -> ToolHandler:
@@ -450,26 +430,31 @@ async def _handle_delete_scout(
 
 
 def _make_run_task_handler(
-    task_type: str,
+    task_type: str | None,
     input_class: type[BaseModel],
     client_method: str,
     include_browser: bool = False,
 ) -> ToolHandler:
-    """Build a ``run_*_task`` handler that differs only by input schema + adapter method + task_type.
+    """Build a handler that parses an input schema and forwards it as scout kwargs.
 
-    The browsing and research variants share one shape: parse a task-input
-    schema, call the adapter method with ``_scout_kwargs(params)``, and stamp
-    the matching ``task_type`` into the formatter context.
-    ``include_browser=True`` additionally surfaces ``params.browser`` so
-    ``format_task_started`` can annotate the local/cloud distinction
-    (research has no browser knob, so it omits the field).
+    Shared shape for tools whose handler body is the one-liner
+    ``client.METHOD(**_scout_kwargs(params))``: parse a schema, call the
+    adapter method, and stamp the matching ``task_type`` into the formatter
+    context. ``task_type=None`` (used for ``create_scout``, which has no
+    task-type concept) omits the context entry entirely rather than stamping
+    a null value. ``include_browser=True`` additionally surfaces
+    ``params.browser`` so ``format_task_started`` can annotate the
+    local/cloud distinction (research has no browser knob, so it omits the
+    field). Generating these from one factory keeps the registry as the
+    single place that pairs the tool name with its input schema and adapter
+    method.
     """
 
     async def handler(
         client: MCPClientAdapter, arguments: dict[str, Any]
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         params = input_class(**arguments)
-        context: dict[str, Any] = {"task_type": task_type}
+        context: dict[str, Any] = {} if task_type is None else {"task_type": task_type}
         if include_browser:
             context["browser"] = params.browser  # type: ignore[attr-defined]
         return await getattr(client, client_method)(**_scout_kwargs(params)), context
@@ -508,7 +493,7 @@ _TOOL_HANDLERS: dict[str, ToolHandler] = {
     "get_scout_updates": _make_model_kwargs_handler(
         GetUpdatesInput, "get_scout_updates"
     ),
-    "create_scout": _make_scout_kwargs_handler(CreateScoutInput, "create_scout"),
+    "create_scout": _make_run_task_handler(None, CreateScoutInput, "create_scout"),
     "edit_scout": _handle_edit_scout,
     "delete_scout": _handle_delete_scout,
     "list_browsing_tasks": _make_model_kwargs_handler(


### PR DESCRIPTION
## What

`server.py` had two nearly-identical handler-factory functions:

- `_make_scout_kwargs_handler` — parse an input schema, call `client.METHOD(**_scout_kwargs(params))`, return an empty context. Used only by `create_scout`.
- `_make_run_task_handler` — the same shape, plus stamping `{"task_type": ...}` (and optionally `browser`) into the context. Used by `run_browsing_task` / `run_research_task`.

This PR removes `_make_scout_kwargs_handler` and generalizes `_make_run_task_handler` to accept `task_type: str | None`. When `task_type` is `None` (the `create_scout` case), the context omits the `task_type` key entirely — identical to what `_make_scout_kwargs_handler` returned (`{}`).

## Why

One factory function fully subsumes the other; keeping both was pure duplication (same parse → call → return shape, differing only in whether a context key gets stamped). This is the kind of drift the existing `_TOOL_HANDLERS`/`_TOOL_FORMATTERS` dispatch-table pattern in this repo is meant to prevent — see prior refactors in `.claude/REFACTOR.md`'s `yutori-mcp` section (dispatch-table extraction in #71, task-tool-name table merge in #111).

## Why it's safe

- `create_scout`'s registry entry changes from `_make_scout_kwargs_handler(CreateScoutInput, "create_scout")` to `_make_run_task_handler(None, CreateScoutInput, "create_scout")` — same input class, same adapter method, same resulting context (`{}`).
- No change to `run_browsing_task` / `run_research_task` behavior: their call sites pass an explicit string `task_type`, so the `is None` branch never triggers for them.
- Full test suite passes: `185 passed` (`pytest -q`).
- Pure internal refactor — no public tool schema, input validation, or response formatting changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01C2CRpnBvo3Lgu7KGEQKXzW)_