### PR TITLE
docs: fix TOOLS.md claim about unknown-field validation

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -2,7 +2,7 @@
 
 All tool outputs are formatted as human-readable text optimized for LLM consumption.
 
-All tool inputs enforce strict validation: unknown fields are rejected, webhook URLs must use HTTPS, and `output_fields` (where supported) must contain at least one entry.
+All tool inputs enforce validation: webhook URLs must use HTTPS, and `output_fields` (where supported) must contain at least one entry. Unknown/extra fields are silently ignored rather than rejected.
 
 ## Usage
 


### PR DESCRIPTION
## What

Commit `18b8676` migrated `server.py` from the low-level `mcp.server.Server` to FastMCP. This changed how unknown/extra tool arguments are handled: FastMCP extracts only known parameters from the request and silently drops anything else, whereas the old implementation enforced `additionalProperties: false` via JSON Schema and rejected unrecognized fields. This behavior change is pinned by `tests/test_server.py::test_unknown_argument_silently_accepted` (renamed from `test_unknown_argument_rejected_before_handler_runs`).

`TOOLS.md` still stated "unknown fields are rejected" as part of its strict-validation summary, which no longer matches actual behavior after the FastMCP migration.

## Fix

Updated the sentence in `TOOLS.md` to describe the current behavior (unknown/extra fields are silently ignored) while keeping the still-accurate claims about HTTPS webhook URLs and `output_fields` minimum length.

No code or test changes — documentation only.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QHVDda4wH659Er9vWy61w2)_