### PR TITLE
refactor(server): reuse schemas.py literal type aliases instead of re-declaring them

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -38,6 +38,8 @@ WebhookFormat = Literal["scout", "slack", "zapier"] | None
 
 ScoutStatus = Literal["active", "paused", "done"] | None
 TaskListStatus = Literal["running", "succeeded", "failed"] | None
+UsagePeriod = Literal["24h", "7d", "30d", "90d"] | None
+BrowserChoice = Literal["cloud", "local"] | None
 
 # Shared field descriptions, defined once so the call sites cannot drift out
 # of sync as the schemas evolve.
@@ -75,7 +77,7 @@ def _output_fields_description(example: list[str], docs_slug: str | None = None)
 class UsageInput(ToolInput):
     """Input for retrieving API usage statistics."""
 
-    period: Literal["24h", "7d", "30d", "90d"] | None = Field(
+    period: UsagePeriod = Field(
         default=None,
         description="Time range for activity counts: '24h' (default), '7d', '30d', or '90d'",
     )
@@ -298,7 +300,7 @@ class BrowsingTaskInput(ToolInput):
         default=None,
         description="If true, use an auth-optimized cloud browser provider for login flows. Only applies when browser is 'cloud' (default).",
     )
-    browser: Literal["cloud", "local"] | None = Field(
+    browser: BrowserChoice = Field(
         default=None,
         description=(
             "Where to run the browser. 'cloud' (default) uses Yutori's cloud browser. "

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Awaitable, Callable
-from typing import Any, Literal, NoReturn
+from typing import Any, NoReturn
 
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
@@ -15,6 +15,7 @@ from .adapter import MCPClientAdapter, YutoriAPIError
 from .formatters import format_response
 from .schema_utils import output_fields_to_output_schema
 from .schemas import (
+    BrowserChoice,
     BrowsingTaskInput,
     CreateScoutInput,
     EditScoutInput,
@@ -23,8 +24,12 @@ from .schemas import (
     ListTasksInput,
     ResearchTaskInput,
     ScoutIdInput,
+    ScoutStatus,
     TaskIdInput,
+    TaskListStatus,
     UsageInput,
+    UsagePeriod,
+    WebhookFormat,
 )
 
 logger = logging.getLogger(__name__)
@@ -72,7 +77,7 @@ _DESTRUCTIVE = ToolAnnotations(destructiveHint=True)
     annotations=_READ_ONLY,
 )
 async def list_api_usage(
-    period: Literal["24h", "7d", "30d", "90d"] | None = None,
+    period: UsagePeriod = None,
 ) -> str:
     return await _invoke("list_api_usage", {"period": period})
 
@@ -86,7 +91,7 @@ async def list_api_usage(
 )
 async def list_scouts(
     limit: int | None = 10,
-    status: Literal["active", "paused", "done"] | None = None,
+    status: ScoutStatus = None,
     cursor: str | None = None,
 ) -> str:
     return await _invoke("list_scouts", {"limit": limit, "status": status, "cursor": cursor})
@@ -124,7 +129,7 @@ async def create_scout(
     query: str,
     output_interval: int | None = None,
     webhook_url: str | None = None,
-    webhook_format: Literal["scout", "slack", "zapier"] | None = None,
+    webhook_format: WebhookFormat = None,
     output_fields: list[str] | None = None,
     user_timezone: str | None = None,
     skip_email: bool | None = None,
@@ -158,11 +163,11 @@ async def create_scout(
 )
 async def edit_scout(
     scout_id: str,
-    status: Literal["active", "paused", "done"] | None = None,
+    status: ScoutStatus = None,
     query: str | None = None,
     output_interval: int | None = None,
     webhook_url: str | None = None,
-    webhook_format: Literal["scout", "slack", "zapier"] | None = None,
+    webhook_format: WebhookFormat = None,
     output_fields: list[str] | None = None,
     skip_email: bool | None = None,
     user_timezone: str | None = None,
@@ -207,10 +212,10 @@ async def run_browsing_task(
     start_url: str,
     max_steps: int | None = None,
     require_auth: bool | None = None,
-    browser: Literal["cloud", "local"] | None = None,
+    browser: BrowserChoice = None,
     output_fields: list[str] | None = None,
     webhook_url: str | None = None,
-    webhook_format: Literal["scout", "slack", "zapier"] | None = None,
+    webhook_format: WebhookFormat = None,
 ) -> str:
     return await _invoke(
         "run_browsing_task",
@@ -238,7 +243,7 @@ async def run_browsing_task(
 )
 async def list_browsing_tasks(
     limit: int | None = 10,
-    status: Literal["running", "succeeded", "failed"] | None = None,
+    status: TaskListStatus = None,
     cursor: str | None = None,
 ) -> str:
     return await _invoke(
@@ -267,7 +272,7 @@ async def run_research_task(
     user_location: str | None = None,
     output_fields: list[str] | None = None,
     webhook_url: str | None = None,
-    webhook_format: Literal["scout", "slack", "zapier"] | None = None,
+    webhook_format: WebhookFormat = None,
 ) -> str:
     return await _invoke(
         "run_research_task",
@@ -293,7 +298,7 @@ async def run_research_task(
 )
 async def list_research_tasks(
     limit: int | None = 10,
-    status: Literal["running", "succeeded", "failed"] | None = None,
+    status: TaskListStatus = None,
     cursor: str | None = None,
 ) -> str:
     return await _invoke(


### PR DESCRIPTION
## Summary

- `server.py`'s FastMCP tool functions re-typed the same option literals (`webhook_format`, scout/task `status`, `browser`, usage `period`) inline with raw `Literal[...]` annotations, instead of importing the `ScoutStatus` / `TaskListStatus` / `WebhookFormat` aliases `schemas.py` already defines and uses internally across its Pydantic models.
- That left two independent sources of truth per enum (5 occurrences of the webhook-format literal alone, split across `schemas.py` and `server.py`) that could silently drift if a value were ever added to one but not the other — the same "duplicated pattern across files" class of issue flagged by prior cleanups in this repo (#111 did the equivalent for the task-tool-name tables).
- Added two more aliases (`UsagePeriod`, `BrowserChoice`) alongside the existing three so every literal option-set shared between `schemas.py` and `server.py` has exactly one definition, and pointed every matching parameter/field at the shared alias.

No behavior change — the raw `Literal[...] | None` annotations are structurally identical to the type aliases they replace.

## Test plan

- [x] `pytest` — all 185 tests pass unchanged
- [x] `ruff check` — clean
- [x] Verified via `mcp.list_tools()` that the FastMCP-derived JSON Schema for every affected tool (`list_api_usage`, `list_scouts`, `create_scout`, `edit_scout`, `run_browsing_task`, `list_browsing_tasks`, `run_research_task`, `list_research_tasks`) is unchanged (same `enum` values, `type`, `default`, `title` for each field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DsYmvythNDX1mc6Fm8LEPt


---
_Generated by [Claude Code](https://claude.ai/code/session_01DsYmvythNDX1mc6Fm8LEPt)_