### PR TITLE
docs: fix stale ToolInput docstring after FastMCP migration

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -24,11 +24,9 @@ HttpsWebhookUrl = Annotated[str | None, AfterValidator(_check_webhook_https)]
 class ToolInput(BaseModel):
     """Base class for all tool input schemas.
 
-    Forbids unknown fields so a misspelled or unsupported argument fails with
-    a clear validation error instead of being silently dropped. This also
-    emits ``additionalProperties: false`` in the generated JSON Schema, so
-    the MCP server framework's input validation (and any client that
-    pre-validates) rejects bad arguments before they reach the handler.
+    ``extra="forbid"`` guards direct model instantiation (in handler factories
+    and tests). FastMCP strips unknown fields at the protocol level before they
+    reach handlers, so the schema constraint is not enforced at runtime there.
     """
 
     model_config = ConfigDict(extra="forbid")


### PR DESCRIPTION
## Summary

- Update `ToolInput` class docstring in `schemas.py` to accurately describe FastMCP behavior — `extra="forbid"` guards direct model instantiation (handler factories and tests), but FastMCP strips unknown fields at the protocol level before they reach handlers. The previous docstring made the same stale claim that #114 fixed in TOOLS.md.

## Test plan

- [ ] Docstring-only change — existing `test_unknown_argument_silently_accepted` test confirms the described behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018JurRoLZKp5WcEr7bhVqDr

---
_Generated by [Claude Code](https://claude.ai/code/session_018JurRoLZKp5WcEr7bhVqDr)_