### PR TITLE
refactor(server): reuse _make_model_kwargs_handler for get_scout_detail

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -317,13 +317,6 @@ def _make_model_kwargs_handler(
     return handler
 
 
-async def _handle_get_scout_detail(
-    client: MCPClientAdapter, arguments: dict[str, Any]
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    params = ScoutIdInput(**arguments)
-    return await client.get_scout_detail(params.scout_id), {}
-
-
 async def _handle_edit_scout(
     client: MCPClientAdapter, arguments: dict[str, Any]
 ) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -436,7 +429,7 @@ def _make_get_task_result_handler(task_type: str, client_method: str) -> ToolHan
 _TOOL_HANDLERS: dict[str, ToolHandler] = {
     "list_api_usage": _make_model_kwargs_handler(UsageInput, "get_usage"),
     "list_scouts": _make_model_kwargs_handler(ListScoutsInput, "list_scouts"),
-    "get_scout_detail": _handle_get_scout_detail,
+    "get_scout_detail": _make_model_kwargs_handler(ScoutIdInput, "get_scout_detail"),
     "get_scout_updates": _make_model_kwargs_handler(
         GetUpdatesInput, "get_scout_updates"
     ),


### PR DESCRIPTION
## Structural issue

`_TOOL_HANDLERS["get_scout_detail"]` was wired to a one-off hand-written handler, `_handle_get_scout_detail`:

```python
async def _handle_get_scout_detail(
    client: MCPClientAdapter, arguments: dict[str, Any]
) -> tuple[dict[str, Any], dict[str, Any]]:
    params = ScoutIdInput(**arguments)
    return await client.get_scout_detail(params.scout_id), {}
```

This is exactly the shape `_make_model_kwargs_handler` already generalizes: parse an input schema, forward its fields as kwargs to a single adapter method, and return an empty formatter context. `list_api_usage` and `list_scouts` already go through this factory; `get_scout_detail` was the one holdout still using a hand-written function for the identical pattern (the same consolidation `_make_model_kwargs_handler` for `list_api_usage` did in #115).

## Change

- Removed `_handle_get_scout_detail`.
- Registered `_make_model_kwargs_handler(ScoutIdInput, "get_scout_detail")` in `_TOOL_HANDLERS` instead.

## Why it's safe

- Adapter method `get_scout_detail(self, scout_id: str)` accepts `scout_id` as a normal (non-positional-only) parameter, so calling it via `**{"scout_id": ...}` (what the factory does) is behaviorally identical to the previous `client.get_scout_detail(params.scout_id)` positional call.
- `ScoutIdInput.model_dump(exclude_none=True)` on a single required `scout_id: str` field always produces exactly `{"scout_id": ...}` — no other fields to drop or coerce.
- Formatter context is unchanged: both the old handler and the factory return `{}` for this tool, and `format_scout_detail` doesn't consume `context`.
- No call sites reference `_handle_get_scout_detail` by name (checked `tests/` and `src/`), so nothing else needs updating.
- Full test suite passes (185 passed) and `ruff check` is clean. (`ruff format` flags two pre-existing, unrelated formatting diffs on `main` in `server.py`/`tests/test_formatters.py` that predate this change — left untouched as out of scope.)

Single-file, ~7-line diff; no behavior change.


---
_Generated by [Claude Code](https://claude.ai/code/session_012JLE5x1ssEgt1zjnKVY7Rh)_