### PR TITLE
refactor(schemas): extract shared cursor description and min-interval constant

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -48,6 +48,12 @@ _WEBHOOK_FORMAT_DESCRIPTION = (
     "Webhook payload format: 'scout' (default), 'slack', or 'zapier'"
 )
 _IS_PUBLIC_DESCRIPTION = "Whether scout results are publicly accessible"
+_LIST_CURSOR_DESCRIPTION = "Pagination cursor from a previous list response"
+
+# Minimum allowed `output_interval` in seconds, shared by CreateScoutInput and
+# EditScoutInput so the `ge=` validation bound and the "30 minutes" prose
+# describing it cannot drift apart if the minimum ever changes.
+_MIN_OUTPUT_INTERVAL_SECONDS = 1800
 
 
 def _output_fields_description(example: list[str], docs_slug: str | None = None) -> str:
@@ -104,8 +110,11 @@ class CreateScoutInput(ToolInput):
     )
     output_interval: int | None = Field(
         default=None,
-        ge=1800,
-        description="Seconds between scout runs. Minimum 1800 (30 minutes). Default: 86400 (daily)",
+        ge=_MIN_OUTPUT_INTERVAL_SECONDS,
+        description=(
+            f"Seconds between scout runs. Minimum {_MIN_OUTPUT_INTERVAL_SECONDS} "
+            "(30 minutes). Default: 86400 (daily)"
+        ),
     )
     webhook_url: HttpsWebhookUrl = Field(
         default=None,
@@ -165,8 +174,10 @@ class EditScoutInput(ToolInput):
     )
     output_interval: int | None = Field(
         default=None,
-        ge=1800,
-        description="Updated run interval in seconds. Minimum 1800 (30 minutes)",
+        ge=_MIN_OUTPUT_INTERVAL_SECONDS,
+        description=(
+            f"Updated run interval in seconds. Minimum {_MIN_OUTPUT_INTERVAL_SECONDS} (30 minutes)"
+        ),
     )
     webhook_url: HttpsWebhookUrl = Field(
         default=None,
@@ -227,7 +238,7 @@ class ListScoutsInput(ToolInput):
     )
     cursor: str | None = Field(
         default=None,
-        description="Pagination cursor from a previous list response",
+        description=_LIST_CURSOR_DESCRIPTION,
     )
 
 
@@ -246,7 +257,7 @@ class ListTasksInput(ToolInput):
     )
     cursor: str | None = Field(
         default=None,
-        description="Pagination cursor from a previous list response",
+        description=_LIST_CURSOR_DESCRIPTION,
     )
 
 


### PR DESCRIPTION
## Issue

`schemas.py` already has an established pattern of factoring out duplicated `Field(description=...)` text into shared module-level constants (`_SCOUT_ID_DESCRIPTION`, `_WEBHOOK_FORMAT_DESCRIPTION`, `_IS_PUBLIC_DESCRIPTION`) so call sites can't drift as the schemas evolve. Two instances of the same pattern were missed:

- `ListScoutsInput.cursor` and `ListTasksInput.cursor` both hardcoded the identical literal string `"Pagination cursor from a previous list response"`.
- `CreateScoutInput.output_interval` and `EditScoutInput.output_interval` both hardcoded `ge=1800` plus a "Minimum 1800 (30 minutes)" prose fragment restating the same bound — a real validation constraint duplicated as a bare magic number, not just documentation.

## Improvement

Added `_LIST_CURSOR_DESCRIPTION` and `_MIN_OUTPUT_INTERVAL_SECONDS` alongside the existing shared constants, and pointed all four call sites at them, matching the file's existing convention.

## Safety

- No behavior change: verified the rendered field descriptions are byte-identical before/after the change, and the `ge=` validation bound is unchanged (1800).
- Full test suite passes: `uv run pytest -q` → 185 passed.
- `ruff check` and `ruff format --diff` both clean on the changed file.
- Single file touched (`src/yutori_mcp/schemas.py`), no PR template present in the repo.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VMGdx83p9qCSDjpduaDWCD


---
_Generated by [Claude Code](https://claude.ai/code/session_01VMGdx83p9qCSDjpduaDWCD)_