### PR TITLE
refactor(server): rename _scout_kwargs to _output_schema_kwargs

### DIFF
--- a/src/yutori_mcp/adapter.py
+++ b/src/yutori_mcp/adapter.py
@@ -1,7 +1,7 @@
 """Thin adapter mapping MCP tool calls to the Yutori SDK async client.
 
-Wraps AsyncYutoriClient namespace methods, preserving the same interface that
-server.py's _handle_tool() expects. Catches SDK APIError and re-raises
+Wraps AsyncYutoriClient namespace methods, preserving the interface that
+server.py's _invoke()/_TOOL_HANDLERS dispatch expects. Catches SDK APIError and re-raises
 as YutoriAPIError for consistent MCP error formatting. The async client is
 used so slow Yutori API calls never block the MCP server's event loop.
 """

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -271,16 +271,16 @@ ToolHandler = Callable[
 ]
 
 
-def _scout_kwargs(
+def _output_schema_kwargs(
     params: BaseModel, extra_exclude: set[str] | None = None
 ) -> dict[str, Any]:
     """Convert a Pydantic input model into adapter kwargs.
 
-    Drops None fields — _handle_edit_scout relies on the result being empty
-    when no config fields were provided — and
-    transforms `output_fields` into the API's `output_schema` format.
-    Callers can pass `extra_exclude` to drop additional fields (e.g. control
-    fields that are not part of the scout config payload).
+    Drops None fields — callers relying on an empty result when no config
+    fields were provided (e.g. _handle_edit_scout) should confirm that still
+    holds — and transforms `output_fields` into the API's `output_schema`
+    format. Callers can pass `extra_exclude` to drop additional fields (e.g.
+    control fields that should not be forwarded to the adapter method).
     """
     exclude = {"output_fields"} | (extra_exclude or set())
     kwargs = params.model_dump(exclude=exclude, exclude_none=True)
@@ -327,7 +327,7 @@ async def _handle_edit_scout(
 
     # Build config kwargs, excluding control fields (scout_id is passed
     # explicitly below; status is applied separately after config updates).
-    config_kwargs = _scout_kwargs(params, extra_exclude={"scout_id", "status"})
+    config_kwargs = _output_schema_kwargs(params, extra_exclude={"scout_id", "status"})
 
     if config_kwargs:
         await client.edit_scout(scout_id=params.scout_id, **config_kwargs)
@@ -375,10 +375,10 @@ def _make_run_task_handler(
     client_method: str,
     include_browser: bool = False,
 ) -> ToolHandler:
-    """Build a handler that parses an input schema and forwards it as scout kwargs.
+    """Build a handler that parses an input schema and forwards it as adapter kwargs.
 
     Shared shape for tools whose handler body is the one-liner
-    ``client.METHOD(**_scout_kwargs(params))``: parse a schema, call the
+    ``client.METHOD(**_output_schema_kwargs(params))``: parse a schema, call the
     adapter method, and stamp the matching ``task_type`` into the formatter
     context. ``task_type=None`` (used for ``create_scout``, which has no
     task-type concept) omits the context entry entirely rather than stamping
@@ -397,7 +397,9 @@ def _make_run_task_handler(
         context: dict[str, Any] = {} if task_type is None else {"task_type": task_type}
         if include_browser:
             context["browser"] = params.browser  # type: ignore[attr-defined]
-        return await getattr(client, client_method)(**_scout_kwargs(params)), context
+        return await getattr(client, client_method)(
+            **_output_schema_kwargs(params)
+        ), context
 
     return handler
 


### PR DESCRIPTION
## Naming drift

`_scout_kwargs` (added in 794563e, reused by `_handle_edit_scout` in 53444da) was originally scout-only: it converted a scout config Pydantic model into adapter kwargs, dropping `None` fields and turning `output_fields` into the API's `output_schema` format.

A later consolidation generalized it into the shared kwargs-builder used by `_make_run_task_handler`, which backs `create_scout`, `run_browsing_task`, **and** `run_research_task` (see the `_TOOL_HANDLERS` registry). So `BrowsingTaskInput` and `ResearchTaskInput` — which have nothing to do with scouts — now flow through a function named `_scout_kwargs`, and its docstring still said "the scout config payload," which is misleading for anyone reading or extending this code.

## Change

- Renamed `_scout_kwargs` → `_output_schema_kwargs` (reflects its defining behavior — converting `output_fields` into `output_schema` — applicable to any input model with that field, not just scouts). Updated every call site (`_handle_edit_scout`, `_make_run_task_handler`, and the shared one-liner shape documented in `_make_run_task_handler`'s docstring).
- Reworded the docstring to describe the function in general "input model" terms instead of "scout config payload," while keeping the still-relevant caveat that `_handle_edit_scout` relies on getting back an empty dict when no config fields were provided.
- Drive-by: fixed a stale reference in `adapter.py`'s module docstring to `server.py`'s `_handle_tool()`, which no longer exists — it was replaced by `_invoke()` + the `_TOOL_HANDLERS` registry during the FastMCP migration. (#118 fixed a similar stale reference elsewhere but missed this one.)

## Why it's safe

- Pure rename + docstring/comment fix — no Pydantic model field definitions, tool signatures, or MCP-visible schemas were touched.
- `grep -rn "_scout_kwargs" src/ tests/` returns zero hits after the change; `grep -rn "_output_schema_kwargs"` shows exactly the 4 expected call sites (definition + 3 usages).
- Full test suite passes: `pytest -q` → 185 passed.
- `ruff check` and `ruff format --diff` are clean on both changed files.

## Test plan

- [x] `pytest -q` → 185 passed
- [x] `ruff check src/yutori_mcp/server.py src/yutori_mcp/adapter.py` → clean
- [x] `ruff format --diff` → clean on both changed files
- [x] `grep -rn "_scout_kwargs" src/ tests/` → no hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SDA8FqYaZMJ3SbAyYDKJqu)_