### PR TITLE
refactor(server): extract shared list/get-task-result tool descriptions

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -77,6 +77,32 @@ _IDEMPOTENT = ToolAnnotations(idempotentHint=True)
 _DESTRUCTIVE = ToolAnnotations(destructiveHint=True)
 
 
+def _list_tasks_description(task_label: str, get_tool: str) -> str:
+    """Build the shared list_*_tasks tool description.
+
+    list_browsing_tasks and list_research_tasks share identical boilerplate
+    describing pagination/status filtering and pointing at the matching
+    get_*_task_result tool for authoritative status; only the task label and
+    get-tool name differ. Mirrors the ``_output_fields_description`` helper
+    in schemas.py, which extracts the same kind of repeated tool-facing prose.
+    """
+    return (
+        f"List one-time {task_label} tasks for the authenticated user. "
+        "Supports cursor pagination and status filtering. List status is approximate "
+        f"(running also covers queued and not-yet-reconciled tasks); call "
+        f"{get_tool} for a task's authoritative status."
+    )
+
+
+def _get_task_result_description(task_label: str) -> str:
+    """Build the shared get_*_task_result tool description.
+
+    get_browsing_task_result and get_research_task_result share identical
+    text apart from the task label.
+    """
+    return f"Poll for {task_label} task status and result. Call until status is 'succeeded' or 'failed'."
+
+
 @mcp.tool(
     description=(
         "Get API usage statistics including active scout counts, rate limits, and activity metrics."
@@ -197,12 +223,7 @@ async def run_browsing_task(
 
 
 @mcp.tool(
-    description=(
-        "List one-time browsing tasks for the authenticated user. "
-        "Supports cursor pagination and status filtering. List status is approximate "
-        "(running also covers queued and not-yet-reconciled tasks); call "
-        "get_browsing_task_result for a task's authoritative status."
-    ),
+    description=_list_tasks_description("browsing", "get_browsing_task_result"),
     annotations=_READ_ONLY,
 )
 async def list_browsing_tasks(
@@ -214,7 +235,7 @@ async def list_browsing_tasks(
 
 
 @mcp.tool(
-    description="Poll for browsing task status and result. Call until status is 'succeeded' or 'failed'.",
+    description=_get_task_result_description("browsing"),
     annotations=_READ_ONLY,
 )
 async def get_browsing_task_result(task_id: str) -> str:
@@ -240,12 +261,7 @@ async def run_research_task(
 
 
 @mcp.tool(
-    description=(
-        "List one-time research tasks for the authenticated user. "
-        "Supports cursor pagination and status filtering. List status is approximate "
-        "(running also covers queued and not-yet-reconciled tasks); call "
-        "get_research_task_result for a task's authoritative status."
-    ),
+    description=_list_tasks_description("research", "get_research_task_result"),
     annotations=_READ_ONLY,
 )
 async def list_research_tasks(
@@ -257,7 +273,7 @@ async def list_research_tasks(
 
 
 @mcp.tool(
-    description="Poll for research task status and result. Call until status is 'succeeded' or 'failed'.",
+    description=_get_task_result_description("research"),
     annotations=_READ_ONLY,
 )
 async def get_research_task_result(task_id: str) -> str:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -11,7 +11,13 @@ from yutori_mcp import __version__
 from yutori_mcp.adapter import YutoriAPIError
 from yutori_mcp.formatters import format_scout_edited
 from yutori_mcp.schema_utils import output_fields_to_output_schema
-from yutori_mcp.server import _handle_edit_scout, main, mcp
+from yutori_mcp.server import (
+    _get_task_result_description,
+    _handle_edit_scout,
+    _list_tasks_description,
+    main,
+    mcp,
+)
 
 
 class TestOutputFieldsToOutputSchema:
@@ -56,6 +62,45 @@ class TestOutputFieldsToOutputSchema:
         """Array items are always objects."""
         result = output_fields_to_output_schema(["field1"])
         assert result["items"]["type"] == "object"
+
+
+class TestTaskDescriptionHelpers:
+    """`_list_tasks_description`/`_get_task_result_description` are extracted
+    so the browsing and research tool descriptions cannot drift out of sync
+    with each other (mirrors `_output_fields_description` in schemas.py)."""
+
+    def test_list_tasks_description_substitutes_label_and_get_tool(self):
+        result = _list_tasks_description("browsing", "get_browsing_task_result")
+        assert result == (
+            "List one-time browsing tasks for the authenticated user. "
+            "Supports cursor pagination and status filtering. List status is approximate "
+            "(running also covers queued and not-yet-reconciled tasks); call "
+            "get_browsing_task_result for a task's authoritative status."
+        )
+
+    def test_get_task_result_description_substitutes_label(self):
+        result = _get_task_result_description("research")
+        assert (
+            result
+            == "Poll for research task status and result. Call until status is 'succeeded' or 'failed'."
+        )
+
+    async def test_registered_tool_descriptions_match_helpers(self):
+        """Drift guard: the live tool registry must use these helpers, not
+        hand-written duplicates that could diverge from the browsing variant."""
+        tools = {t.name: t.description for t in await mcp.list_tools()}
+        assert tools["list_browsing_tasks"] == _list_tasks_description(
+            "browsing", "get_browsing_task_result"
+        )
+        assert tools["list_research_tasks"] == _list_tasks_description(
+            "research", "get_research_task_result"
+        )
+        assert tools["get_browsing_task_result"] == _get_task_result_description(
+            "browsing"
+        )
+        assert tools["get_research_task_result"] == _get_task_result_description(
+            "research"
+        )
 
 
 class TestMainStatusExitCode:


### PR DESCRIPTION
## Structural issue

`server.py` had two pairs of `@mcp.tool` description strings that were template-identical:

- `list_browsing_tasks` / `list_research_tasks` — same boilerplate about pagination/status filtering, differing only by the task label ("browsing"/"research") and the cross-referenced polling tool name.
- `get_browsing_task_result` / `get_research_task_result` — identical "Poll for ... task status and result..." text apart from the task label.

This is the same class of duplication `_output_fields_description()` was already extracted for in `schemas.py` (four input classes sharing near-identical `output_fields` prose) — it just hadn't been applied to these two tool-description pairs, so they could silently drift out of sync if one variant's wording was tweaked and the other forgotten.

## Improvement

Extracted two small helpers in `server.py`, mirroring the existing `_output_fields_description` pattern:

- `_list_tasks_description(task_label, get_tool)`
- `_get_task_result_description(task_label)`

The four `@mcp.tool(description=...)` call sites now call these helpers instead of hand-duplicating the prose.

## Why it's safe

- Pure string-template extraction — no control flow, schema, or dispatch changes.
- Verified the rendered tool descriptions are **byte-identical** before/after by calling `mcp.list_tools()` and diffing against the original literal strings.
- Added a drift-guard test (`TestTaskDescriptionHelpers` in `tests/test_server.py`) that asserts the live tool registry's descriptions match the helper output, so future edits can't silently diverge between the browsing/research variants.
- Full test suite passes: 188 passed (185 existing + 3 new).
- `ruff check` passes on the touched files; the one pre-existing `ruff format` finding in `server.py` (an unrelated line-wrap in `_make_model_kwargs_handler`) predates this change and is untouched by this diff.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01UwNGHh26ksoUEAYZxTviae)_