### PR TITLE
refactor(formatters): extract shared _format_temporal helper

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any
 
@@ -112,26 +113,44 @@ def _timestamp_to_utc(timestamp: int | float) -> datetime:
     return datetime.fromtimestamp(timestamp, tz=timezone.utc)
 
 
-def _format_date(value: str | int | float | None) -> str:
-    """Format an ISO date string or Unix timestamp (s or ms) as YYYY-MM-DD."""
+def _format_temporal(
+    value: str | int | float | None,
+    *,
+    numeric_format: str,
+    format_iso_string: Callable[[str], str],
+) -> str:
+    """Shared not-set guard and numeric/string dispatch for timestamp formatting.
+
+    ``_format_date`` and ``_format_datetime`` differ only in the strftime
+    format applied to numeric (Unix s/ms) timestamps and how an already-ISO
+    string is sliced; this centralizes the "not set" guard and the
+    numeric-vs-string branch so the two can't drift apart.
+    """
     if not value:
         return "not set"
     if isinstance(value, (int, float)):
-        return _timestamp_to_utc(value).strftime("%Y-%m-%d")
-    # Extract date portion (YYYY-MM-DD)
-    return value[:10] if len(value) >= 10 else value
+        return _timestamp_to_utc(value).strftime(numeric_format)
+    return format_iso_string(value)
+
+
+def _format_date(value: str | int | float | None) -> str:
+    """Format an ISO date string or Unix timestamp (s or ms) as YYYY-MM-DD."""
+    return _format_temporal(
+        value,
+        numeric_format="%Y-%m-%d",
+        # Extract date portion (YYYY-MM-DD)
+        format_iso_string=lambda v: v[:10] if len(v) >= 10 else v,
+    )
 
 
 def _format_datetime(timestamp: str | int | float | None) -> str:
     """Format an ISO datetime string or Unix timestamp (s or ms) as readable UTC."""
-    if not timestamp:
-        return "not set"
-    if isinstance(timestamp, (int, float)):
-        return _timestamp_to_utc(timestamp).strftime("%Y-%m-%d %H:%M UTC")
-    # Handle ISO datetime string
-    if len(timestamp) >= 16:
-        return f"{timestamp[:10]} {timestamp[11:16]} UTC"
-    return timestamp
+    return _format_temporal(
+        timestamp,
+        numeric_format="%Y-%m-%d %H:%M UTC",
+        # Handle ISO datetime string
+        format_iso_string=lambda v: f"{v[:10]} {v[11:16]} UTC" if len(v) >= 16 else v,
+    )
 
 
 def _truncate(text: str, max_len: int = 60) -> str:


### PR DESCRIPTION
## Issue

`_format_date` and `_format_datetime` in `src/yutori_mcp/formatters.py` both:
1. Return `"not set"` for a falsy input (guard clause).
2. Dispatch on `isinstance(value, (int, float))` to convert a Unix timestamp (s or ms) to UTC via `_timestamp_to_utc(...).strftime(...)`.
3. Otherwise treat the value as an already-formatted ISO string and slice it.

Steps 1 and 2 were byte-for-byte identical between the two functions, differing only in the `strftime` format string and how the ISO-string branch slices its input. That's the kind of duplication that can silently drift (e.g. one function's guard changing without the other following).

## Improvement

Extracted the shared guard + numeric/string dispatch into a new private helper, `_format_temporal(value, *, numeric_format, format_iso_string)`. Both `_format_date` and `_format_datetime` are now thin callers that supply only what's actually different: the `strftime` format for numeric input, and a small lambda for slicing the ISO-string case.

## Safety

- Both `_format_date` and `_format_datetime` keep their exact signatures and return the exact same values for every input — this is a pure structural extraction, not a logic change.
- Both functions are private (`_`-prefixed) formatting helpers internal to the MCP server's response rendering; they are not part of any published tool schema or MCP-facing behavior, so this has **no observable effect on MCP tool callers**.
- Full test suite passes unchanged (188 passed), including the existing `TestTimestampFormatting` cases in `tests/test_formatters.py` that exercise both functions with ISO strings and Unix seconds/milliseconds.
- `ruff check` and `ruff format --diff` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KT3ayfuPEBg4LxMGAwEAap

---
_Generated by [Claude Code](https://claude.ai/code/session_01KT3ayfuPEBg4LxMGAwEAap)_