### PR TITLE
refactor(formatters): reuse _format_yes_no for is_public in format_scout_detail

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -441,7 +441,7 @@ def format_scout_detail(response: dict[str, Any], **context: Any) -> str:
     lines.append(f"  Email notifications: {'disabled' if skip_email else 'enabled'}")
 
     is_public = response.get("is_public", False)
-    lines.append(f"  Public: {'yes' if is_public else 'no'}")
+    lines.append(f"  Public: {_format_yes_no(is_public)}")
 
     if response.get("user_location"):
         lines.append(f"  Location: {response['user_location']}")


### PR DESCRIPTION
## Summary

`format_scout_detail` hand-rolled `'yes' if is_public else 'no'` inline for the `is_public` field, even though `_format_yes_no` already exists in the same module and renders the exact same `is_public` field with identical `yes`/`no` wording in `_SCOUT_EDIT_FIELDS` (consumed by `format_scout_edited`'s diff view).

This consolidates the duplicate onto the shared helper so the two call sites for the same field (detail view and edit-diff view) can't silently drift apart in wording.

- No behavior change: `_format_yes_no(True)` == `"yes"` and `_format_yes_no(False)` == `"no"`, identical to the inline ternary it replaces.
- Existing test coverage (`tests/test_formatters.py`, `assert "Public: yes" in result`) already pins this exact output and continues to pass.
- Ran the full test suite: `188 passed`.
- Confirmed via `ruff check` / `ruff format --check`.

## Why it's safe

Single-file, one-line change with no new logic — purely reusing an existing, already-tested helper (`_format_yes_no`, defined at line 178 of `formatters.py`) in place of a duplicated literal. No public MCP tool schema/API surface is touched.

## Test plan

- [x] `pytest tests/` — 188 passed
- [x] `ruff check src/ tests/` — all checks passed
- [x] `ruff format --check` — already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013jdU69QZZgwyua5HtPPxzH


---
_Generated by [Claude Code](https://claude.ai/code/session_013jdU69QZZgwyua5HtPPxzH)_