### PR TITLE
refactor(server,formatters): centralize task_type literals as shared constants

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -846,13 +846,22 @@ _SCOUT_EDIT_FIELDS = (
     ("is_public", "Public", _format_yes_no),
 )
 
-# Map task_type (as stamped by the run_*_task / list_*_task handlers in
-# server.py) to its (list_tool, get_tool) names, surfaced in the user-facing
-# hints emitted by format_task_started() and format_task_list(). A single
-# table keeps the two formatters from drifting if a tool is ever renamed.
+# Canonical task_type labels stamped into the formatter context by server.py's
+# tool handlers (via _make_model_kwargs_handler / _make_run_task_handler) and
+# consumed as _TASK_TOOLS keys below. Defined once so server.py and this
+# module can't drift on the literal spelling -- a mismatch would surface as a
+# KeyError in format_task_started()/format_task_list() rather than a
+# statically-checkable typo.
+TASK_TYPE_BROWSING = "Browsing"
+TASK_TYPE_RESEARCH = "Research"
+
+# Map task_type to its (list_tool, get_tool) names, surfaced in the
+# user-facing hints emitted by format_task_started() and format_task_list().
+# A single table keeps the two formatters from drifting if a tool is ever
+# renamed.
 _TASK_TOOLS: dict[str, tuple[str, str]] = {
-    "Research": ("list_research_tasks", "get_research_task_result"),
-    "Browsing": ("list_browsing_tasks", "get_browsing_task_result"),
+    TASK_TYPE_RESEARCH: ("list_research_tasks", "get_research_task_result"),
+    TASK_TYPE_BROWSING: ("list_browsing_tasks", "get_browsing_task_result"),
 }
 
 # Tool-name -> formatter registry, referenced by format_response() above.

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel, ValidationError
 
 from . import __version__
 from .adapter import MCPClientAdapter, YutoriAPIError
-from .formatters import format_response
+from .formatters import TASK_TYPE_BROWSING, TASK_TYPE_RESEARCH, format_response
 from .schema_utils import output_fields_to_output_schema
 from .schemas import (
     BrowserChoice,
@@ -434,22 +434,22 @@ _TOOL_HANDLERS: dict[str, ToolHandler] = {
     "edit_scout": _handle_edit_scout,
     "delete_scout": _handle_delete_scout,
     "list_browsing_tasks": _make_model_kwargs_handler(
-        ListTasksInput, "list_browsing_tasks", {"task_type": "Browsing"}
+        ListTasksInput, "list_browsing_tasks", {"task_type": TASK_TYPE_BROWSING}
     ),
     "run_browsing_task": _make_run_task_handler(
-        "Browsing", BrowsingTaskInput, "run_browsing_task", include_browser=True
+        TASK_TYPE_BROWSING, BrowsingTaskInput, "run_browsing_task", include_browser=True
     ),
     "get_browsing_task_result": _make_model_kwargs_handler(
-        TaskIdInput, "get_browsing_task", {"task_type": "Browsing"}
+        TaskIdInput, "get_browsing_task", {"task_type": TASK_TYPE_BROWSING}
     ),
     "list_research_tasks": _make_model_kwargs_handler(
-        ListTasksInput, "list_research_tasks", {"task_type": "Research"}
+        ListTasksInput, "list_research_tasks", {"task_type": TASK_TYPE_RESEARCH}
     ),
     "run_research_task": _make_run_task_handler(
-        "Research", ResearchTaskInput, "run_research_task"
+        TASK_TYPE_RESEARCH, ResearchTaskInput, "run_research_task"
     ),
     "get_research_task_result": _make_model_kwargs_handler(
-        TaskIdInput, "get_research_task", {"task_type": "Research"}
+        TaskIdInput, "get_research_task", {"task_type": TASK_TYPE_RESEARCH}
     ),
 }
 


### PR DESCRIPTION
## Structural issue

`server.py` and `formatters.py` each independently hardcoded the `"Browsing"` / `"Research"` `task_type` labels:

- `server.py`'s `_TOOL_HANDLERS` registry spelled them out 4 times (as the `task_type` argument to `_make_run_task_handler` and inside the `{"task_type": ...}` context dicts passed to `_make_model_kwargs_handler`).
- `formatters.py`'s `_TASK_TOOLS` table spelled them out again as its 2 dict keys.

Nothing enforced that the two files' copies stayed spelled identically — a typo in either location (e.g. `"browsing"` vs `"Browsing"`) would not be caught until runtime, when `_TASK_TOOLS[task_type]` raises a `KeyError` inside `format_task_started()` / `format_task_list()`.

## Fix

Added `TASK_TYPE_BROWSING` / `TASK_TYPE_RESEARCH` constants in `formatters.py`, right next to the `_TASK_TOOLS` table that keys off them, and imported them into `server.py`'s `_TOOL_HANDLERS` registry in place of the repeated literals. This follows the same "define shared value once" convention already used elsewhere in this codebase (e.g. `_MIN_OUTPUT_INTERVAL_SECONDS`, `_SCOUT_ID_DESCRIPTION` in `schemas.py`, and the earlier `_TASK_TOOLS` consolidation itself in #111).

## Why it's safe

- Pure constant extraction — the string values (`"Browsing"`, `"Research"`) are unchanged, so `_TOOL_HANDLERS` and `_TASK_TOOLS` end up with byte-identical contents to before.
- No public API, tool schema, or MCP-facing behavior changes.
- Only 2 files touched, no call-site signature changes.
- Full test suite passes unchanged (188 passed) and `ruff check` is clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_014ZZ5LT8vmL6JKb4AxToAvB)_