### PR TITLE
refactor(server): route _make_model_kwargs_handler through _output_schema_kwargs

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -295,8 +295,13 @@ def _output_schema_kwargs(
     Drops None fields — callers relying on an empty result when no config
     fields were provided (e.g. _handle_edit_scout) should confirm that still
     holds — and transforms `output_fields` into the API's `output_schema`
-    format. Callers can pass `extra_exclude` to drop additional fields (e.g.
-    control fields that should not be forwarded to the adapter method).
+    format when present. This is the single kwargs-building step shared by
+    every handler factory below (``_make_model_kwargs_handler`` and
+    ``_make_run_task_handler``): input classes without an `output_fields`
+    field simply skip the transform, since `exclude={"output_fields", ...}`
+    on a model without that field is a no-op. Callers can pass
+    `extra_exclude` to drop additional fields (e.g. control fields that
+    should not be forwarded to the adapter method).
     """
     exclude = {"output_fields"} | (extra_exclude or set())
     kwargs = params.model_dump(exclude=exclude, exclude_none=True)
@@ -319,7 +324,10 @@ def _make_model_kwargs_handler(
 
     ``context`` is the formatter context stamped onto the result (e.g.
     ``{"task_type": "Browsing"}`` for the list_*_tasks tools); it defaults to
-    an empty context for tools whose formatter needs none.
+    an empty context for tools whose formatter needs none. Goes through
+    ``_output_schema_kwargs`` (like ``_make_run_task_handler`` below) so both
+    handler factories build adapter kwargs the same way; none of the input
+    classes used here define `output_fields`, so its transform is a no-op.
     """
 
     async def handler(
@@ -327,7 +335,7 @@ def _make_model_kwargs_handler(
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         params = input_class(**arguments)
         return await getattr(client, client_method)(
-            **params.model_dump(exclude_none=True)
+            **_output_schema_kwargs(params)
         ), context or {}
 
     return handler


### PR DESCRIPTION
## What

`server.py` has two handler-factory functions that both parse a Pydantic input model and forward it as adapter kwargs:

- `_make_run_task_handler` already builds kwargs via `_output_schema_kwargs(params)`.
- `_make_model_kwargs_handler` built kwargs via a separate, plain `params.model_dump(exclude_none=True)` call.

These are two different code paths for the same "convert an input model into adapter kwargs" step. This PR switches `_make_model_kwargs_handler` to use `_output_schema_kwargs` too, so there is a single kwargs-building helper shared by both handler factories.

## Why it's safe (no behavior change)

None of the input classes used by `_make_model_kwargs_handler` (`UsageInput`, `ListScoutsInput`, `ScoutIdInput`, `GetUpdatesInput`, `ListTasksInput`, `TaskIdInput`) define an `output_fields` field. `_output_schema_kwargs` excludes `"output_fields"` from `model_dump()` and only adds an `output_schema` key when `getattr(params, "output_fields", None) is not None`. For these classes:

- Excluding a field name that doesn't exist on the model is a no-op (verified directly: `Model(...).model_dump(exclude={"nonexistent_field"}, exclude_none=True)` returns the same dict as without the exclude).
- `getattr(params, "output_fields", None)` is `None`, so the `output_schema` transform never fires.

So `_output_schema_kwargs(params)` produces byte-for-byte the same kwargs dict as the old `params.model_dump(exclude_none=True)` for every caller of `_make_model_kwargs_handler`.

This is a pure internal refactor:
- No tool signatures, descriptions, or input schemas change.
- No adapter call sites change which arguments they receive.
- Full test suite (188 tests) passes unchanged.

## Why it's an improvement

Before this change, adding new shared kwargs-building behavior to `_output_schema_kwargs` (e.g. a future exclusion or transform) would silently not apply to tools built via `_make_model_kwargs_handler`, since they went through a separate code path. Now every model-based handler factory in `server.py` builds kwargs the same way, removing that drift risk — consistent with prior structural-refactor passes on this file (e.g. #113, #115, #119, #125, #126).

## Test plan

- [x] `uv run --extra dev pytest -q` — 188 passed
- [x] Verified via a standalone pydantic snippet that `model_dump(exclude={<nonexistent field>}, exclude_none=True)` is a no-op


---
_Generated by [Claude Code](https://claude.ai/code/session_01RZ1DNw8JaxcjJdMKRzSBNr)_