### PR TITLE
refactor(formatters): extract shared _showing_line pagination helper

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -180,6 +180,19 @@ def _append_more_indicator(
         lines.append(f"{indent}... and {remaining} more")
 
 
+def _showing_line(showing: int, total: int, has_more: bool) -> str:
+    """Build the shared `Showing N of M:` / `Showing all N:` pagination line.
+
+    ``format_list_scouts`` and ``format_task_list`` both render this line
+    right after their "Found ..." summary; ``format_task_list`` layers an
+    extra "matching tasks" branch (keyed off ``filtered_total``) ahead of
+    this shared has_more/else check.
+    """
+    if has_more:
+        return f"\nShowing {showing} of {total}:"
+    return f"\nShowing all {showing}:"
+
+
 def _format_yes_no(value: Any) -> str:
     """Render a boolean-ish value as ``yes``/``no`` for diff display."""
     return "yes" if value else "no"
@@ -375,10 +388,7 @@ def format_list_scouts(response: dict[str, Any], **context: Any) -> str:
 
     # Show count context
     showing = len(scouts)
-    if has_more:
-        lines.append(f"\nShowing {showing} of {total}:")
-    else:
-        lines.append(f"\nShowing all {showing}:")
+    lines.append(_showing_line(showing, total, has_more))
 
     # Format each scout
     for i, scout in enumerate(scouts, 1):
@@ -767,10 +777,8 @@ def format_task_list(response: dict[str, Any], **context: Any) -> str:
         lines.append(
             f"\nShowing {showing} of {filtered_total} matching tasks ({total} total):"
         )
-    elif has_more:
-        lines.append(f"\nShowing {showing} of {total}:")
     else:
-        lines.append(f"\nShowing all {showing}:")
+        lines.append(_showing_line(showing, total, has_more))
 
     for i, task in enumerate(tasks, 1):
         task_id = task.get("task_id", "")


### PR DESCRIPTION
## What

`format_list_scouts` and `format_task_list` in `src/yutori_mcp/formatters.py` each built the same "Showing N of M:" / "Showing all N:" pagination line via an identical `if has_more: ... else: ...` block. This extracts that block into a single `_showing_line(showing, total, has_more)` helper, used by both formatters.

`format_task_list` has one extra branch ahead of the shared logic (the `filtered_total != total` "matching tasks" case), which is preserved as-is; it now falls through to `_showing_line()` for the remaining two cases instead of duplicating them inline.

## Why

Two independent formatters carried the exact same 4-line conditional. Centralizing it means the two call sites can no longer drift on wording if one is edited without the other — the same rationale already applied to helpers like `_scout_identity_lines`, `_append_more_indicator`, and `_task_status_lines` elsewhere in this file.

## Safety

- Purely a code-structure change — no output text, tool schema, or tool behavior changes. The generated strings are byte-for-byte identical to before (helper returns the exact same f-strings previously inlined).
- Full test suite passes: `188 passed` (`uv run --active pytest tests/ -q`), including the pagination-string assertions in `tests/test_formatters.py` (`test_showing_all_when_complete`, `test_has_more_without_filter`, `test_minimal_response_without_total_or_summary`, `test_task_list_filtered_by_status`) that pin the exact "Showing ..." text for both formatters.
- Single file touched (`src/yutori_mcp/formatters.py`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01RJhLoSDB1mYyY8TF14dZa8)_