### PR TITLE
refactor(formatters): extract shared _id_url_lines helper

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -233,6 +233,20 @@ def _scout_platform_url(scout_id: str) -> str:
     return f"https://platform.yutori.com/scouting/tasks/{scout_id}"
 
 
+def _id_url_lines(scout_id: str, *, indent: str = "") -> list[str]:
+    """Build the shared `ID: ...` / `URL: ...` two-line pair, optionally indented.
+
+    Used by ``_scout_identity_lines`` (unindented, for the top-level scout
+    detail/created/edited formatters) and directly by ``format_list_scouts``
+    (indented under each numbered entry), so the two call sites can't drift
+    on the URL format.
+    """
+    return [
+        f"{indent}ID: {scout_id}",
+        f"{indent}URL: {_scout_platform_url(scout_id)}",
+    ]
+
+
 _STATUS_UNSET: Any = object()
 
 
@@ -251,14 +265,9 @@ def _scout_identity_lines(
     line entirely (e.g. the diff path of ``format_scout_edited``) simply
     don't pass ``status``.
 
-    Used by the top-level scout detail / created / edited formatters. The list-scouts
-    formatter uses its own indented variant and doesn't call this helper.
+    Used by the top-level scout detail / created / edited formatters.
     """
-    lines = [
-        f"{name_label}: {name}",
-        f"ID: {scout_id}",
-        f"URL: {_scout_platform_url(scout_id)}",
-    ]
+    lines = [f"{name_label}: {name}", *_id_url_lines(scout_id)]
     if status is not _STATUS_UNSET:
         lines.append(f"Status: {status}")
     return lines
@@ -401,8 +410,7 @@ def format_list_scouts(response: dict[str, Any], **context: Any) -> str:
 
         lines.append(f"\n{i}. {name} ({status})")
         lines.append(f'   Query: "{_truncate(query)}"')
-        lines.append(f"   ID: {scout_id}")
-        lines.append(f"   URL: {_scout_platform_url(scout_id)}")
+        lines.extend(_id_url_lines(scout_id, indent="   "))
         lines.append(f"   Runs {interval} | Next: {next_run}")
         _append_rejection_reason(lines, scout.get("rejection_reason"), indent="   ")
 


### PR DESCRIPTION
## What

`format_list_scouts` built its own indented `ID: ...` / `URL: ...` two-line pair inline, duplicating the same pair that `_scout_identity_lines` already builds (unindented) for `format_scout_detail`, `format_scout_created`, and `format_scout_edited`.

This extracts the pair into a small `_id_url_lines(scout_id, indent="")` helper and has both call sites (the existing `_scout_identity_lines` and `format_list_scouts`) use it, so the URL format can't drift between the two spellings.

## Why it's safe

- Pure internal refactor confined to `src/yutori_mcp/formatters.py` (1 file).
- No public MCP tool name, parameter, or schema changes.
- Output text is byte-identical (the new helper produces the exact same strings the inline code produced, just parameterized by `indent`).
- Full test suite passes unchanged: `188 passed`.
- Verified with `ruff check` / `ruff format --check` and `python -m py_compile`.

No functionality change, no behavior change — just removing a duplicated two-line string pattern.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V9rz68T1EuT66RbQXYKihc)_