### PR TITLE
Reject unknown tool arguments instead of silently dropping them

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -2,7 +2,7 @@
 
 All tool outputs are formatted as human-readable text optimized for LLM consumption.
 
-All tool inputs enforce validation: webhook URLs must use HTTPS, and `output_fields` (where supported) must contain at least one entry. Unknown/extra fields are silently ignored rather than rejected.
+All tool inputs enforce validation: webhook URLs must use HTTPS, and `output_fields` (where supported) must contain at least one entry. Unknown/extra fields are rejected.
 
 ## Usage
 

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -7,6 +7,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any, NoReturn
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 from pydantic import BaseModel, ValidationError
 
@@ -34,7 +35,44 @@ from .schemas import (
 
 logger = logging.getLogger(__name__)
 
-mcp = FastMCP("yutori-mcp")
+
+class _StrictArgsFastMCP(FastMCP):
+    """FastMCP that rejects tool calls containing unknown argument names.
+
+    FastMCP's own tool-call binding silently drops any argument name it
+    doesn't recognize (it disables the low-level Server's jsonschema
+    additionalProperties:false check "for backwards compatibility" - see
+    mcp.server.fastmcp.server.FastMCP._setup_handlers), which defeats the
+    extra="forbid" intent documented on schemas.ToolInput. This restores
+    that rejection at the one point that still sees the client's raw
+    argument dict, before FastMCP's own binding drops anything unknown.
+    `tool.parameters`/`_tool_manager` are undocumented FastMCP internals;
+    if a future `mcp` release renames them, fail open (skip validation)
+    rather than break the server.
+    """
+
+    async def call_tool(self, name: str, arguments: dict[str, Any]) -> Any:
+        try:
+            tool = self._tool_manager.get_tool(name)
+            unknown = (
+                set(arguments) - set(tool.parameters.get("properties", {}))
+                if tool
+                else set()
+            )
+        except AttributeError:
+            logger.warning(
+                "Could not validate tool arguments against %r; skipping strict-args check",
+                name,
+            )
+            unknown = set()
+        if unknown:
+            raise ToolError(
+                f"Unknown argument(s) for tool {name!r}: {', '.join(sorted(unknown))}"
+            )
+        return await super().call_tool(name, arguments)
+
+
+mcp = _StrictArgsFastMCP("yutori-mcp")
 
 
 async def _invoke(tool_name: str, args: dict[str, Any]) -> str:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -310,12 +310,21 @@ class TestCallToolErrorContract:
         assert result.root.isError is False
         assert "Found 0 research tasks" in result.root.content[0].text
 
-    async def test_unknown_argument_silently_accepted(self):
-        # FastMCP extracts only known parameters from the request, silently
-        # dropping unknown arguments. Unlike the old Server-based implementation
-        # (which enforced additionalProperties:false via jsonschema), FastMCP
-        # does not reject extra arguments at the protocol level. The call
-        # succeeds with the known arguments applied and the extra ignored.
+    async def test_unknown_argument_rejected(self):
+        # FastMCP itself extracts only known parameters from the request,
+        # silently dropping unknown ones. _StrictArgsFastMCP.call_tool
+        # restores the old Server-based additionalProperties:false-style
+        # rejection by checking the raw argument dict before FastMCP's own
+        # binding drops anything unrecognized.
+        handler = _call_tool_handler()
+        with _patched_adapter() as client:
+            result = await handler(_call_tool_request("list_scouts", {"bogus": 1}))
+
+        client.list_scouts.assert_not_awaited()
+        assert result.root.isError is True
+        assert "bogus" in result.root.content[0].text
+
+    async def test_known_arguments_still_accepted(self):
         handler = _call_tool_handler()
         with _patched_adapter() as client:
             client.list_scouts.return_value = {
@@ -323,7 +332,7 @@ class TestCallToolErrorContract:
                 "total": 0,
                 "summary": {"active": 0, "paused": 0, "done": 0},
             }
-            result = await handler(_call_tool_request("list_scouts", {"bogus": 1}))
+            result = await handler(_call_tool_request("list_scouts", {"limit": 5}))
 
         assert result.root.isError is False
 


### PR DESCRIPTION
## What

FastMCP's tool-call binding explicitly disables the low-level `Server`'s jsonschema `additionalProperties:false` check ("for backwards compatibility" — see `mcp.server.fastmcp.server.FastMCP._setup_handlers`) and only binds the parameter names it recognizes from the function signature, silently dropping everything else. This defeats the `extra="forbid"` intent already documented on `schemas.ToolInput` ("Forbids unknown fields so a misspelled or unsupported argument fails with a clear validation error instead of being silently dropped") — for the MCP transport path specifically, a misspelled or hallucinated argument name from an LLM caller was silently ignored rather than failing loudly. `tests/test_server.py::test_unknown_argument_silently_accepted` pinned this as known, undesired behavior.

## The fix

`_StrictArgsFastMCP(FastMCP)` overrides `call_tool()` to diff the client's raw argument dict against the tool's published parameter schema (`tool.parameters["properties"]` — the same JSON Schema already sent to clients as the tool's `inputSchema`) *before* FastMCP's own binding silently drops anything unrecognized, raising `ToolError` on a mismatch.

**Why this is safe:**
- `ToolError` propagates through the existing `except Exception` in the low-level handler, producing `CallToolResult(isError=True, ...)` — the exact contract already pinned by `TestCallToolErrorContract`, so no new error shape.
- Every currently-passing call only sends known keys, so `unknown` is empty for all of them — zero behavior change for well-formed calls.
- Relies on two undocumented FastMCP internals (`_tool_manager`, `Tool.parameters`); guarded with `try/except AttributeError` that logs a warning and skips validation rather than crashing if a future `mcp` release renames them.
- Flipped the test that pinned the old (undesired) behavior to pin the new one, and added a sibling test confirming known arguments still work. Updated `TOOLS.md`, which had been deliberately edited to *document* the bug — that line is reverted to describe the intended (and now actual) behavior.
- Full test suite: 189/189 pass. `ruff check` / `ruff format --check` pass.

Found and implemented by the hourly automated structural-refactor job.

## Test plan
- [x] `pytest tests/` — 189/189 pass
- [x] `ruff check` / `ruff format --check` pass
- [x] `test_unknown_argument_rejected` confirms an unknown key now returns `isError=True` mentioning the bad key, and the underlying adapter method is never called
- [x] `test_known_arguments_still_accepted` confirms a call with only known keys still succeeds unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_019pL81nTEpijvLYc56HYWyX)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior change only for malformed tool calls with extra keys; valid calls and existing error contracts are unchanged, with fail-open fallback if FastMCP internals change.
> 
> **Overview**
> **FastMCP** was stripping unrecognized tool argument names before handlers ran, so misspelled or hallucinated keys from LLM callers never surfaced as errors despite **`extra="forbid"`** on input schemas.
> 
> The server now uses **`_StrictArgsFastMCP`**, which overrides **`call_tool`** to compare the raw argument dict against each tool’s published parameter **`properties`** and raises **`ToolError`** for unknown keys before FastMCP’s binding drops them. Well-formed calls are unchanged; if undocumented FastMCP internals move in a future release, validation **fails open** with a warning rather than crashing.
> 
> **`TOOLS.md`** now states that unknown/extra fields are **rejected**. Tests assert unknown args return **`isError=True`** without calling the adapter, and that valid args still succeed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ebb4728b1b7a091b50ea968c0eac86101421a02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->