### PR TITLE
Extract shared output_fields Field() helper in schemas.py

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 from urllib.parse import urlparse
 
 from pydantic import AfterValidator, BaseModel, ConfigDict, Field, model_validator
@@ -78,6 +78,21 @@ def _output_fields_description(example: list[str], docs_slug: str | None = None)
     return base + f" (see example at: https://docs.yutori.com/reference/{docs_slug})."
 
 
+def _output_fields_field(example: list[str], docs_slug: str | None = None) -> Any:
+    """Build the shared `output_fields` Field (text from `_output_fields_description`).
+
+    Four input schemas repeat the identical `Field(default=None, min_length=1, ...)`
+    shape for `output_fields`; only the example names and docs slug differ. Keeping
+    the Field construction here too (not just the description text) means the
+    `min_length=1` constraint cannot drift out of sync across the four schemas.
+    """
+    return Field(
+        default=None,
+        min_length=1,
+        description=_output_fields_description(example, docs_slug),
+    )
+
+
 class UsageInput(ToolInput):
     """Input for retrieving API usage statistics."""
 
@@ -125,13 +140,9 @@ class CreateScoutInput(ToolInput):
         default=None,
         description=_WEBHOOK_FORMAT_DESCRIPTION,
     )
-    output_fields: list[str] | None = Field(
-        default=None,
-        min_length=1,
-        description=_output_fields_description(
-            ["headline", "summary", "url"],
-            docs_slug="scouts-create#using-scheduling-webhooks-and-a-structured-output-schema",
-        ),
+    output_fields: list[str] | None = _output_fields_field(
+        ["headline", "summary", "url"],
+        docs_slug="scouts-create#using-scheduling-webhooks-and-a-structured-output-schema",
     )
     user_timezone: str | None = Field(
         default=None,
@@ -185,10 +196,8 @@ class EditScoutInput(ToolInput):
         default=None,
         description=_WEBHOOK_FORMAT_DESCRIPTION,
     )
-    output_fields: list[str] | None = Field(
-        default=None,
-        min_length=1,
-        description=_output_fields_description(["headline", "summary", "url"]),
+    output_fields: list[str] | None = _output_fields_field(
+        ["headline", "summary", "url"]
     )
     skip_email: bool | None = Field(
         default=None,
@@ -317,13 +326,9 @@ class BrowsingTaskInput(ToolInput):
             "Requires the desktop app to be running."
         ),
     )
-    output_fields: list[str] | None = Field(
-        default=None,
-        min_length=1,
-        description=_output_fields_description(
-            ["name", "title", "email"],
-            docs_slug="browsing-create#using-webhooks-and-a-structured-output-schema",
-        ),
+    output_fields: list[str] | None = _output_fields_field(
+        ["name", "title", "email"],
+        docs_slug="browsing-create#using-webhooks-and-a-structured-output-schema",
     )
     webhook_url: HttpsWebhookUrl = Field(
         default=None,
@@ -369,13 +374,9 @@ class ResearchTaskInput(ToolInput):
         default=None,
         description="Location for contextual awareness. Format: 'city, region, country'. Default: 'San Francisco, CA, US'",
     )
-    output_fields: list[str] | None = Field(
-        default=None,
-        min_length=1,
-        description=_output_fields_description(
-            ["title", "summary", "source_url"],
-            docs_slug="research-create#using-webhooks-and-a-structured-output-schema",
-        ),
+    output_fields: list[str] | None = _output_fields_field(
+        ["title", "summary", "source_url"],
+        docs_slug="research-create#using-webhooks-and-a-structured-output-schema",
     )
     webhook_url: HttpsWebhookUrl = Field(
         default=None,


### PR DESCRIPTION
## Summary
- `CreateScoutInput`, `EditScoutInput`, `BrowsingTaskInput`, and `ResearchTaskInput` each repeated the identical `Field(default=None, min_length=1, description=...)` shape for `output_fields`, differing only in the example names / docs slug passed to the already-shared `_output_fields_description()`.
- Adds `_output_fields_field(example, docs_slug=None)` so the `min_length=1` constraint (and the rest of the `Field` shape) can't silently drift out of sync across the four schemas the way the description text already couldn't, after a prior pass extracted `_output_fields_description()`.
- No behavior/schema change — the four call sites produce identical `FieldInfo` objects before and after.

## Why this is safe
- Pure structural extraction; no new imports beyond `typing.Any` for the return type.
- `tests/test_schemas.py` already directly covers this: `test_empty_output_fields_rejected` (asserts `min_length=1` still rejects `[]` on all 4 classes) and the description-parity assertions. Full suite (189 tests) passes unchanged.

## Test plan
- [x] `pytest tests/` — 189 passed
- [x] `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01QP5hSv5J2v2noroqRJzPGA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with identical Field metadata; validation behavior is unchanged and already covered by schema tests.
> 
> **Overview**
> Introduces **`_output_fields_field(example, docs_slug=None)`** in `schemas.py` so the shared **`output_fields`** Pydantic **`Field`** shape (`default=None`, **`min_length=1`**, description from **`_output_fields_description`**) is defined once instead of duplicated at four call sites.
> 
> **`CreateScoutInput`**, **`EditScoutInput`**, **`BrowsingTaskInput`**, and **`ResearchTaskInput`** now assign **`output_fields`** via that helper, with the same per-tool example field names and optional docs slug as before. Adds **`typing.Any`** for the helper’s return type only.
> 
> No intended validation or schema behavior change; existing tests (e.g. empty **`output_fields`** rejection across all four classes) still cover parity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b07e3b7a44041d62f837cdb143680b0040a4913. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->