### PR TITLE
refactor(schemas): extract shared _limit_field pagination Field helper

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -93,6 +93,21 @@ def _output_fields_field(example: list[str], docs_slug: str | None = None) -> An
     )
 
 
+def _limit_field(noun: str, *, default: int | None = 10) -> Any:
+    """Build the shared pagination `limit` Field (1-100, optional "Default: N" suffix).
+
+    ListScoutsInput, ListTasksInput, and GetUpdatesInput each repeat the same
+    `Field(..., ge=1, le=100, description="Maximum number of {noun} to return
+    (1-100)...")` shape; only the noun and whether a client-side default is
+    advertised differ. Centralizing the `ge=1`/`le=100` bounds here means they
+    cannot drift apart across the three schemas.
+    """
+    description = f"Maximum number of {noun} to return (1-100)"
+    if default is not None:
+        description += f". Default: {default}"
+    return Field(default=default, ge=1, le=100, description=description)
+
+
 class UsageInput(ToolInput):
     """Input for retrieving API usage statistics."""
 
@@ -233,12 +248,7 @@ class ScoutIdInput(ToolInput):
 class ListScoutsInput(ToolInput):
     """Input for listing scouts with optional limit and filtering."""
 
-    limit: int | None = Field(
-        default=10,
-        ge=1,
-        le=100,
-        description="Maximum number of scouts to return (1-100). Default: 10",
-    )
+    limit: int | None = _limit_field("scouts")
     status: ScoutStatus = Field(
         default=None,
         description="Filter by status: 'active', 'paused', or 'done'",
@@ -252,12 +262,7 @@ class ListScoutsInput(ToolInput):
 class ListTasksInput(ToolInput):
     """Input for listing one-time browsing or research tasks."""
 
-    limit: int | None = Field(
-        default=10,
-        ge=1,
-        le=100,
-        description="Maximum number of tasks to return (1-100). Default: 10",
-    )
+    limit: int | None = _limit_field("tasks")
     status: TaskListStatus = Field(
         default=None,
         description="Filter by status: 'running', 'succeeded', or 'failed'",
@@ -276,12 +281,7 @@ class GetUpdatesInput(ToolInput):
         default=None,
         description="Pagination cursor from a previous response",
     )
-    limit: int | None = Field(
-        default=None,
-        ge=1,
-        le=100,
-        description="Maximum number of updates to return (1-100)",
-    )
+    limit: int | None = _limit_field("updates", default=None)
 
 
 class BrowsingTaskInput(ToolInput):


### PR DESCRIPTION
## Issue

`ListScoutsInput.limit`, `ListTasksInput.limit`, and `GetUpdatesInput.limit` in `src/yutori_mcp/schemas.py` each repeated the identical `Field(..., ge=1, le=100, description="Maximum number of X to return (1-100)...")` shape, differing only in the noun ("scouts"/"tasks"/"updates") and whether a client-side default of 10 is advertised in the description.

## Improvement

Extracted a `_limit_field(noun, *, default=10)` helper that builds this Field, so the `ge=1`/`le=100` bounds and the description wording can't drift apart across the three schemas as new list-style tools are added. This mirrors the existing `_output_fields_field`/`_output_fields_description` helper pattern already used in the same file for the `output_fields` Field.

## Safety justification

- Pure extraction, single file changed (`src/yutori_mcp/schemas.py`), no behavior change.
- Verified the generated `description` and `default` for all three fields are byte-identical to what was there before:
  - `ListScoutsInput.limit`: `"Maximum number of scouts to return (1-100). Default: 10"`, default `10`
  - `ListTasksInput.limit`: `"Maximum number of tasks to return (1-100). Default: 10"`, default `10`
  - `GetUpdatesInput.limit`: `"Maximum number of updates to return (1-100)"`, default `None`
- Full test suite passes unchanged: 189 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PFgxKQh2rGG7qQA9aHXPqs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file schema refactor with identical Field metadata; no runtime or API behavior intended to change.
> 
> **Overview**
> Adds **`_limit_field(noun, *, default=10)`** in `schemas.py` to build the shared paginated **`limit`** Pydantic field (`ge=1`, `le=100`, noun-specific description, optional “Default: N” in the text).
> 
> **`ListScoutsInput`**, **`ListTasksInput`**, and **`GetUpdatesInput`** now use that helper instead of inline **`Field(...)`** definitions; **`GetUpdatesInput`** still passes **`default=None`** so its description omits a default line, matching prior behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd9d7001ce789a7103ad17968c3ca64a0e356264. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->