### PR TITLE
refactor(server): reuse _make_handler for delete_scout

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -430,14 +430,6 @@ async def _handle_edit_scout(
     return {"old": old_scout, "new": new_scout}, {}
 
 
-async def _handle_delete_scout(
-    client: MCPClientAdapter, arguments: dict[str, Any]
-) -> tuple[dict[str, Any], dict[str, Any]]:
-    params = ScoutIdInput(**arguments)
-    result = await client.delete_scout(params.scout_id)
-    return result, {"scout_id": params.scout_id}
-
-
 # Tool-name -> handler registry, consulted by _invoke() above. Mirrors
 # the _TOOL_FORMATTERS registry in formatters.py so the parse/dispatch side
 # of the MCP tool lifecycle is structured the same way as the format side.
@@ -448,7 +440,11 @@ _TOOL_HANDLERS: dict[str, ToolHandler] = {
     "get_scout_updates": _make_handler(GetUpdatesInput, "get_scout_updates"),
     "create_scout": _make_handler(CreateScoutInput, "create_scout"),
     "edit_scout": _handle_edit_scout,
-    "delete_scout": _handle_delete_scout,
+    "delete_scout": _make_handler(
+        ScoutIdInput,
+        "delete_scout",
+        lambda params: {"scout_id": params.scout_id},  # type: ignore[attr-defined]
+    ),
     "list_browsing_tasks": _make_handler(
         ListTasksInput, "list_browsing_tasks", {"task_type": TASK_TYPE_BROWSING}
     ),

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -310,6 +310,19 @@ class TestCallToolErrorContract:
         assert result.root.isError is False
         assert "Found 0 research tasks" in result.root.content[0].text
 
+    async def test_delete_scout_dispatches_with_scout_id(self):
+        handler = _call_tool_handler()
+        with _patched_adapter() as client:
+            client.delete_scout.return_value = {}
+            result = await handler(
+                _call_tool_request("delete_scout", {"scout_id": "scout-1"})
+            )
+
+        client.delete_scout.assert_awaited_once_with(scout_id="scout-1")
+        assert result.root.isError is False
+        assert "Scout deleted" in result.root.content[0].text
+        assert "scout-1" in result.root.content[0].text
+
     async def test_unknown_argument_rejected(self):
         # FastMCP itself extracts only known parameters from the request,
         # silently dropping unknown ones. _StrictArgsFastMCP.call_tool


### PR DESCRIPTION
## Summary
- `_handle_delete_scout` in `src/yutori_mcp/server.py` was a hand-written tool handler with exactly the shape `_make_handler` already generalizes for every other simple tool: parse the input schema, forward it as adapter kwargs via `_output_schema_kwargs`, and stamp a formatter context.
- `ScoutIdInput` has no `output_fields` field, so `_output_schema_kwargs()` dumps it to `{"scout_id": ...}` unchanged, and `client.delete_scout(**kwargs)` is identical to the old `client.delete_scout(params.scout_id)` positional call — no behavior change.
- Replaced it with `_make_handler(ScoutIdInput, "delete_scout", lambda params: {"scout_id": params.scout_id})`, removing a redundant one-off function and matching the pattern already used by `get_scout_detail` and the rest of `_TOOL_HANDLERS` (this is the same shape `_make_handler` was generalized to support in #131).
- Added `test_delete_scout_dispatches_with_scout_id` in `tests/test_server.py`, since no existing test exercised `delete_scout` at the tool-dispatch level — it pins the exact kwargs passed to the adapter and the formatted response.

## Test plan
- [x] `uv run --extra dev pytest -q` — 190 passed (189 existing + 1 new)
- [x] `ruff check src/ tests/test_server.py` and `ruff format --check src/ tests/test_server.py` — clean (an unrelated pre-existing formatting nit in `tests/test_formatters.py` is untouched by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Un4TpnaZ6dwuh7Ki2BwV2S


---
_Generated by [Claude Code](https://claude.ai/code/session_01Un4TpnaZ6dwuh7Ki2BwV2S)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with equivalent adapter kwargs and formatter context; new test locks behavior.
> 
> **Overview**
> **`delete_scout`** no longer uses a bespoke `_handle_delete_scout`; it is wired through the same **`_make_handler`** factory as other simple tools, with a small lambda supplying **`scout_id`** for the delete confirmation formatter.
> 
> Adds **`test_delete_scout_dispatches_with_scout_id`** so tool-level dispatch asserts **`delete_scout(scout_id=...)`** on the adapter and the expected success text—there was no prior end-to-end test for this tool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1c517cd5b294e48b83d14039e85b1478a9d98b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->