### PR TITLE
docs(schemas): fix stale ToolInput docstring post-_StrictArgsFastMCP

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -25,8 +25,11 @@ class ToolInput(BaseModel):
     """Base class for all tool input schemas.
 
     ``extra="forbid"`` guards direct model instantiation (in handler factories
-    and tests). FastMCP strips unknown fields at the protocol level before they
-    reach handlers, so the schema constraint is not enforced at runtime there.
+    and tests). FastMCP's own tool-call binding would otherwise silently drop
+    unknown fields at the protocol level before they reach handlers, but
+    ``server._StrictArgsFastMCP`` restores that rejection at the point that
+    still sees the client's raw argument dict, so the constraint is enforced
+    at runtime there too.
     """
 
     model_config = ConfigDict(extra="forbid")


### PR DESCRIPTION
## Summary

While reviewing the last 24h of merged commits (#134, #135, both small and clean — no leftover duplication found), I re-checked a known follow-up already flagged in the sibling monorepo's `.claude/REFACTOR.md` backlog: `schemas.py`'s `ToolInput` docstring is stale after PR #132.

PR #132 added `server._StrictArgsFastMCP`, which rejects unknown tool-call arguments before FastMCP's own binding can silently drop them — this **restores** enforcement of `ToolInput`'s `extra="forbid"` constraint at runtime. The docstring still said the opposite: "FastMCP strips unknown fields at the protocol level before they reach handlers, so the schema constraint is not enforced at runtime there." That sentence was accurate before #132 but not after.

## Change

- `src/yutori_mcp/schemas.py`: updated `ToolInput`'s docstring to describe `_StrictArgsFastMCP`'s role instead of the outdated claim.

Documentation-only, no behavior/test implications.

## Test plan

- [x] `python -m py_compile` passes
- [x] Confirmed the module imports and the docstring resolves correctly
- [ ] CI — pending, no local Python env with project deps installed in this sandbox


---
_Generated by [Claude Code](https://claude.ai/code/session_01UogpgiegcgnynNU3fGBhfH)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change in `schemas.py` with no runtime or test impact.
> 
> **Overview**
> Updates the **`ToolInput`** class docstring in `schemas.py` so it matches current MCP tool-call behavior after **`_StrictArgsFastMCP`**.
> 
> The old text said FastMCP strips unknown fields and that **`extra="forbid"`** is not enforced at runtime on tool calls. The docstring now explains that FastMCP would still drop unknown args on its own, but **`server._StrictArgsFastMCP`** rejects them from the raw client argument dict, so the forbid-extra rule applies in production tool calls as well as in direct model instantiation and tests.
> 
> **Documentation only** — no schema, server, or test changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b7c54665b233c8480645823337603c4c76c7da7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->