### PR TITLE
Extract _assert_main_exits() helper in test_server.py

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -103,6 +103,12 @@ class TestTaskDescriptionHelpers:
         )
 
 
+def _assert_main_exits(expected_code: int) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == expected_code
+
+
 class TestMainStatusExitCode:
     """Ensure `yutori-mcp status` exits 1 when unauthenticated, 0 when authenticated."""
 
@@ -112,9 +118,7 @@ class TestMainStatusExitCode:
             patch("sys.argv", ["yutori-mcp", "status"]),
             patch("yutori.auth.get_auth_status", return_value=status),
         ):
-            with pytest.raises(SystemExit) as exc_info:
-                main()
-            assert exc_info.value.code == 1
+            _assert_main_exits(1)
 
     def test_status_authenticated_exits_0(self):
         status = AuthStatus(
@@ -127,9 +131,7 @@ class TestMainStatusExitCode:
             patch("sys.argv", ["yutori-mcp", "status"]),
             patch("yutori.auth.get_auth_status", return_value=status),
         ):
-            with pytest.raises(SystemExit) as exc_info:
-                main()
-            assert exc_info.value.code == 0
+            _assert_main_exits(0)
 
 
 class TestMainLoginAuthUrl:
@@ -147,9 +149,7 @@ class TestMainLoginAuthUrl:
                 "yutori.auth.run_login_flow", return_value=result
             ) as mock_run_login_flow,
         ):
-            with pytest.raises(SystemExit) as exc_info:
-                main()
-            assert exc_info.value.code == 1
+            _assert_main_exits(1)
         mock_run_login_flow.assert_called_once_with(key_source="yutori-mcp")
         output = capsys.readouterr().out
         assert "https://clerk.example.com/oauth/authorize?x=1" in output
@@ -162,9 +162,7 @@ class TestMainLoginAuthUrl:
                 "yutori.auth.run_login_flow", return_value=result
             ) as mock_run_login_flow,
         ):
-            with pytest.raises(SystemExit) as exc_info:
-                main()
-            assert exc_info.value.code == 1
+            _assert_main_exits(1)
         mock_run_login_flow.assert_called_once_with(key_source="yutori-mcp")
         output = capsys.readouterr().out
         assert "browser" not in output.lower()
@@ -175,9 +173,7 @@ class TestMainVersionFlag:
 
     def test_version_flag_prints_version(self, capsys):
         with patch("sys.argv", ["yutori-mcp", "--version"]):
-            with pytest.raises(SystemExit) as exc_info:
-                main()
-            assert exc_info.value.code == 0
+            _assert_main_exits(0)
         output = capsys.readouterr().out.strip()
         assert output == f"yutori-mcp {__version__}"
 


### PR DESCRIPTION
## What

`TestMainStatusExitCode`, `TestMainLoginAuthUrl`, and `TestMainVersionFlag` in `tests/test_server.py` each repeated the identical 3-line assertion block 5 times:

```python
with pytest.raises(SystemExit) as exc_info:
    main()
assert exc_info.value.code == N
```

differing only in the expected exit code. Extracted a module-level `_assert_main_exits(expected_code: int) -> None` helper; all five call sites now delegate to it. Surrounding `patch(...)` context managers, mocks, and post-assertions are untouched.

## Why it's an improvement

Removes repeated assertion boilerplate from `main()`'s CLI exit-code tests; a future change to how `SystemExit` is asserted only needs to happen in one place.

## Why it's safe

- Test-only change, single file.
- Full suite: 190 passed before and after (same count, same test names/outcomes).
- `ruff check`/`ruff format --check` pass.

🤖 Generated as part of the automated hourly refactor job.


---
_Generated by [Claude Code](https://claude.ai/code/session_019Ft2ssZA4sBUSGmGCMGz4k)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tests-only deduplication with no production code changes; behavior should be identical.
> 
> **Overview**
> **Test-only refactor** in `tests/test_server.py`: adds module-level `_assert_main_exits(expected_code)` that wraps `pytest.raises(SystemExit)` around `main()` and asserts the exit code.
> 
> Five CLI tests in `TestMainStatusExitCode`, `TestMainLoginAuthUrl`, and `TestMainVersionFlag` now call that helper instead of repeating the same three-line block. Patches, mocks, and assertions on stdout remain unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 369e8e01f508821a5eb8d8eb48f5c54b211e8e8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->