### PR TITLE
refactor(schemas): extract shared _webhook_format_field helper

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -96,6 +96,17 @@ def _output_fields_field(example: list[str], docs_slug: str | None = None) -> An
     )
 
 
+def _webhook_format_field() -> Any:
+    """Build the shared `webhook_format` Field (text from `_WEBHOOK_FORMAT_DESCRIPTION`).
+
+    CreateScoutInput, EditScoutInput, BrowsingTaskInput, and ResearchTaskInput
+    each repeat the identical `Field(default=None, description=_WEBHOOK_FORMAT_DESCRIPTION)`
+    shape for `webhook_format`. Centralizing the Field construction (not just the
+    description text) means the four call sites cannot drift apart.
+    """
+    return Field(default=None, description=_WEBHOOK_FORMAT_DESCRIPTION)
+
+
 def _limit_field(noun: str, *, default: int | None = 10) -> Any:
     """Build the shared pagination `limit` Field (1-100, optional "Default: N" suffix).
 
@@ -154,10 +165,7 @@ class CreateScoutInput(ToolInput):
             "Must use https://. Confirm the URL with the user before setting."
         ),
     )
-    webhook_format: WebhookFormat = Field(
-        default=None,
-        description=_WEBHOOK_FORMAT_DESCRIPTION,
-    )
+    webhook_format: WebhookFormat = _webhook_format_field()
     output_fields: list[str] | None = _output_fields_field(
         ["headline", "summary", "url"],
         docs_slug="scouts-create#using-scheduling-webhooks-and-a-structured-output-schema",
@@ -210,10 +218,7 @@ class EditScoutInput(ToolInput):
         default=None,
         description="Updated HTTPS webhook URL. Must use https://. Confirm the URL with the user before setting.",
     )
-    webhook_format: WebhookFormat = Field(
-        default=None,
-        description=_WEBHOOK_FORMAT_DESCRIPTION,
-    )
+    webhook_format: WebhookFormat = _webhook_format_field()
     output_fields: list[str] | None = _output_fields_field(
         ["headline", "summary", "url"]
     )
@@ -337,10 +342,7 @@ class BrowsingTaskInput(ToolInput):
         default=None,
         description="HTTPS URL to receive webhook notification when task completes. Must use https://.",
     )
-    webhook_format: WebhookFormat = Field(
-        default=None,
-        description=_WEBHOOK_FORMAT_DESCRIPTION,
-    )
+    webhook_format: WebhookFormat = _webhook_format_field()
 
 
 class TaskIdInput(ToolInput):
@@ -385,7 +387,4 @@ class ResearchTaskInput(ToolInput):
         default=None,
         description="HTTPS URL to receive webhook notification when research completes. Must use https://.",
     )
-    webhook_format: WebhookFormat = Field(
-        default=None,
-        description=_WEBHOOK_FORMAT_DESCRIPTION,
-    )
+    webhook_format: WebhookFormat = _webhook_format_field()


### PR DESCRIPTION
## What

`CreateScoutInput`, `EditScoutInput`, `BrowsingTaskInput`, and `ResearchTaskInput` in `src/yutori_mcp/schemas.py` each declared:

```python
webhook_format: WebhookFormat = Field(
    default=None,
    description=_WEBHOOK_FORMAT_DESCRIPTION,
)
```

byte-for-byte identically, four times. This adds a `_webhook_format_field()` helper (mirroring the existing `_output_fields_field()` and `_limit_field()` helpers already used for other Field shapes shared across these same four schemas) and replaces all four call sites with `webhook_format: WebhookFormat = _webhook_format_field()`.

## Why this is an improvement

- Removes exact 4x duplication of a `Field(...)` construction.
- Follows the established pattern in this file: `_output_fields_field()` and `_limit_field()` already centralize other Field shapes shared across the same set of input schemas, for the same reason (so the shape can't silently drift across call sites if it's ever changed in only one place).

## Why this is safe

- Pure extraction — the resulting `Field(default=None, description=_WEBHOOK_FORMAT_DESCRIPTION)` is identical to what was inline before at each of the 4 sites, so there is no behavior change (verified `git diff` shows only the mechanical replacement).
- Full test suite (190 tests) passes both before and after the change.
- `ruff check` and `ruff format --check` pass clean on the touched file.
- Single file touched (`src/yutori_mcp/schemas.py`), no functionality/schema/API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hh7K36RwF5W8rZjYFmhjaj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical extraction with identical Field metadata; no API or validation behavior change.
> 
> **Overview**
> Introduces **`_webhook_format_field()`** in `schemas.py` and wires **`webhook_format`** on **`CreateScoutInput`**, **`EditScoutInput`**, **`BrowsingTaskInput`**, and **`ResearchTaskInput`** through that helper instead of repeating the same inline **`Field(default=None, description=_WEBHOOK_FORMAT_DESCRIPTION)`** four times.
> 
> This matches how **`_output_fields_field()`** and **`_limit_field()`** already centralize shared Pydantic field shapes in the same file, so future tweaks to the webhook format field stay in one place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d42176dab51ccc8fa1816f549e5d21fe5b72808d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->