### PR TITLE
refactor(schemas): extract shared _webhook_url_field helper

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -107,6 +107,18 @@ def _webhook_format_field() -> Any:
     return Field(default=None, description=_WEBHOOK_FORMAT_DESCRIPTION)
 
 
+def _webhook_url_field(description: str) -> Any:
+    """Build the shared `webhook_url` Field (type is always `HttpsWebhookUrl`).
+
+    CreateScoutInput, EditScoutInput, BrowsingTaskInput, and ResearchTaskInput
+    each repeat the identical `Field(default=None, description=...)` shape for
+    `webhook_url`; only the description wording differs per call site.
+    Centralizing the Field construction means the shared `default=None` cannot
+    drift out of sync, mirroring `_webhook_format_field` above.
+    """
+    return Field(default=None, description=description)
+
+
 def _limit_field(noun: str, *, default: int | None = 10) -> Any:
     """Build the shared pagination `limit` Field (1-100, optional "Default: N" suffix).
 
@@ -158,12 +170,9 @@ class CreateScoutInput(ToolInput):
             "(30 minutes). Default: 86400 (daily)"
         ),
     )
-    webhook_url: HttpsWebhookUrl = Field(
-        default=None,
-        description=(
-            "HTTPS URL to receive webhook notifications when updates are available. "
-            "Must use https://. Confirm the URL with the user before setting."
-        ),
+    webhook_url: HttpsWebhookUrl = _webhook_url_field(
+        "HTTPS URL to receive webhook notifications when updates are available. "
+        "Must use https://. Confirm the URL with the user before setting."
     )
     webhook_format: WebhookFormat = _webhook_format_field()
     output_fields: list[str] | None = _output_fields_field(
@@ -214,9 +223,8 @@ class EditScoutInput(ToolInput):
             f"Updated run interval in seconds. Minimum {_MIN_OUTPUT_INTERVAL_SECONDS} (30 minutes)"
         ),
     )
-    webhook_url: HttpsWebhookUrl = Field(
-        default=None,
-        description="Updated HTTPS webhook URL. Must use https://. Confirm the URL with the user before setting.",
+    webhook_url: HttpsWebhookUrl = _webhook_url_field(
+        "Updated HTTPS webhook URL. Must use https://. Confirm the URL with the user before setting."
     )
     webhook_format: WebhookFormat = _webhook_format_field()
     output_fields: list[str] | None = _output_fields_field(
@@ -338,9 +346,8 @@ class BrowsingTaskInput(ToolInput):
         ["name", "title", "email"],
         docs_slug="browsing-create#using-webhooks-and-a-structured-output-schema",
     )
-    webhook_url: HttpsWebhookUrl = Field(
-        default=None,
-        description="HTTPS URL to receive webhook notification when task completes. Must use https://.",
+    webhook_url: HttpsWebhookUrl = _webhook_url_field(
+        "HTTPS URL to receive webhook notification when task completes. Must use https://."
     )
     webhook_format: WebhookFormat = _webhook_format_field()
 
@@ -383,8 +390,7 @@ class ResearchTaskInput(ToolInput):
         ["title", "summary", "source_url"],
         docs_slug="research-create#using-webhooks-and-a-structured-output-schema",
     )
-    webhook_url: HttpsWebhookUrl = Field(
-        default=None,
-        description="HTTPS URL to receive webhook notification when research completes. Must use https://.",
+    webhook_url: HttpsWebhookUrl = _webhook_url_field(
+        "HTTPS URL to receive webhook notification when research completes. Must use https://."
     )
     webhook_format: WebhookFormat = _webhook_format_field()


### PR DESCRIPTION
## What

`CreateScoutInput`, `EditScoutInput`, `BrowsingTaskInput`, and `ResearchTaskInput` each repeated the identical `Field(default=None, description=...)` shape for `webhook_url`, differing only in the description wording.

## Why it's an improvement

This is the direct sibling of the immediately-prior PR (#138) which consolidated the adjacent `webhook_format` field into `_webhook_format_field()` across these same four classes — `webhook_url` was left untouched. Centralizing the Field construction means the shared `default=None` (and the `HttpsWebhookUrl` type contract) can't drift out of sync across the four call sites, matching the file's existing helper conventions (`_output_fields_field`, `_limit_field`, `_webhook_format_field`).

## Why it's safe — no behavioral change

- Each call site's description text is passed through unchanged, byte-for-byte identical to before.
- Single file changed (`src/yutori_mcp/schemas.py`), 4 call sites updated.
- Verified: full test suite (`tests/test_schemas.py` + rest) — 190 passed. `ruff format` / `ruff check` — clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01JgvK61Ry3L79sAdRCZdz97)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file refactor with identical field metadata and validated tests; no API or validation behavior change.
> 
> **Overview**
> Adds **`_webhook_url_field(description)`** in `schemas.py`, following the same pattern as `_webhook_format_field`, and wires **`webhook_url`** on **CreateScoutInput**, **EditScoutInput**, **BrowsingTaskInput**, and **ResearchTaskInput** through it instead of repeating `Field(default=None, ...)`.
> 
> Per-tool **description strings are unchanged**; only the shared `default=None` construction is centralized so those four schemas stay aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 830e6ac51a61aadaa1d07a7a0a809ef8386d4648. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->