### PR TITLE
refactor(schemas): extract shared _output_interval_field helper

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -107,6 +107,18 @@ def _webhook_format_field() -> Any:
     return Field(default=None, description=_WEBHOOK_FORMAT_DESCRIPTION)
 
 
+def _output_interval_field(description: str) -> Any:
+    """Build the shared `output_interval` Field (bound is always `_MIN_OUTPUT_INTERVAL_SECONDS`).
+
+    CreateScoutInput and EditScoutInput each repeat the identical
+    `Field(default=None, ge=_MIN_OUTPUT_INTERVAL_SECONDS, description=...)` shape;
+    only the description wording differs. Centralizing the Field construction
+    means the `ge=` bound cannot drift out of sync, mirroring `_webhook_url_field`
+    below.
+    """
+    return Field(default=None, ge=_MIN_OUTPUT_INTERVAL_SECONDS, description=description)
+
+
 def _webhook_url_field(description: str) -> Any:
     """Build the shared `webhook_url` Field (type is always `HttpsWebhookUrl`).
 
@@ -162,13 +174,9 @@ class CreateScoutInput(ToolInput):
             "'anytime a startup in SF announces seed funding'"
         ),
     )
-    output_interval: int | None = Field(
-        default=None,
-        ge=_MIN_OUTPUT_INTERVAL_SECONDS,
-        description=(
-            f"Seconds between scout runs. Minimum {_MIN_OUTPUT_INTERVAL_SECONDS} "
-            "(30 minutes). Default: 86400 (daily)"
-        ),
+    output_interval: int | None = _output_interval_field(
+        f"Seconds between scout runs. Minimum {_MIN_OUTPUT_INTERVAL_SECONDS} "
+        "(30 minutes). Default: 86400 (daily)"
     )
     webhook_url: HttpsWebhookUrl = _webhook_url_field(
         "HTTPS URL to receive webhook notifications when updates are available. "
@@ -216,12 +224,8 @@ class EditScoutInput(ToolInput):
         default=None,
         description="Updated monitoring query",
     )
-    output_interval: int | None = Field(
-        default=None,
-        ge=_MIN_OUTPUT_INTERVAL_SECONDS,
-        description=(
-            f"Updated run interval in seconds. Minimum {_MIN_OUTPUT_INTERVAL_SECONDS} (30 minutes)"
-        ),
+    output_interval: int | None = _output_interval_field(
+        f"Updated run interval in seconds. Minimum {_MIN_OUTPUT_INTERVAL_SECONDS} (30 minutes)"
     )
     webhook_url: HttpsWebhookUrl = _webhook_url_field(
         "Updated HTTPS webhook URL. Must use https://. Confirm the URL with the user before setting."


### PR DESCRIPTION
## What

`CreateScoutInput.output_interval` and `EditScoutInput.output_interval` in `src/yutori_mcp/schemas.py` each repeated the identical
```python
Field(default=None, ge=_MIN_OUTPUT_INTERVAL_SECONDS, description=...)
```
shape — only the description prose differed between the two call sites. This extracts a `_output_interval_field(description)` helper (mirroring the existing `_webhook_url_field`/`_webhook_format_field` helpers added in #138/#140) so the `ge=` bound can't drift out of sync between the two schemas.

## Why it's an improvement

`_MIN_OUTPUT_INTERVAL_SECONDS` was already centralized as a constant (#120), but the `Field()` construction around it was still duplicated. This closes that last gap in the same family of Field-helper extractions that already covered `output_fields` (#133), `limit` (#134), `webhook_format` (#138), and `webhook_url` (#140) — `output_interval` was the one remaining duplicate Field shape of that kind.

## Why it's safe

- Pure extraction: `default=None` and `ge=_MIN_OUTPUT_INTERVAL_SECONDS` were already byte-identical across both call sites; only the (already-parameterized) description string differs, exactly like the precedent `_webhook_url_field`.
- No behavior change — the resulting `FieldInfo` objects are equivalent to what was there before.
- `tests/test_schemas.py` exercises `output_interval` validation (default is `None`, values below the minimum raise, valid values accepted) and passes unchanged.
- Full test suite (190 tests) and `ruff check` both pass locally.

## Test plan

- [x] `uv run --extra dev pytest -q` — 190 passed
- [x] `uv run ruff check .` — all checks passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01PeSWLi6tkzNij13KKdgCX7)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only refactor with no runtime behavior change; existing `output_interval` validation tests cover the unchanged constraints.
> 
> **Overview**
> Introduces **`_output_interval_field(description)`** in `schemas.py` so **`CreateScoutInput`** and **`EditScoutInput`** no longer duplicate the same `Field(default=None, ge=_MIN_OUTPUT_INTERVAL_SECONDS, …)` block. Each schema now passes only its own description string, matching the pattern used for `_webhook_url_field` and `_webhook_format_field`.
> 
> This is a **pure extraction**: validation bounds and defaults stay the same; only call sites are simplified so the minimum interval constraint cannot drift between create and edit schemas.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f9bc2fe3aca41509e91bfd4aa3b841b0d569df4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->