### PR TITLE
refactor(schemas): extract shared _is_public_field helper

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -131,6 +131,17 @@ def _webhook_url_field(description: str) -> Any:
     return Field(default=None, description=description)
 
 
+def _is_public_field() -> Any:
+    """Build the shared `is_public` Field (text from `_IS_PUBLIC_DESCRIPTION`).
+
+    CreateScoutInput and EditScoutInput each repeat the identical
+    `Field(default=None, description=_IS_PUBLIC_DESCRIPTION)` shape for
+    `is_public`. Centralizing the Field construction mirrors
+    `_webhook_format_field` above.
+    """
+    return Field(default=None, description=_IS_PUBLIC_DESCRIPTION)
+
+
 def _limit_field(noun: str, *, default: int | None = 10) -> Any:
     """Build the shared pagination `limit` Field (1-100, optional "Default: N" suffix).
 
@@ -203,10 +214,7 @@ class CreateScoutInput(ToolInput):
         default=None,
         description="User location for geo-relevant searches. Format: 'city, region, country'",
     )
-    is_public: bool | None = Field(
-        default=None,
-        description=_IS_PUBLIC_DESCRIPTION,
-    )
+    is_public: bool | None = _is_public_field()
 
 
 class EditScoutInput(ToolInput):
@@ -246,10 +254,7 @@ class EditScoutInput(ToolInput):
         default=None,
         description="User location for geo-relevant searches",
     )
-    is_public: bool | None = Field(
-        default=None,
-        description=_IS_PUBLIC_DESCRIPTION,
-    )
+    is_public: bool | None = _is_public_field()
 
     @model_validator(mode="after")
     def validate_has_changes(self) -> "EditScoutInput":


### PR DESCRIPTION
## Summary

Daily cross-commit cleanup pass over the last 24h of merges. #139, #140, and #141 landed a sequence of Field-builder extractions in `src/yutori_mcp/schemas.py` (`_pagination_state`, `_webhook_url_field`, `_output_interval_field`), all following the existing `_webhook_format_field()` convention. Checking the same file for any remaining un-factored duplicate of that "constant + zero-arg `Field()` wrapper, shared across `CreateScoutInput`/`EditScoutInput`" shape turned up one more: `is_public`.

- `CreateScoutInput.is_public` and `EditScoutInput.is_public` both repeated the byte-identical `Field(default=None, description=_IS_PUBLIC_DESCRIPTION)`.
- Extracted `_is_public_field()` next to `_webhook_format_field()`, following the exact same shape and docstring convention.
- No behavior change — same default, same description text, at both call sites.

## Test plan

- [x] `pytest` — 190 passed
- [x] `ruff check` / `ruff format --check` on `schemas.py` — clean

cc @dhruvbatra (author of the #139/#140/#141 Field-extraction sequence this follows)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmJzepxRgVdoSSXqHRe1Wj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical schema refactor with no validation or API behavior changes.
> 
> **Overview**
> Adds **`_is_public_field()`** in `schemas.py` so **`CreateScoutInput`** and **`EditScoutInput`** no longer duplicate the same `Field(default=None, description=_IS_PUBLIC_DESCRIPTION)` for **`is_public`**, matching the existing `_webhook_format_field` pattern.
> 
> Runtime validation and MCP tool behavior are unchanged—only where the shared Field is defined.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab64b322abd1da7542f132869ae79fec6d8c8b03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->