### PR TITLE
refactor: dedup output_schema shape logic between schema_utils and formatters

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -6,6 +6,8 @@ from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any
 
+from .schema_utils import output_schema_field_names
+
 # Markers wrapping API payloads that may contain user-controlled text (scout
 # content/findings, browsing/research task results). Surfaced verbatim so the
 # downstream LLM client can distinguish remote data from MCP instructions.
@@ -228,13 +230,8 @@ def _format_output_fields_diff(value: Any) -> Any:
     than crashing or rendering as unset.
     """
     if isinstance(value, dict):
-        items = value.get("items")
-        container = items if isinstance(items, dict) else value
-        properties = container.get("properties")
-        if isinstance(properties, dict) and properties:
-            value = ", ".join(properties)
-        else:
-            value = "(custom schema)"
+        field_names = output_schema_field_names(value)
+        value = ", ".join(field_names) if field_names is not None else "(custom schema)"
     return _format_or_unset(value)
 
 

--- a/src/yutori_mcp/schema_utils.py
+++ b/src/yutori_mcp/schema_utils.py
@@ -30,3 +30,28 @@ def output_fields_to_output_schema(
             "properties": properties,
         },
     }
+
+
+def output_schema_field_names(schema: dict[str, Any]) -> list[str] | None:
+    """Extract field names from a schema shaped like ``output_fields_to_output_schema()`` produces.
+
+    Inverse of ``output_fields_to_output_schema``: accepts either the
+    array-of-objects shape it builds (properties nested under ``items``) or a
+    bare top-level object schema (properties at the top level). Returns None
+    if ``schema`` doesn't match either shape (e.g. a custom JSON Schema set
+    via the REST API directly, such as tuple-form ``items`` or an object
+    schema with no/empty ``properties``).
+
+    Args:
+        schema: A dict, typically the ``output_schema`` field of a scout.
+
+    Returns:
+        The list of field names in insertion order, or None if the shape
+        doesn't match.
+    """
+    items = schema.get("items")
+    container = items if isinstance(items, dict) else schema
+    properties = container.get("properties")
+    if isinstance(properties, dict) and properties:
+        return list(properties)
+    return None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,10 @@ from yutori.auth.types import AuthStatus, LoginResult
 from yutori_mcp import __version__
 from yutori_mcp.adapter import YutoriAPIError
 from yutori_mcp.formatters import format_scout_edited
-from yutori_mcp.schema_utils import output_fields_to_output_schema
+from yutori_mcp.schema_utils import (
+    output_fields_to_output_schema,
+    output_schema_field_names,
+)
 from yutori_mcp.server import (
     _get_task_result_description,
     _handle_edit_scout,
@@ -62,6 +65,19 @@ class TestOutputFieldsToOutputSchema:
         """Array items are always objects."""
         result = output_fields_to_output_schema(["field1"])
         assert result["items"]["type"] == "object"
+
+    def test_round_trips_through_output_schema_field_names(self):
+        """output_schema_field_names must invert output_fields_to_output_schema.
+
+        Drift guard: formatters._format_output_fields_diff renders diffs by
+        calling output_schema_field_names() on the schema this function
+        builds. If the two ever fall out of sync (e.g. this function adds a
+        `required` list or changes nesting), this test catches it instead of
+        the diff formatter silently degrading to "(custom schema)".
+        """
+        fields = ["headline", "summary", "url"]
+        schema = output_fields_to_output_schema(fields)
+        assert output_schema_field_names(schema) == fields
 
 
 class TestTaskDescriptionHelpers:


### PR DESCRIPTION
## Summary

- `output_fields_to_output_schema()` (`schema_utils.py`) and `_format_output_fields_diff()` (`formatters.py`) each independently encoded the same `output_schema` shape (array-of-objects with field names as `items.properties` keys), in opposite directions, with no shared constant or helper connecting them — unlike `_SCOUT_EDIT_FIELDS`, which already has an explicit drift-guard test in `tests/test_schemas.py`.
- Extracted a new inverse helper, `output_schema_field_names()`, next to `output_fields_to_output_schema()` in `schema_utils.py`. `_format_output_fields_diff()` now calls it instead of re-implementing the `items` → `properties` traversal inline.
- Added a round-trip test (`output_fields_to_output_schema` → `output_schema_field_names`) in `tests/test_server.py`, modeled on the existing `_SCOUT_EDIT_FIELDS` drift guard, so a future shape change (e.g. adding a `required` list or changing nesting) is caught by a failing test instead of silently degrading the diff output to `"(custom schema)"`.

## Why it's safe

- Pure extraction: the traversal logic in `_format_output_fields_diff` is unchanged, just moved.
- All existing `_format_output_fields_diff` test cases in `tests/test_formatters.py` — including the `"(custom schema)"` fallback for non-matching shapes (list-form `items`, empty `properties`) — pass unmodified with no changes to their inputs or expected outputs.
- Full test suite passes: `191 passed`.

## Test plan

- [x] `uv run --extra dev pytest -q` — 191 passed
- [x] Verified `tests/test_formatters.py::TestFormatOutputFieldsDiffShapes` and `TestFormatScoutEditedOutputFields` pass unchanged
- [x] Added `tests/test_server.py::TestOutputFieldsToOutputSchema::test_round_trips_through_output_schema_field_names`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015B9u54cvz7vM1DJtwM8DCg

---
_Generated by [Claude Code](https://claude.ai/code/session_015B9u54cvz7vM1DJtwM8DCg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor in MCP formatting utilities only; existing formatter tests cover the same outputs.
> 
> **Overview**
> **Deduplicates** the shared `output_schema` shape logic that was split between building schemas and rendering scout edit diffs.
> 
> Adds **`output_schema_field_names()`** in `schema_utils.py` as the inverse of **`output_fields_to_output_schema()`**, and **`_format_output_fields_diff()`** now calls that helper instead of inlining the `items` → `properties` walk. Non-matching custom schemas still show as **`(custom schema)`**.
> 
> Adds a **round-trip test** so if the builder and extractor ever drift, tests fail instead of diffs silently degrading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef9610196c2beebb1a111297d64bc6613f875990. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->