### PR TITLE
refactor(formatters): extract shared _found_summary_line helper

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -192,6 +192,20 @@ def _pagination_state(response: dict[str, Any]) -> tuple[bool, str | None]:
     return response.get("has_more", False), response.get("next_cursor")
 
 
+def _found_summary_line(label: str, total: int, breakdown: list[tuple[str, int]] | None) -> str:
+    """Build the shared `Found N <label>[: a x, b y, c z].` summary line.
+
+    ``format_list_scouts`` always supplies a breakdown (defaulting missing
+    counts to 0). ``format_task_list`` passes ``None`` when the response
+    omitted ``summary`` entirely, to avoid printing a misleading all-zero
+    breakdown over real rows.
+    """
+    if breakdown is None:
+        return f"Found {total} {label}."
+    parts = ", ".join(f"{count} {name}" for name, count in breakdown)
+    return f"Found {total} {label}: {parts}."
+
+
 def _showing_line(showing: int, total: int, has_more: bool) -> str:
     """Build the shared `Showing N of M:` / `Showing all N:` pagination line.
 
@@ -396,7 +410,8 @@ def format_list_scouts(response: dict[str, Any], **context: Any) -> str:
     paused = summary.get("paused", 0)
     done = summary.get("done", 0)
 
-    lines = [f"Found {total} scouts: {active} active, {paused} paused, {done} done."]
+    breakdown = [("active", active), ("paused", paused), ("done", done)]
+    lines = [_found_summary_line("scouts", total, breakdown)]
 
     if not scouts:
         lines.append("\nNo scouts to display.")
@@ -770,15 +785,16 @@ def format_task_list(response: dict[str, Any], **context: Any) -> str:
     has_more, next_cursor = _pagination_state(response)
     list_tool, get_tool = _TASK_TOOLS[task_type]
 
-    if summary:
-        lines = [
-            f"Found {total} {task_label} tasks: "
-            f"{summary.get('running', 0)} running, "
-            f"{summary.get('succeeded', 0)} succeeded, "
-            f"{summary.get('failed', 0)} failed."
+    breakdown = (
+        [
+            ("running", summary.get("running", 0)),
+            ("succeeded", summary.get("succeeded", 0)),
+            ("failed", summary.get("failed", 0)),
         ]
-    else:
-        lines = [f"Found {total} {task_label} tasks."]
+        if summary
+        else None
+    )
+    lines = [_found_summary_line(f"{task_label} tasks", total, breakdown)]
 
     if not tasks:
         lines.append(f"\nNo {task_label} tasks to display.")

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -200,6 +200,25 @@ class TestFormatListScouts:
         assert "abc-123" in result
         assert "active" in result
 
+    def test_summary_breakdown_line_exact(self):
+        """Pin the exact 'Found N scouts: a active, b paused, c done.' summary line."""
+        response = {
+            "scouts": [{"id": "abc", "query": "test", "status": "active"}],
+            "total": 6,
+            "summary": {"active": 3, "paused": 2, "done": 1},
+        }
+        result = format_list_scouts(response)
+        assert "Found 6 scouts: 3 active, 2 paused, 1 done." in result
+
+    def test_summary_breakdown_shown_even_when_summary_missing(self):
+        """Unlike format_task_list, a missing summary still renders an all-zero breakdown."""
+        response = {
+            "scouts": [{"id": "abc", "query": "test", "status": "active"}],
+            "total": 1,
+        }
+        result = format_list_scouts(response)
+        assert "Found 1 scouts: 0 active, 0 paused, 0 done." in result
+
     def test_has_more_hint(self):
         """When has_more is true, shows hint to increase limit."""
         response = {


### PR DESCRIPTION
## Issue

`format_list_scouts` and `format_task_list` in `src/yutori_mcp/formatters.py` each independently build a `"Found N ...: a x, b y, c z."` summary line — same shape (count, label, colon-delimited breakdown), but with different breakdown fields (active/paused/done vs running/succeeded/failed), and `format_task_list` additionally omits the breakdown entirely when `summary` is falsy (to avoid printing a misleading all-zero breakdown over real rows), while `format_list_scouts` always shows it.

This candidate was previously logged in `yutori-ai/yutori`'s `.claude/REFACTOR.md` (`## yutori-mcp` section) with a caution that the two shapes "diverge enough that a future pass should weigh carefully whether extraction is worth the added indirection." On close inspection, the divergence is narrow and mechanical (present-vs-omitted breakdown, different field sets) — a small helper cleanly captures the shared part without hiding the differences.

## Improvement

Added `_found_summary_line(label, total, breakdown)`:
- `breakdown=None` → `"Found {total} {label}."`
- `breakdown=[(name, count), ...]` → `"Found {total} {label}: {count} {name}, ...".`

Both formatters now call this helper, each still constructing its own field-specific breakdown list (or `None`), preserving their existing divergent behavior exactly. The separate "showing" line logic (`_showing_line` / `filtered_total` branch) was intentionally left untouched — it's already partially shared and the note's caution applies more there.

## Safety

- No behavior change: output strings are byte-identical for all existing test cases.
- Added two characterization tests (`test_summary_breakdown_line_exact`, `test_summary_breakdown_shown_even_when_summary_missing`) pinning the exact scout summary line, since prior tests only asserted substrings.
- Full test suite passes: 193 passed (`pytest -q`), including existing task-list tests (`test_minimal_response_without_total_or_summary`, `test_null_summary_does_not_crash`) that already pinned the task-list summary-line shape.
- Change is scoped to one file (`formatters.py`) plus its test file; no public API/signature changes.

## Test plan
- [x] `pytest -q` — 193 passed
- [x] Manually diffed old vs. new summary-line construction for both formatters (present/absent summary, all breakdown fields)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BrhohMfGuUVCUfMkiigpct

---
_Generated by [Claude Code](https://claude.ai/code/session_01BrhohMfGuUVCUfMkiigpct)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only in MCP text formatters with characterization tests; no API or runtime behavior change intended.
> 
> **Overview**
> Introduces **`_found_summary_line`** so scout and task list formatters share one way to build the **"Found N …"** header, with an optional status breakdown.
> 
> **`format_list_scouts`** and **`format_task_list`** now call that helper instead of duplicating string assembly. Scout lists still always show active/paused/done counts (including zeros when `summary` is missing). Task lists still omit the breakdown when `summary` is absent, so minimal payloads stay **"Found N browsing tasks."** without misleading all-zero stats.
> 
> Two tests lock in the exact scout summary line and the missing-summary all-zero breakdown behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbda11008a1cf1fc554dea1a550d00c06919d68e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->