### PR TITLE
refactor(schemas): extract shared _cursor_field helper

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -142,6 +142,19 @@ def _is_public_field() -> Any:
     return Field(default=None, description=_IS_PUBLIC_DESCRIPTION)
 
 
+def _cursor_field() -> Any:
+    """Build the shared list-pagination `cursor` Field (text from `_LIST_CURSOR_DESCRIPTION`).
+
+    ListScoutsInput and ListTasksInput each repeat the identical
+    `Field(default=None, description=_LIST_CURSOR_DESCRIPTION)` shape for
+    `cursor`. Centralizing the Field construction mirrors `_webhook_format_field`
+    and `_is_public_field` above. GetUpdatesInput's `cursor` field uses different
+    description wording ("previous response" vs. "previous list response"), so
+    it is intentionally not routed through this helper.
+    """
+    return Field(default=None, description=_LIST_CURSOR_DESCRIPTION)
+
+
 def _limit_field(noun: str, *, default: int | None = 10) -> Any:
     """Build the shared pagination `limit` Field (1-100, optional "Default: N" suffix).
 
@@ -278,10 +291,7 @@ class ListScoutsInput(ToolInput):
         default=None,
         description="Filter by status: 'active', 'paused', or 'done'",
     )
-    cursor: str | None = Field(
-        default=None,
-        description=_LIST_CURSOR_DESCRIPTION,
-    )
+    cursor: str | None = _cursor_field()
 
 
 class ListTasksInput(ToolInput):
@@ -292,10 +302,7 @@ class ListTasksInput(ToolInput):
         default=None,
         description="Filter by status: 'running', 'succeeded', or 'failed'",
     )
-    cursor: str | None = Field(
-        default=None,
-        description=_LIST_CURSOR_DESCRIPTION,
-    )
+    cursor: str | None = _cursor_field()
 
 
 class GetUpdatesInput(ToolInput):

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -362,6 +362,20 @@ class TestListTasksInput:
             ListTasksInput(status="queued")
 
 
+class TestCursorFieldSharedDescription:
+    """ListScoutsInput and ListTasksInput share the same `_cursor_field()` construction.
+
+    Drift guard: both schemas' `cursor` field must keep the identical
+    description text so the two call sites cannot silently diverge.
+    """
+
+    def test_descriptions_match(self):
+        assert (
+            ListScoutsInput.model_fields["cursor"].description
+            == ListTasksInput.model_fields["cursor"].description
+        )
+
+
 class TestTaskIdInput:
     def test_task_id_required(self):
         """task_id is required."""


### PR DESCRIPTION
## Summary
- `ListScoutsInput.cursor` and `ListTasksInput.cursor` repeated the identical `Field(default=None, description=_LIST_CURSOR_DESCRIPTION)` construction.
- Extracts a `_cursor_field()` helper (mirroring the existing `_webhook_format_field()`/`_is_public_field()` helpers) so the two call sites cannot drift apart.
- No behavior change: field default, type, and description text are unchanged. `GetUpdatesInput.cursor` intentionally keeps its own distinct description and is not routed through this helper.
- Adds a small drift-guard test asserting the two schemas' `cursor` descriptions stay in sync.

## Test plan
- [x] `pytest -q` — 194 passed
- [x] `ruff check` / `ruff format --diff` clean on changed files


---
_Generated by [Claude Code](https://claude.ai/code/session_016saEAMgMKXHfn6zieRqnkP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-only refactor with identical defaults, types, and descriptions; no handler or API logic touched.
> 
> **Overview**
> Introduces **`_cursor_field()`** in `schemas.py` so **`ListScoutsInput`** and **`ListTasksInput`** share one definition for optional list-pagination **`cursor`** (same pattern as `_is_public_field` / `_webhook_format_field`). **`GetUpdatesInput.cursor`** stays a separate **`Field`** because its description differs (“previous response” vs “previous list response”).
> 
> Adds **`TestCursorFieldSharedDescription`** to assert both list schemas keep identical **`cursor`** description text. **No runtime or validation behavior change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cd52e93f2c185e71af5c15eaeb22f472aab61ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->