### PR TITLE
refactor(schemas): extract shared _scout_id_field helper

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -142,6 +142,17 @@ def _is_public_field() -> Any:
     return Field(default=None, description=_IS_PUBLIC_DESCRIPTION)
 
 
+def _scout_id_field() -> Any:
+    """Build the shared required `scout_id` Field (text from `_SCOUT_ID_DESCRIPTION`).
+
+    EditScoutInput, ScoutIdInput, and GetUpdatesInput each repeat the identical
+    `Field(..., description=_SCOUT_ID_DESCRIPTION)` shape for `scout_id`.
+    Centralizing the Field construction mirrors `_webhook_format_field`/
+    `_is_public_field` above, so the three call sites cannot drift apart.
+    """
+    return Field(..., description=_SCOUT_ID_DESCRIPTION)
+
+
 def _cursor_field() -> Any:
     """Build the shared list-pagination `cursor` Field (text from `_LIST_CURSOR_DESCRIPTION`).
 
@@ -233,7 +244,7 @@ class CreateScoutInput(ToolInput):
 class EditScoutInput(ToolInput):
     """Input for editing an existing scout or changing its status."""
 
-    scout_id: str = Field(..., description=_SCOUT_ID_DESCRIPTION)
+    scout_id: str = _scout_id_field()
     status: ScoutStatus = Field(
         default=None,
         description=(
@@ -280,7 +291,7 @@ class EditScoutInput(ToolInput):
 class ScoutIdInput(ToolInput):
     """Input for operations on a specific scout."""
 
-    scout_id: str = Field(..., description=_SCOUT_ID_DESCRIPTION)
+    scout_id: str = _scout_id_field()
 
 
 class ListScoutsInput(ToolInput):
@@ -308,7 +319,7 @@ class ListTasksInput(ToolInput):
 class GetUpdatesInput(ToolInput):
     """Input for retrieving scout updates."""
 
-    scout_id: str = Field(..., description=_SCOUT_ID_DESCRIPTION)
+    scout_id: str = _scout_id_field()
     cursor: str | None = Field(
         default=None,
         description="Pagination cursor from a previous response",

--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -376,6 +376,32 @@ class TestCursorFieldSharedDescription:
         )
 
 
+class TestScoutIdFieldSharedDescription:
+    """EditScoutInput, ScoutIdInput, and GetUpdatesInput share `_scout_id_field()`.
+
+    Drift guard: all three schemas' `scout_id` field must keep the identical
+    description text (and stay required) so the call sites cannot silently
+    diverge.
+    """
+
+    def test_descriptions_match(self):
+        description = EditScoutInput.model_fields["scout_id"].description
+        assert ScoutIdInput.model_fields["scout_id"].description == description
+        assert GetUpdatesInput.model_fields["scout_id"].description == description
+
+    @pytest.mark.parametrize(
+        "cls,extra_kwargs",
+        [
+            pytest.param(EditScoutInput, {"query": "q"}, id="EditScoutInput"),
+            pytest.param(ScoutIdInput, {}, id="ScoutIdInput"),
+            pytest.param(GetUpdatesInput, {}, id="GetUpdatesInput"),
+        ],
+    )
+    def test_scout_id_required(self, cls, extra_kwargs):
+        with pytest.raises(ValidationError):
+            cls(**extra_kwargs)
+
+
 class TestTaskIdInput:
     def test_task_id_required(self):
         """task_id is required."""


### PR DESCRIPTION
## Structural issue

`EditScoutInput`, `ScoutIdInput`, and `GetUpdatesInput` in `src/yutori_mcp/schemas.py` each repeated the identical
`Field(..., description=_SCOUT_ID_DESCRIPTION)` construction for the required `scout_id` field. This is the same
class of duplication that motivated the existing `_webhook_format_field`, `_is_public_field`, and `_cursor_field`
helpers (which centralize a fixed-description `Field()` shape across 2-4 call sites) — `scout_id` had simply been
missed since `_SCOUT_ID_DESCRIPTION` was introduced.

## Improvement

Added `_scout_id_field()`, mirroring the existing helper family, and routed all three call sites through it. Also
added a `TestScoutIdFieldSharedDescription` drift-guard test (parallel to the existing `TestCursorFieldSharedDescription`)
asserting the three schemas keep an identical `scout_id` description and stay required.

## Safety

Purely internal construction change — the resulting `Field(...)` object is byte-identical (same `...` default,
same description text), so there is no user-facing/tool-doc change and no behavior change.

- `pytest`: 194 passed before -> 198 passed after (4 new tests added, no existing test touched)
- `ruff check .`: clean before and after
- `ruff format --check .`: the two files I touched (`schemas.py`, `test_schemas.py`) are clean; two pre-existing,
  unrelated files (`formatters.py`, `test_formatters.py`) already fail `ruff format --check` before this change
  (unrelated formatting drift, not modified here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MT2GBu88S1s8Yv5ThpTRyQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal schema construction only; Field defaults and descriptions are unchanged, so MCP validation and tool docs should behave the same.
> 
> **Overview**
> Introduces **`_scout_id_field()`** in `schemas.py`, aligned with helpers like `_is_public_field()` and `_cursor_field()`, and wires **`EditScoutInput`**, **`ScoutIdInput`**, and **`GetUpdatesInput`** to use it instead of repeating `Field(..., description=_SCOUT_ID_DESCRIPTION)`.
> 
> Adds **`TestScoutIdFieldSharedDescription`** in `test_schemas.py` to assert the three schemas keep the same `scout_id` description and that `scout_id` stays required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4dbe28653c973e9bcf4544c48ad8c0691194c99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->