### PR TITLE
test(schemas): parametrize EditScoutInput status validity tests

### DIFF
--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -140,20 +140,11 @@ class TestEditScoutInput:
         assert data.scout_id == "abc-123"
         assert data.query is None
 
-    def test_status_paused(self):
-        """Status can be set to paused."""
-        data = EditScoutInput(scout_id="abc-123", status="paused")
-        assert data.status == "paused"
-
-    def test_status_active(self):
-        """Status can be set to active."""
-        data = EditScoutInput(scout_id="abc-123", status="active")
-        assert data.status == "active"
-
-    def test_status_done(self):
-        """Status can be set to done."""
-        data = EditScoutInput(scout_id="abc-123", status="done")
-        assert data.status == "done"
+    @pytest.mark.parametrize("status", ["paused", "active", "done"])
+    def test_status_valid(self, status):
+        """Status can be set to any of the valid literal values."""
+        data = EditScoutInput(scout_id="abc-123", status=status)
+        assert data.status == status
 
     def test_status_invalid(self):
         """Invalid status values are rejected."""


### PR DESCRIPTION
## Structural issue

`tests/test_schemas.py`'s `TestEditScoutInput` had three separate test methods — `test_status_paused`, `test_status_active`, `test_status_done` — that were byte-identical apart from the single status literal:

```python
def test_status_paused(self):
    """Status can be set to paused."""
    data = EditScoutInput(scout_id="abc-123", status="paused")
    assert data.status == "paused"

def test_status_active(self):
    """Status can be set to active."""
    data = EditScoutInput(scout_id="abc-123", status="active")
    assert data.status == "active"

def test_status_done(self):
    """Status can be set to done."""
    data = EditScoutInput(scout_id="abc-123", status="done")
    assert data.status == "done"
```

## Why this is an improvement

This is exactly the "differs only in one literal value" pattern that `pytest.mark.parametrize` exists for, and the same file already uses `parametrize` extensively elsewhere (e.g. `_ALL_INPUT_CLASSES`, `TestScoutIdFieldSharedDescription`), so this brings the file in line with its own established convention rather than introducing a new one.

## Why it's safe

- Pure test-only change — no source files touched, no behavior change.
- All three original cases (`paused`, `active`, `done`) are still individually collected and run by pytest as separate parametrized cases — coverage is identical, just de-duplicated.
- Verified: `uv run --extra dev pytest -q` → 198 passed (same effective test cases, net -2 from removing 2 duplicate function definitions while parametrize still yields 3 cases).
- `uv run --extra dev ruff check .` → all checks passed.

This is package `src/yutori_mcp/` in the `yutori-ai/yutori-mcp` repo, which per `yutori-ai/yutori`'s `.claude/REFACTOR.md` backlog is already extremely thoroughly refactored on the source side (through PR #147); this PR targets a small remaining duplication in the test suite instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PaLhcdGBW5ZSXiP93DadY8)_