### PR TITLE
test(schemas): parametrize ListScoutsInput status filter tests

### DIFF
--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -289,16 +289,11 @@ class TestListScoutsInput:
         with pytest.raises(ValidationError):
             ListScoutsInput(limit=101)
 
-    def test_status_filter(self):
+    @pytest.mark.parametrize("status", ["active", "paused", "done"])
+    def test_status_filter(self, status):
         """Status filter works with valid values."""
-        data = ListScoutsInput(status="active")
-        assert data.status == "active"
-
-        data = ListScoutsInput(status="paused")
-        assert data.status == "paused"
-
-        data = ListScoutsInput(status="done")
-        assert data.status == "done"
+        data = ListScoutsInput(status=status)
+        assert data.status == status
 
     def test_status_invalid(self):
         """Invalid status values are rejected."""


### PR DESCRIPTION
## Issue

`src/yutori_mcp/` (adapter.py, server.py, formatters.py, schemas.py, schema_utils.py) has been refactored extremely thoroughly over many prior hourly passes and is fully saturated at the source level. Widening the search to the test suite (per the same approach that found PR #148) turned up one more instance of the exact pattern #148 just fixed.

`tests/test_schemas.py::TestListScoutsInput::test_status_filter` set three status values inline in a single test body:

```python
def test_status_filter(self):
    """Status filter works with valid values."""
    data = ListScoutsInput(status="active")
    assert data.status == "active"

    data = ListScoutsInput(status="paused")
    assert data.status == "paused"

    data = ListScoutsInput(status="done")
    assert data.status == "done"
```

This differs only in the literal per block — the same duplication shape #148 collapsed for `EditScoutInput.test_status_paused/active/done` into a single `pytest.mark.parametrize`d test.

## Improvement

Collapsed into:

```python
@pytest.mark.parametrize("status", ["active", "paused", "done"])
def test_status_filter(self, status):
    """Status filter works with valid values."""
    data = ListScoutsInput(status=status)
    assert data.status == status
```

This matches the existing `pytest.mark.parametrize` convention already used elsewhere in this file (e.g. `_ALL_INPUT_CLASSES`, and #148's `EditScoutInput.test_status_valid`).

## Safety

- Test-only change, zero behavior/coverage change — still exercises exactly the same 3 cases (`active`, `paused`, `done`) against the same assertion.
- Full suite: 200 passed (up from 198, since parametrize expands the single test into 3 distinct collected test IDs — same net effect as #148).
- `ruff check` clean. `ruff format --check` reports two pre-existing unrelated formatting diffs in `formatters.py`/`test_formatters.py` (not touched by this PR).
- Single file touched (`tests/test_schemas.py`).

🤖 Generated as part of the hourly automated refactor cronjob.


---
_Generated by [Claude Code](https://claude.ai/code/session_01K9VNWbc95DSpSLg349RmiP)_