### PR TITLE
test(schemas): consolidate limit-range boundary checks across list inputs

### DIFF
--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -32,6 +32,26 @@ _ALL_INPUT_CLASSES = [
     pytest.param(ResearchTaskInput, {"query": "Test"}, id="ResearchTaskInput"),
 ]
 
+# Boundary cases for the shared `_limit_field()` 1-100 range, used by
+# ListScoutsInput's and ListTasksInput's `test_limit_range` below. Centralizing
+# the (limit, is_valid) pairs here means the two classes' boundary checks can't
+# silently drift apart. GetUpdatesInput also uses `_limit_field()` but has no
+# equivalent boundary test, so it intentionally doesn't participate here.
+_LIMIT_BOUNDARY_CASES = [
+    pytest.param(1, True, id="min-valid"),
+    pytest.param(100, True, id="max-valid"),
+    pytest.param(0, False, id="below-min"),
+    pytest.param(101, False, id="above-max"),
+]
+
+
+def _assert_limit_boundary(cls, limit, is_valid):
+    if is_valid:
+        assert cls(limit=limit).limit == limit
+    else:
+        with pytest.raises(ValidationError):
+            cls(limit=limit)
+
 
 class TestUsageInput:
     def test_default_period(self):
@@ -275,19 +295,10 @@ class TestListScoutsInput:
         data = ListScoutsInput(limit=50)
         assert data.limit == 50
 
-    def test_limit_range(self):
+    @pytest.mark.parametrize("limit,is_valid", _LIMIT_BOUNDARY_CASES)
+    def test_limit_range(self, limit, is_valid):
         """Limit must be between 1 and 100."""
-        data = ListScoutsInput(limit=1)
-        assert data.limit == 1
-
-        data = ListScoutsInput(limit=100)
-        assert data.limit == 100
-
-        with pytest.raises(ValidationError):
-            ListScoutsInput(limit=0)
-
-        with pytest.raises(ValidationError):
-            ListScoutsInput(limit=101)
+        _assert_limit_boundary(ListScoutsInput, limit, is_valid)
 
     @pytest.mark.parametrize("status", ["active", "paused", "done"])
     def test_status_filter(self, status):
@@ -326,16 +337,10 @@ class TestListTasksInput:
         assert data.limit == 50
         assert data.cursor == "next-page"
 
-    def test_limit_range(self):
+    @pytest.mark.parametrize("limit,is_valid", _LIMIT_BOUNDARY_CASES)
+    def test_limit_range(self, limit, is_valid):
         """Limit must be between 1 and 100."""
-        assert ListTasksInput(limit=1).limit == 1
-        assert ListTasksInput(limit=100).limit == 100
-
-        with pytest.raises(ValidationError):
-            ListTasksInput(limit=0)
-
-        with pytest.raises(ValidationError):
-            ListTasksInput(limit=101)
+        _assert_limit_boundary(ListTasksInput, limit, is_valid)
 
     def test_status_filter(self):
         """Status filter accepts the task-list statuses from the REST API."""


### PR DESCRIPTION
## Structural issue

`tests/test_schemas.py`'s `TestListScoutsInput` and `TestListTasksInput` each had a `test_limit_range` method that hand-rolled the identical 1/100 valid, 0/101 invalid boundary check against the shared `_limit_field()` helper (`src/yutori_mcp/schemas.py`), just written in slightly different styles:

```python
# TestListScoutsInput
def test_limit_range(self):
    data = ListScoutsInput(limit=1)
    assert data.limit == 1
    data = ListScoutsInput(limit=100)
    assert data.limit == 100
    with pytest.raises(ValidationError):
        ListScoutsInput(limit=0)
    with pytest.raises(ValidationError):
        ListScoutsInput(limit=101)

# TestListTasksInput
def test_limit_range(self):
    assert ListTasksInput(limit=1).limit == 1
    assert ListTasksInput(limit=100).limit == 100
    with pytest.raises(ValidationError):
        ListTasksInput(limit=0)
    with pytest.raises(ValidationError):
        ListTasksInput(limit=101)
```

## Why this is an improvement

Extracted the `(limit, is_valid)` boundary cases into a shared `_LIMIT_BOUNDARY_CASES` list and the assert-or-raise logic into a shared `_assert_limit_boundary(cls, limit, is_valid)` helper, then had each class's own `test_limit_range` parametrize over the shared cases and delegate to the helper. This follows the same "drift guard" idiom already used in this file (`TestCursorFieldSharedDescription`, `TestScoutIdFieldSharedDescription`) — the two classes' boundary checks can no longer silently diverge — while keeping each `test_limit_range` in its own class.

`GetUpdatesInput` is a third `_limit_field()` consumer but has no equivalent boundary test today, so it intentionally does not participate in this helper (folding it in would mean writing a new test for it, which is a separate, more invasive change).

## Why it's safe

- Pure test-only change — no source files touched, no behavior change.
- All four original boundary cases (`limit=1`, `limit=100`, `limit=0`, `limit=101`) are still individually collected and run per class via `pytest.mark.parametrize`.
- Verified: `pytest -q` → 206 passed.
- `ruff check .` → all checks passed.

This is package `src/yutori_mcp/` in the `yutori-ai/yutori-mcp` repo, which per `yutori-ai/yutori`'s `.claude/REFACTOR.md` backlog is already extremely thoroughly refactored on the source side; this targets a small remaining duplication in the test suite that a previous run flagged but didn't act on, pending confirmation that a non-invasive consolidation was possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVfp3XcEuGzK2YXcn5VBEq)_