### PR TITLE
refactor(schemas,server): extract shared DEFAULT_LIST_LIMIT constant

### DIFF
--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -56,6 +56,14 @@ _LIST_CURSOR_DESCRIPTION = "Pagination cursor from a previous list response"
 # describing it cannot drift apart if the minimum ever changes.
 _MIN_OUTPUT_INTERVAL_SECONDS = 1800
 
+# Default `limit` for list_scouts/list_browsing_tasks/list_research_tasks,
+# shared with the matching `@mcp.tool` function signatures in server.py.
+# FastMCP builds each tool's advertised JSON Schema `default` from the Python
+# function signature, not from this module's Pydantic field default, so
+# server.py can't simply rely on `_limit_field()`'s default -- it needs its
+# own literal. Centralizing the number here means the two cannot drift apart.
+DEFAULT_LIST_LIMIT = 10
+
 
 def _output_fields_description(example: list[str], docs_slug: str | None = None) -> str:
     """Build the shared `output_fields` field description.
@@ -166,7 +174,7 @@ def _cursor_field() -> Any:
     return Field(default=None, description=_LIST_CURSOR_DESCRIPTION)
 
 
-def _limit_field(noun: str, *, default: int | None = 10) -> Any:
+def _limit_field(noun: str, *, default: int | None = DEFAULT_LIST_LIMIT) -> Any:
     """Build the shared pagination `limit` Field (1-100, optional "Default: N" suffix).
 
     ListScoutsInput, ListTasksInput, and GetUpdatesInput each repeat the same

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -16,6 +16,7 @@ from .adapter import MCPClientAdapter, YutoriAPIError
 from .formatters import TASK_TYPE_BROWSING, TASK_TYPE_RESEARCH, format_response
 from .schema_utils import output_fields_to_output_schema
 from .schemas import (
+    DEFAULT_LIST_LIMIT,
     BrowserChoice,
     BrowsingTaskInput,
     CreateScoutInput,
@@ -161,7 +162,7 @@ async def list_api_usage(
     annotations=_READ_ONLY,
 )
 async def list_scouts(
-    limit: int | None = 10,
+    limit: int | None = DEFAULT_LIST_LIMIT,
     status: ScoutStatus = None,
     cursor: str | None = None,
 ) -> str:
@@ -265,7 +266,7 @@ async def run_browsing_task(
     annotations=_READ_ONLY,
 )
 async def list_browsing_tasks(
-    limit: int | None = 10,
+    limit: int | None = DEFAULT_LIST_LIMIT,
     status: TaskListStatus = None,
     cursor: str | None = None,
 ) -> str:
@@ -303,7 +304,7 @@ async def run_research_task(
     annotations=_READ_ONLY,
 )
 async def list_research_tasks(
-    limit: int | None = 10,
+    limit: int | None = DEFAULT_LIST_LIMIT,
     status: TaskListStatus = None,
     cursor: str | None = None,
 ) -> str:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -14,6 +14,7 @@ from yutori_mcp.schema_utils import (
     output_fields_to_output_schema,
     output_schema_field_names,
 )
+from yutori_mcp.schemas import DEFAULT_LIST_LIMIT
 from yutori_mcp.server import (
     _get_task_result_description,
     _handle_edit_scout,
@@ -117,6 +118,20 @@ class TestTaskDescriptionHelpers:
         assert tools["get_research_task_result"] == _get_task_result_description(
             "research"
         )
+
+
+class TestRegisteredToolLimitDefaults:
+    """Drift guard: the `limit` default FastMCP advertises to callers for
+    list_scouts/list_browsing_tasks/list_research_tasks comes from each
+    ``@mcp.tool`` function's own signature default in server.py, not from
+    schemas.DEFAULT_LIST_LIMIT (schemas.py's Pydantic field default only
+    applies once a request omits the argument entirely). The two must be
+    kept in sync manually, so pin them here."""
+
+    async def test_advertised_limit_defaults_match_shared_constant(self):
+        tools = {t.name: t.inputSchema for t in await mcp.list_tools()}
+        for name in ("list_scouts", "list_browsing_tasks", "list_research_tasks"):
+            assert tools[name]["properties"]["limit"]["default"] == DEFAULT_LIST_LIMIT
 
 
 def _assert_main_exits(expected_code: int) -> None:


### PR DESCRIPTION
## Issue

`list_scouts`, `list_browsing_tasks`, and `list_research_tasks` in `server.py` each hardcoded the literal `10` as their `limit` parameter's default:

```python
async def list_scouts(
    limit: int | None = 10,
    ...
```

This looks like it mirrors `schemas.py`'s `_limit_field(default=10)` (used by `ListScoutsInput`/`ListTasksInput`), but there was no actual connection between the two. I verified via `mcp.list_tools()` that FastMCP builds each tool's advertised JSON Schema `default` from the **Python function signature** in `server.py`, not from the Pydantic field default in `schemas.py`:

```
list_scouts          {'default': 10, ...}   # from server.py's literal
list_browsing_tasks  {'default': 10, ...}   # from server.py's literal
list_research_tasks  {'default': 10, ...}   # from server.py's literal
```

So the `10` in `schemas.py` and the three `10`s in `server.py` were four independently-editable copies of the same number, with nothing enforcing that they stay in sync — exactly the kind of drift risk this repo already guards against elsewhere (e.g. `_MIN_OUTPUT_INTERVAL_SECONDS`, `_output_fields_description`, `_list_tasks_description`).

## Fix

- Added `DEFAULT_LIST_LIMIT = 10` in `schemas.py`, used as `_limit_field`'s default parameter default.
- Imported it into `server.py` and replaced the three hardcoded `10` literals in the `list_scouts`/`list_browsing_tasks`/`list_research_tasks` tool signatures.
- Added a regression test (`TestRegisteredToolLimitDefaults`) that inspects the live `mcp.list_tools()` registry and pins each tool's advertised `limit` default to `schemas.DEFAULT_LIST_LIMIT`, mirroring the existing `test_registered_tool_descriptions_match_helpers` drift guard.

## Safety

- Pure structural refactor: same runtime value (`10`) everywhere, no behavior or API change.
- Touches only `src/yutori_mcp/schemas.py`, `src/yutori_mcp/server.py`, and `tests/test_server.py`.
- Full test suite: 206 passed before → 207 passed after (206 pre-existing + 1 new drift-guard test), no failures.
- `ruff check .`: clean. `ruff format --check .`: pre-existing findings in `formatters.py`/`test_formatters.py` (confirmed present on `main` before this change, unrelated to this diff) are untouched; no new formatting issues introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GPvf6S95ZkptCwR2rSCtKj)_