### PR TITLE
refactor(server,tests): extract _format_api_error and fix tautological test

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -76,6 +76,18 @@ class _StrictArgsFastMCP(FastMCP):
 mcp = _StrictArgsFastMCP("yutori-mcp")
 
 
+def _format_api_error(e: YutoriAPIError) -> str:
+    """Render a YutoriAPIError in the stable `API Error (status): message` text shape.
+
+    Single source of truth for this string: `_invoke()` uses it to build the
+    RuntimeError message that becomes the MCP tool result's error text, and
+    tests assert against this function directly instead of re-deriving the
+    format inline (which previously let a test believe it was covering the
+    format while never exercising it).
+    """
+    return f"API Error ({e.status_code}): {e.message}"
+
+
 async def _invoke(tool_name: str, args: dict[str, Any]) -> str:
     """Invoke a tool handler and return the formatted response text.
 
@@ -89,7 +101,7 @@ async def _invoke(tool_name: str, args: dict[str, Any]) -> str:
             result, context = await handler(client, args)
         return format_response(tool_name, result, **context)
     except YutoriAPIError as e:
-        raise RuntimeError(f"API Error ({e.status_code}): {e.message}") from e
+        raise RuntimeError(_format_api_error(e)) from e
     except ValidationError:
         raise
     except Exception:

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -6,6 +6,7 @@ import pytest
 
 from yutori.exceptions import APIConnectionError, APIError, AuthenticationError
 from yutori_mcp.adapter import MCPClientAdapter, YutoriAPIError, _strip_none
+from yutori_mcp.server import _format_api_error
 
 
 @pytest.fixture()
@@ -82,17 +83,21 @@ class TestErrorMapping:
 
 
 class TestErrorFormattingContract:
-    """Ensure the server formats YutoriAPIError into a stable text shape."""
+    """Ensure server._format_api_error renders a stable text shape.
+
+    Calls the real helper _invoke() uses (rather than re-deriving the format
+    string inline), so a change to that formatting is actually caught here
+    instead of only in the end-to-end assertion in
+    test_server.py::TestCallToolErrorContract.
+    """
 
     def test_api_error_formatted_as_text(self):
         err = YutoriAPIError(message="Not found", status_code=404)
-        formatted = f"API Error ({err.status_code}): {err.message}"
-        assert formatted == "API Error (404): Not found"
+        assert _format_api_error(err) == "API Error (404): Not found"
 
     def test_auth_error_formatted_as_401(self):
         err = YutoriAPIError(message="Invalid API key", status_code=401)
-        formatted = f"API Error ({err.status_code}): {err.message}"
-        assert formatted == "API Error (401): Invalid API key"
+        assert _format_api_error(err) == "API Error (401): Invalid API key"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Issue

`server._invoke()` builds the MCP-facing error text inline:

```python
raise RuntimeError(f"API Error ({e.status_code}): {e.message}") from e
```

`tests/test_adapter.py::TestErrorFormattingContract` (docstring: "Ensure the server formats YutoriAPIError into a stable text shape") was meant to pin that format, but it never actually called `server.py` code — it re-derived the identical f-string locally and asserted the string equaled itself:

```python
def test_api_error_formatted_as_text(self):
    err = YutoriAPIError(message="Not found", status_code=404)
    formatted = f"API Error ({err.status_code}): {err.message}"
    assert formatted == "API Error (404): Not found"
```

That means the test would keep passing unchanged even if the format string in `server.py` were edited or broken — it provided zero regression coverage for the thing its docstring claimed to cover. (The real end-to-end contract is separately exercised in `tests/test_server.py::TestCallToolErrorContract`, which does go through the actual tool-call handler.)

## Improvement

- Extracted the format string into a small `_format_api_error(e: YutoriAPIError) -> str` helper in `src/yutori_mcp/server.py`, now the single source of truth for that text shape.
- `_invoke()` calls the helper instead of duplicating the f-string.
- Updated `TestErrorFormattingContract` in `tests/test_adapter.py` to import and call `_format_api_error` directly, so the test now actually exercises production code instead of restating it.

## Safety

- Purely additive extraction + a test fix; no behavior change (verified the resulting string is byte-identical via the existing assertions).
- Contained to 2 files.
- Full suite: `pytest -q` → 207 passed (same count as before the change).
- `ruff check` and `ruff format --check` clean on both touched files.

## Test plan

- [x] `pytest -q` passes (207 passed)
- [x] `ruff check src tests` passes
- [x] `ruff format --check src/yutori_mcp/server.py tests/test_adapter.py` passes
- [x] Manually confirmed `_format_api_error` output is unchanged from the prior inline f-string for both a plain `APIError` (404) and an `AuthenticationError`-derived (401) case

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NWjaizg2UDELHDGzCwXBke)_