### PR TITLE
test(schemas): parametrize remaining hand-rolled for-loop test cases

### DIFF
--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -59,11 +59,11 @@ class TestUsageInput:
         data = UsageInput()
         assert data.period is None
 
-    def test_valid_periods(self):
+    @pytest.mark.parametrize("period", ["24h", "7d", "30d", "90d"])
+    def test_valid_periods(self, period):
         """All valid period values are accepted."""
-        for period in ("24h", "7d", "30d", "90d"):
-            data = UsageInput(period=period)
-            assert data.period == period
+        data = UsageInput(period=period)
+        assert data.period == period
 
     def test_invalid_period_rejected(self):
         """Invalid period values are rejected."""
@@ -342,10 +342,10 @@ class TestListTasksInput:
         """Limit must be between 1 and 100."""
         _assert_limit_boundary(ListTasksInput, limit, is_valid)
 
-    def test_status_filter(self):
+    @pytest.mark.parametrize("status", ["running", "succeeded", "failed"])
+    def test_status_filter(self, status):
         """Status filter accepts the task-list statuses from the REST API."""
-        for status in ("running", "succeeded", "failed"):
-            assert ListTasksInput(status=status).status == status
+        assert ListTasksInput(status=status).status == status
 
     def test_status_invalid(self):
         """Detail-only statuses are rejected for list filters."""


### PR DESCRIPTION
## Summary
- `TestUsageInput.test_valid_periods` and `TestListTasksInput.test_status_filter` in `tests/test_schemas.py` still used a hand-rolled `for` loop over literal values instead of `@pytest.mark.parametrize` — the same anti-pattern PRs #148 and #149 already fixed elsewhere in this same file (e.g. `TestEditScoutInput`, `TestListScoutsInput.test_status_filter`). This pair was evidently missed by those same-day sweeps.
- Converted both to `@pytest.mark.parametrize`, matching the file's established convention.

## Why it's safe
- Test-only change, single file, no coverage change (each parametrized case still exercises exactly the same assertion it did before).
- Full suite passes unchanged: 212 passed.
- `ruff check` clean.

## Test plan
- [x] `pytest tests/test_schemas.py -q` — 86 passed
- [x] `pytest -q` (full suite) — 212 passed
- [x] `ruff check .` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0196G2UiwE9FmCDJ3mdcpdtK

---
_Generated by [Claude Code](https://claude.ai/code/session_0196G2UiwE9FmCDJ3mdcpdtK)_