### PR TITLE
test(schemas): parametrize remaining manual for-loop status/period tests

### DIFF
--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -59,11 +59,11 @@ class TestUsageInput:
         data = UsageInput()
         assert data.period is None
 
-    def test_valid_periods(self):
+    @pytest.mark.parametrize("period", ["24h", "7d", "30d", "90d"])
+    def test_valid_periods(self, period):
         """All valid period values are accepted."""
-        for period in ("24h", "7d", "30d", "90d"):
-            data = UsageInput(period=period)
-            assert data.period == period
+        data = UsageInput(period=period)
+        assert data.period == period
 
     def test_invalid_period_rejected(self):
         """Invalid period values are rejected."""
@@ -342,10 +342,10 @@ class TestListTasksInput:
         """Limit must be between 1 and 100."""
         _assert_limit_boundary(ListTasksInput, limit, is_valid)
 
-    def test_status_filter(self):
+    @pytest.mark.parametrize("status", ["running", "succeeded", "failed"])
+    def test_status_filter(self, status):
         """Status filter accepts the task-list statuses from the REST API."""
-        for status in ("running", "succeeded", "failed"):
-            assert ListTasksInput(status=status).status == status
+        assert ListTasksInput(status=status).status == status
 
     def test_status_invalid(self):
         """Detail-only statuses are rejected for list filters."""


### PR DESCRIPTION
## What

`tests/test_schemas.py::TestUsageInput.test_valid_periods` and `TestListTasksInput.test_status_filter` each iterated over their valid literal values (`"24h"/"7d"/"30d"/"90d"` and `"running"/"succeeded"/"failed"`) with a plain `for` loop inside a single test method, while sibling tests covering the identical shape in this same file already use `@pytest.mark.parametrize` (e.g. `TestListScoutsInput.test_status_filter`, and the recent `#148`/`#149` consolidations that converted equivalent repeated-literal test bodies to parametrize).

This PR converts both remaining for-loop tests to `@pytest.mark.parametrize`, matching the file's established convention.

## Why this is an improvement

- **Consistency**: every other "N valid literal values" test in this file already uses parametrize; these two were the last holdouts.
- **Better failure signal**: a `for` loop stops at the first failing value and reports one aggregate pass/fail; parametrize reports each case independently, so a regression in (say) just `"90d"` or just `"failed"` is visible on its own line instead of being masked by whichever case happens to run first.

## Why this is safe

- Test-only change, no production code touched.
- Same cases are exercised before and after (no coverage change) — just reported as separate parametrized cases instead of one aggregate test. Full suite goes from 207 to 212 passed (the +5 is exactly the newly-independent parametrized cases: +3 for periods, +2 for statuses).
- `ruff check` and `ruff format --check` both clean (pre-existing formatting drift in `formatters.py`/`test_formatters.py` is unrelated to this change and untouched).
- Contained to a single file (`tests/test_schemas.py`).

## Test plan

- [x] `uv run pytest -q` — 212 passed
- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean (for the touched file; two pre-existing unrelated files would reformat, left untouched)


---
_Generated by [Claude Code](https://claude.ai/code/session_01AZcBE8dgwAiPxuBkwibiTX)_