### PR TITLE
test(adapter): parametrize manual for-loop status-code test

### DIFF
--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -62,15 +62,15 @@ class TestErrorMapping:
         assert exc_info.value.status_code == 401
         assert "Invalid API key" in exc_info.value.message
 
-    async def test_api_error_preserves_status_code(self, adapter):
-        for code in [400, 403, 429, 500, 503]:
-            sdk_error = APIError(message=f"Error {code}", status_code=code)
-            adapter._client.scouts.list = AsyncMock(side_effect=sdk_error)
+    @pytest.mark.parametrize("code", [400, 403, 429, 500, 503])
+    async def test_api_error_preserves_status_code(self, adapter, code):
+        sdk_error = APIError(message=f"Error {code}", status_code=code)
+        adapter._client.scouts.list = AsyncMock(side_effect=sdk_error)
 
-            with pytest.raises(YutoriAPIError) as exc_info:
-                await adapter.list_scouts()
+        with pytest.raises(YutoriAPIError) as exc_info:
+            await adapter.list_scouts()
 
-            assert exc_info.value.status_code == code
+        assert exc_info.value.status_code == code
 
     async def test_api_error_chains_original_exception(self, adapter):
         sdk_error = APIError(message="Rate limited", status_code=429)


### PR DESCRIPTION
## What

`tests/test_adapter.py::TestErrorMapping.test_api_error_preserves_status_code` iterated over `[400, 403, 429, 500, 503]` with a plain `for` loop inside a single test method, while every sibling "N cases, one assertion each" test in this file (and the rest of the suite, per #148-#154) already uses `@pytest.mark.parametrize`.

This PR converts it to `@pytest.mark.parametrize("code", [...])`, matching the codebase's established convention. `test_adapter.py` wasn't touched by the #148-#154 parametrization pass (that pass was scoped to `test_schemas.py`), so this was a genuine remaining instance of the same pattern, not a re-tread.

## Why this is an improvement

- **Consistency**: matches the parametrize convention used everywhere else in the suite for this exact shape (independent setup + single assertion per case).
- **Better failure signal**: the `for` loop stops at the first failing status code and reports one aggregate pass/fail; parametrize reports each of the 5 status codes independently, so a regression in just one status code (e.g. only 503) is visible on its own line instead of being masked by whichever code happens to run first in the loop.

## Why this is safe

- Test-only change, no production code touched.
- Same 5 status codes are exercised before and after (no coverage change) — just reported as independent parametrized cases instead of one aggregate test. Full suite goes from 212 to 216 passed (the +4 is exactly the newly-independent parametrized cases for this one test).
- `ruff check` and `ruff format --check` both clean on the touched file.
- Contained to a single file (`tests/test_adapter.py`).

## Test plan

- [x] `pytest -q` — 212 passed before, 216 passed after
- [x] `pytest -v -k preserves_status_code` — 5 independent passing cases (400/403/429/500/503)
- [x] `ruff check tests/test_adapter.py` — clean
- [x] `ruff format --check tests/test_adapter.py` — already formatted

---
_Generated by [Claude Code](https://claude.ai/code/session_01XiDYpTyaesUu3qs9scqXpn)_