### PR TITLE
test(schemas): parametrize manual for-loop in test_all_schemas_use_helper

### DIFF
--- a/tests/test_schemas.py
+++ b/tests/test_schemas.py
@@ -475,19 +475,17 @@ class TestOutputFieldsDescription:
         )
         assert result.endswith(".")
 
-    def test_all_schemas_use_helper(self):
-        """All four output_fields descriptions are produced by the helper."""
-        for model_cls in (
-            CreateScoutInput,
-            EditScoutInput,
-            BrowsingTaskInput,
-            ResearchTaskInput,
-        ):
-            desc = model_cls.model_fields["output_fields"].description
-            assert desc is not None
-            assert "Optional: Extract structured data" in desc, (
-                f"{model_cls.__name__}.output_fields description does not use _output_fields_description"
-            )
+    @pytest.mark.parametrize(
+        "model_cls",
+        [CreateScoutInput, EditScoutInput, BrowsingTaskInput, ResearchTaskInput],
+    )
+    def test_all_schemas_use_helper(self, model_cls):
+        """Each output_fields description is produced by the helper."""
+        desc = model_cls.model_fields["output_fields"].description
+        assert desc is not None
+        assert "Optional: Extract structured data" in desc, (
+            f"{model_cls.__name__}.output_fields description does not use _output_fields_description"
+        )
 
 
 class TestInvalidBrowserRejected:


### PR DESCRIPTION
## Issue

`TestOutputFieldsDescription.test_all_schemas_use_helper` in `tests/test_schemas.py` iterated over the same 4 input classes (`CreateScoutInput`, `EditScoutInput`, `BrowsingTaskInput`, `ResearchTaskInput` — the same set tracked by `_ALL_INPUT_CLASSES` in the same file) in a plain `for` loop with assertions inside the loop body. This is the exact manual-for-loop-over-test-cases shape that PRs #148, #149, #154, and #155 already converted elsewhere in this file/repo: if an earlier class in the loop fails the assertion, the loop stops and the remaining classes are never checked, and the failure output doesn't identify which class failed without reading the traceback.

## Improvement

Converted to `@pytest.mark.parametrize("model_cls", [...])`, matching the established convention in this file. Each class is now an independently reported test case.

## Safety

- Test-only change, no `src/` behavior touched.
- Same 4 cases exercised — no coverage change. Full suite goes from 216 to 219 passed (net +3, consistent with how prior parametrize PRs in this file reported deltas: one test method collapsing into N independently-run parametrized cases).
- Verified new parametrized ids resolve correctly:
  ```
  tests/test_schemas.py::TestOutputFieldsDescription::test_all_schemas_use_helper[CreateScoutInput]
  tests/test_schemas.py::TestOutputFieldsDescription::test_all_schemas_use_helper[EditScoutInput]
  tests/test_schemas.py::TestOutputFieldsDescription::test_all_schemas_use_helper[BrowsingTaskInput]
  tests/test_schemas.py::TestOutputFieldsDescription::test_all_schemas_use_helper[ResearchTaskInput]
  ```
- `pytest -q` (219 passed) and `ruff check .` both clean locally before pushing.


---
_Generated by [Claude Code](https://claude.ai/code/session_011zcec8DYF7kMT9CPwtGeE1)_