### PR TITLE
test(server): parametrize manual for-loop in TestRegisteredToolLimitDefaults

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -128,10 +128,12 @@ class TestRegisteredToolLimitDefaults:
     applies once a request omits the argument entirely). The two must be
     kept in sync manually, so pin them here."""
 
-    async def test_advertised_limit_defaults_match_shared_constant(self):
+    @pytest.mark.parametrize(
+        "name", ["list_scouts", "list_browsing_tasks", "list_research_tasks"]
+    )
+    async def test_advertised_limit_defaults_match_shared_constant(self, name):
         tools = {t.name: t.inputSchema for t in await mcp.list_tools()}
-        for name in ("list_scouts", "list_browsing_tasks", "list_research_tasks"):
-            assert tools[name]["properties"]["limit"]["default"] == DEFAULT_LIST_LIMIT
+        assert tools[name]["properties"]["limit"]["default"] == DEFAULT_LIST_LIMIT
 
 
 def _assert_main_exits(expected_code: int) -> None:


### PR DESCRIPTION
## What

`TestRegisteredToolLimitDefaults::test_advertised_limit_defaults_match_shared_constant` in `tests/test_server.py` iterated over `("list_scouts", "list_browsing_tasks", "list_research_tasks")` in a plain `for` loop with an `assert` inside — the same shape that PRs #148, #149, #154, #155, and #156 already converted to `@pytest.mark.parametrize` elsewhere in this repo (in `test_schemas.py` and `test_adapter.py`). This instance was in `test_server.py`, which was out of scope for those earlier passes.

## Why

With a plain loop, a failure on an earlier tool name (e.g. `list_scouts`) stops the loop before checking the remaining ones, hiding failures. Parametrizing reports each of the 3 tool names as an independent test case, matching the convention already established in this file's siblings.

## Change

Converted the loop to `@pytest.mark.parametrize("name", ["list_scouts", "list_browsing_tasks", "list_research_tasks"])`. Test-only, no coverage change: the same 3 cases are exercised.

- `pytest`: 219 -> 221 passed (net +2, matching the pattern of prior parametrize PRs in this series)
- `ruff check` / `ruff format`: clean on the touched file

No functional/behavior change — this only touches `tests/test_server.py`.

Co-authored-by: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_018qSGdSNY3DyJq4EiLRxRxk)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor in `tests/test_server.py`; no production or MCP server behavior changes.
> 
> **Overview**
> Refactors **`TestRegisteredToolLimitDefaults::test_advertised_limit_defaults_match_shared_constant`** so the three list tools (`list_scouts`, `list_browsing_tasks`, `list_research_tasks`) are checked via **`@pytest.mark.parametrize`** instead of a single test with an internal `for` loop.
> 
> Behavior is unchanged: each tool’s advertised MCP `limit` default is still asserted against **`DEFAULT_LIST_LIMIT`**. Pytest now reports **three separate cases**, so a failure on one tool name does not skip the others—aligned with parametrized tests elsewhere in the repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2db14b06832b1bc99f16cc3f4dbb8a9a8034de4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->