### PR TITLE
test(adapter): parametrize duplicate TestErrorFormattingContract methods

### DIFF
--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -91,13 +91,16 @@ class TestErrorFormattingContract:
     test_server.py::TestCallToolErrorContract.
     """
 
-    def test_api_error_formatted_as_text(self):
-        err = YutoriAPIError(message="Not found", status_code=404)
-        assert _format_api_error(err) == "API Error (404): Not found"
-
-    def test_auth_error_formatted_as_401(self):
-        err = YutoriAPIError(message="Invalid API key", status_code=401)
-        assert _format_api_error(err) == "API Error (401): Invalid API key"
+    @pytest.mark.parametrize(
+        "message,status_code",
+        [
+            pytest.param("Not found", 404, id="api-error"),
+            pytest.param("Invalid API key", 401, id="auth-error-as-401"),
+        ],
+    )
+    def test_error_formatted_as_text(self, message, status_code):
+        err = YutoriAPIError(message=message, status_code=status_code)
+        assert _format_api_error(err) == f"API Error ({status_code}): {message}"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Structural issue

`tests/test_adapter.py::TestErrorFormattingContract` had two test methods —
`test_api_error_formatted_as_text` and `test_auth_error_formatted_as_401` —
that were structurally identical: construct a `YutoriAPIError(message=..., status_code=...)`
and assert `_format_api_error(err) == "API Error (<code>): <message>"`. The
only differences were the literal `message`/`status_code` values and the
resulting formatted string, which is itself a deterministic function of
those two inputs.

This is the same "near-identical test methods differing only by a literal"
shape that this file/repo has repeatedly consolidated via
`@pytest.mark.parametrize` (e.g. `TestErrorMapping.test_api_error_preserves_status_code`,
and the schemas-side `TestEditScoutInput`/`TestListScoutsInput`/`TestListTasksInput`
parametrizations). I did a fresh read of `src/yutori_mcp/` and `tests/` looking for
an un-mined duplicate-shape candidate and this pair was the cleanest one still
outstanding (confirmed via an AST-based structural-duplicate scan across all four
test modules, which also ruled out a couple of other superficially-similar pairs
whose bodies actually exercise unrelated behavior and shouldn't be merged).

## Fix

Folded both cases into a single parametrized `test_error_formatted_as_text`,
deriving the expected string from the same `message`/`status_code` parameters
via an f-string instead of duplicating the literal formatted string per case.

## Why it's safe

- Test-only change; no production code touched.
- Both original cases are still exercised independently (pytest reports them
  as separate parametrized cases via `id=`), so coverage is unchanged.
- Full suite passes: 221 passed (`uv run --extra dev pytest -q`).
- `ruff check` and `ruff format --diff` both clean on the touched file.
- Diff is a single, small, mechanical hunk in one file — reviewable at a glance.


---
_Generated by [Claude Code](https://claude.ai/code/session_01VE3icdSQF9ULWAraK2MVUw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tests-only change with no production code touched; same assertions exercised via parametrized cases.
> 
> **Overview**
> **Test-only refactor** in `TestErrorFormattingContract`: the separate `test_api_error_formatted_as_text` and `test_auth_error_formatted_as_401` methods are replaced by one **`@pytest.mark.parametrize`** test, `test_error_formatted_as_text`, with cases for 404 and 401 (`id="api-error"` / `id="auth-error-as-401"`).
> 
> The expected string is now built with an f-string from `message` and `status_code` instead of hard-coded literals per case. Behavior and coverage for `_format_api_error` are unchanged; this matches the same parametrize pattern used elsewhere in `tests/test_adapter.py` (e.g. `TestErrorMapping.test_api_error_preserves_status_code`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59028f63caf00e37ee8e8fa100b70f385631b6c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->