### PR TITLE
test(server): parametrize duplicate TestMainStatusExitCode methods

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -145,26 +145,33 @@ def _assert_main_exits(expected_code: int) -> None:
 class TestMainStatusExitCode:
     """Ensure `yutori-mcp status` exits 1 when unauthenticated, 0 when authenticated."""
 
-    def test_status_unauthenticated_exits_1(self):
-        status = AuthStatus(authenticated=False, config_path="/tmp/.yutori/config.json")
+    @pytest.mark.parametrize(
+        "status_kwargs,expected_exit_code",
+        [
+            pytest.param(
+                {"authenticated": False, "config_path": "/tmp/.yutori/config.json"},
+                1,
+                id="unauthenticated",
+            ),
+            pytest.param(
+                {
+                    "authenticated": True,
+                    "masked_key": "yt-abc...xyz",
+                    "source": "config_file",
+                    "config_path": "/tmp",
+                },
+                0,
+                id="authenticated",
+            ),
+        ],
+    )
+    def test_status_exit_code(self, status_kwargs, expected_exit_code):
+        status = AuthStatus(**status_kwargs)
         with (
             patch("sys.argv", ["yutori-mcp", "status"]),
             patch("yutori.auth.get_auth_status", return_value=status),
         ):
-            _assert_main_exits(1)
-
-    def test_status_authenticated_exits_0(self):
-        status = AuthStatus(
-            authenticated=True,
-            masked_key="yt-abc...xyz",
-            source="config_file",
-            config_path="/tmp",
-        )
-        with (
-            patch("sys.argv", ["yutori-mcp", "status"]),
-            patch("yutori.auth.get_auth_status", return_value=status),
-        ):
-            _assert_main_exits(0)
+            _assert_main_exits(expected_exit_code)
 
 
 class TestMainLoginAuthUrl:


### PR DESCRIPTION
## Summary

`TestMainStatusExitCode` in `tests/test_server.py` had two test methods identical in shape:

- `test_status_unauthenticated_exits_1`
- `test_status_authenticated_exits_0`

Both build an `AuthStatus`, patch `sys.argv` and `yutori.auth.get_auth_status`, then assert the exit code from `main()`. They differed only in the `AuthStatus` constructor kwargs and the expected exit code — the same shape this test file has repeatedly folded via `@pytest.mark.parametrize` (e.g. `TestRegisteredToolLimitDefaults` in #157, `TestErrorFormattingContract` in #158).

Folded the two into a single parametrized `test_status_exit_code`, with `pytest.param(..., id=...)` for readability, matching the established convention in this file/repo.

## Why it's safe

- Test-only change; no production code touched.
- Both original cases are still exercised independently (parametrize IDs: `unauthenticated`, `authenticated`).
- Full suite: **221 passed before, 221 passed after** (same count — no coverage change).
- `ruff check` and `ruff format --check` both clean on the changed file.

## Test plan

- [x] `pytest -q` — 221 passed (both before and after the change)
- [x] `ruff check tests/test_server.py` — clean
- [x] `ruff format --check tests/test_server.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01HCLMtR3AFfLpnQvjvoafkL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor; no production code changed and both auth scenarios remain covered.
> 
> **Overview**
> Refactors **`TestMainStatusExitCode`** in `tests/test_server.py` by replacing **`test_status_unauthenticated_exits_1`** and **`test_status_authenticated_exits_0`** with a single **`test_status_exit_code`** driven by **`@pytest.mark.parametrize`**.
> 
> Each case still builds an **`AuthStatus`**, patches **`sys.argv`** and **`get_auth_status`**, and asserts **`main()`**’s exit code via **`_assert_main_exits`** — with **`pytest.param(..., id="unauthenticated"|"authenticated")`** for the two scenarios (exit **1** vs **0**). Aligns with the same parametrize style used elsewhere in this file (e.g. **`TestRegisteredToolLimitDefaults`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45bc584a92272797e2c5eacfac7164ed38e2cedb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->