### PR TITLE
test(formatters): parametrize duplicate TestTimestampFormatting methods

### DIFF
--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -1,5 +1,7 @@
 """Tests for output formatters."""
 
+import pytest
+
 from yutori_mcp.formatters import (
     _EXTERNAL_CONTENT_END,
     _EXTERNAL_CONTENT_START,
@@ -779,12 +781,16 @@ class TestTimestampFormatting:
         result = format_list_scouts(response)
         assert "Next: 2026-02-02" in result
 
-    def test_format_datetime_unix_seconds(self):
-        # Same instant as the millisecond value used elsewhere in this suite.
-        assert _format_datetime(1769997854) == "2026-02-02 02:04 UTC"
-
-    def test_format_datetime_unix_milliseconds(self):
-        assert _format_datetime(1769997854699) == "2026-02-02 02:04 UTC"
+    @pytest.mark.parametrize(
+        "timestamp",
+        [
+            # Same instant expressed as Unix seconds and Unix milliseconds.
+            pytest.param(1769997854, id="seconds"),
+            pytest.param(1769997854699, id="milliseconds"),
+        ],
+    )
+    def test_format_datetime_unix(self, timestamp):
+        assert _format_datetime(timestamp) == "2026-02-02 02:04 UTC"
 
 
 class TestFormatTaskResultUnrecognizedStatus:


### PR DESCRIPTION
## Issue

`tests/test_formatters.py::TestTimestampFormatting` had two structurally identical single-assert test methods:

```python
def test_format_datetime_unix_seconds(self):
    assert _format_datetime(1769997854) == "2026-02-02 02:04 UTC"

def test_format_datetime_unix_milliseconds(self):
    assert _format_datetime(1769997854699) == "2026-02-02 02:04 UTC"
```

They differ only in the input literal (the same instant expressed as Unix seconds vs. Unix milliseconds), matching the exact "two near-identical test methods differing only by a literal" shape this test suite has been repeatedly converting to `@pytest.mark.parametrize` (see `TestEditScoutInput.test_status_valid`, `TestListScoutsInput.test_status_filter`, `TestErrorMapping.test_api_error_preserves_status_code`, `TestErrorFormattingContract.test_error_formatted_as_text`, `TestMainStatusExitCode.test_status_exit_code`, etc. from PRs #148-#155, #158, #159). This one was in `test_formatters.py`, a file none of the prior passes had focused this specific cleanup on.

## Improvement

Folded both into a single parametrized test:

```python
@pytest.mark.parametrize(
    "timestamp",
    [
        pytest.param(1769997854, id="seconds"),
        pytest.param(1769997854699, id="milliseconds"),
    ],
)
def test_format_datetime_unix(self, timestamp):
    assert _format_datetime(timestamp) == "2026-02-02 02:04 UTC"
```

Each case is now reported independently by pytest (rather than being two separately-named methods), matching the file's/repo's established convention.

## Safety

- Test-only change; no production code touched.
- No coverage change: both cases (seconds-path and milliseconds-path through `_format_datetime`/`_timestamp_to_utc`) are still exercised independently.
- `pytest -q`: **221 passed** before and after this change (identical count).
- `ruff check`: clean before and after.

This was found via a fresh, careful read of all 5 source files (`adapter.py`, `server.py`, `formatters.py`, `schemas.py`, `schema_utils.py`, confirmed still fully saturated — every duplicated Field()-shape/dispatch-table/formatter-helper already extracted per `.claude/REFACTOR.md`'s `## yutori-mcp` history) plus a structural AST-diff scan of the full test suite, which surfaced this one remaining un-mined pair (one other near-match, in `TestFormatUsage`, was considered and correctly left alone — its two methods assert on genuinely different response sections and merging would lose that distinction).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PUbvcYCaquGTvzDVZvktr9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tests-only refactor with no production code changes; same assertions and coverage as before.
> 
> **Overview**
> **Test-only cleanup** in `TestTimestampFormatting`: the two nearly identical methods `test_format_datetime_unix_seconds` and `test_format_datetime_unix_milliseconds` are replaced by one `@pytest.mark.parametrize` test, `test_format_datetime_unix`, with `id="seconds"` and `id="milliseconds"`.
> 
> Adds a top-level `pytest` import for `pytest.param`. Behavior and coverage are unchanged—both Unix second and millisecond inputs still assert the same UTC string—aligned with how other tests in the repo use parametrization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 107e6216e3f4cd53196f52efb09c90962245a4b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->