### PR TITLE
Parametrize duplicated browsing/research pagination-forwarding tests

### DIFF
--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -230,26 +230,35 @@ class TestEditScoutForwarding:
 class TestBrowsingAndResearchForwarding:
     """Browsing and research should forward newly supported developer API fields."""
 
-    async def test_list_browsing_tasks_forwards_pagination_filters(self, adapter):
-        adapter._client.browsing.list = AsyncMock(return_value={"tasks": []})
-        await adapter.list_browsing_tasks(limit=20, status="succeeded", cursor="cur-1")
+    @pytest.mark.parametrize(
+        "adapter_method,client_ns,status,cursor",
+        [
+            pytest.param("list_browsing_tasks", "browsing", "succeeded", "cur-1", id="browsing"),
+            pytest.param("list_research_tasks", "research", "failed", "cur-2", id="research"),
+        ],
+    )
+    async def test_list_tasks_forwards_pagination_filters(self, adapter, adapter_method, client_ns, status, cursor):
+        namespace = getattr(adapter._client, client_ns)
+        namespace.list = AsyncMock(return_value={"tasks": []})
+        await getattr(adapter, adapter_method)(limit=20, status=status, cursor=cursor)
 
-        _, kwargs = adapter._client.browsing.list.call_args
-        assert kwargs == {"limit": 20, "status": "succeeded", "cursor": "cur-1"}
+        _, kwargs = namespace.list.call_args
+        assert kwargs == {"limit": 20, "status": status, "cursor": cursor}
 
-    async def test_list_browsing_tasks_strips_none_values(self, adapter):
-        adapter._client.browsing.list = AsyncMock(return_value={"tasks": []})
-        await adapter.list_browsing_tasks(limit=None, status=None, cursor=None)
+    @pytest.mark.parametrize(
+        "adapter_method,client_ns",
+        [
+            pytest.param("list_browsing_tasks", "browsing", id="browsing"),
+            pytest.param("list_research_tasks", "research", id="research"),
+        ],
+    )
+    async def test_list_tasks_strips_none_values(self, adapter, adapter_method, client_ns):
+        namespace = getattr(adapter._client, client_ns)
+        namespace.list = AsyncMock(return_value={"tasks": []})
+        await getattr(adapter, adapter_method)(limit=None, status=None, cursor=None)
 
-        _, kwargs = adapter._client.browsing.list.call_args
+        _, kwargs = namespace.list.call_args
         assert kwargs == {}
-
-    async def test_list_research_tasks_forwards_pagination_filters(self, adapter):
-        adapter._client.research.list = AsyncMock(return_value={"tasks": []})
-        await adapter.list_research_tasks(limit=20, status="failed", cursor="cur-2")
-
-        _, kwargs = adapter._client.research.list.call_args
-        assert kwargs == {"limit": 20, "status": "failed", "cursor": "cur-2"}
 
     async def test_browsing_forwards_require_auth_browser_and_zapier(self, adapter):
         adapter._client.browsing.create = AsyncMock(return_value={"task_id": "t1"})


### PR DESCRIPTION
## What

`tests/test_adapter.py`'s `test_list_browsing_tasks_forwards_pagination_filters` and `test_list_research_tasks_forwards_pagination_filters` were structurally identical — same mock setup, same await + assert shape — differing only in the namespace name and status literal. Parametrized them into a single test.

Also noticed `test_list_browsing_tasks_strips_none_values` had no research-side counterpart (a coverage gap), so parametrized that pair too while touching this test class, closing the gap for both namespaces.

## Why this is safe

- **Test-only change**, zero production code touched, zero behavior/schema/tool-interface change.
- Full suite passes: `222/222` tests green locally after the change.
- Matches this repo's own established convention — `pytest.mark.parametrize` with `pytest.param(..., id=...)` is already used extensively elsewhere in `tests/test_adapter.py`, `test_schemas.py`, `test_server.py`, `test_formatters.py`.

---
🤖 Generated with automated refactor cronjob

Claude-Session: https://claude.ai/code/session_01B2jEj2sEcy15pBafcj5QGx

---
_Generated by [Claude Code](https://claude.ai/code/session_01B2jEj2sEcy15pBafcj5QGx)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production code changes; behavior under test is unchanged aside from new research-side None-stripping assertion.
> 
> **Overview**
> Refactors **test-only** coverage in `TestBrowsingAndResearchForwarding` so browsing and research share the same assertions instead of copy-pasted tests.
> 
> **Pagination forwarding:** `list_browsing_tasks` and `list_research_tasks` pagination tests are merged into one parametrized `test_list_tasks_forwards_pagination_filters` that drives the adapter method and client namespace via `getattr`, with distinct status/cursor values per case.
> 
> **None-stripping:** `test_list_browsing_tasks_strips_none_values` becomes parametrized `test_list_tasks_strips_none_values`, adding the same “don’t forward None kwargs” check for `list_research_tasks` (previously only browsing was covered).
> 
> No production or adapter behavior changes—only test structure and slightly broader parity coverage for research list calls.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd75c82a27847b86f858613b9e0c980c40b67506. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->