### PR TITLE
Parametrize duplicated list_tasks dispatch tests in test_server.py

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -307,44 +307,42 @@ class TestCallToolErrorContract:
         assert result.root.isError is False
         assert "Found 0 scouts" in result.root.content[0].text
 
-    async def test_list_browsing_tasks_dispatches_with_filters(self):
+    @pytest.mark.parametrize(
+        "tool_name,request_args,expected_kwargs,expected_label",
+        [
+            pytest.param(
+                "list_browsing_tasks",
+                {"limit": 20, "status": "succeeded", "cursor": "cur-1"},
+                {"limit": 20, "status": "succeeded", "cursor": "cur-1"},
+                "browsing",
+                id="browsing",
+            ),
+            pytest.param(
+                "list_research_tasks",
+                {"status": "failed"},
+                {"limit": 10, "status": "failed"},
+                "research",
+                id="research",
+            ),
+        ],
+    )
+    async def test_list_tasks_dispatches_with_filters(
+        self, tool_name, request_args, expected_kwargs, expected_label
+    ):
         handler = _call_tool_handler()
         with _patched_adapter() as client:
-            client.list_browsing_tasks.return_value = {
+            mock_method = getattr(client, tool_name)
+            mock_method.return_value = {
                 "tasks": [],
                 "total": 0,
                 "filtered_total": 0,
                 "summary": {"running": 0, "succeeded": 0, "failed": 0},
             }
-            result = await handler(
-                _call_tool_request(
-                    "list_browsing_tasks",
-                    {"limit": 20, "status": "succeeded", "cursor": "cur-1"},
-                )
-            )
+            result = await handler(_call_tool_request(tool_name, request_args))
 
-        client.list_browsing_tasks.assert_awaited_once_with(
-            limit=20, status="succeeded", cursor="cur-1"
-        )
+        mock_method.assert_awaited_once_with(**expected_kwargs)
         assert result.root.isError is False
-        assert "Found 0 browsing tasks" in result.root.content[0].text
-
-    async def test_list_research_tasks_dispatches_with_filters(self):
-        handler = _call_tool_handler()
-        with _patched_adapter() as client:
-            client.list_research_tasks.return_value = {
-                "tasks": [],
-                "total": 0,
-                "filtered_total": 0,
-                "summary": {"running": 0, "succeeded": 0, "failed": 0},
-            }
-            result = await handler(
-                _call_tool_request("list_research_tasks", {"status": "failed"})
-            )
-
-        client.list_research_tasks.assert_awaited_once_with(limit=10, status="failed")
-        assert result.root.isError is False
-        assert "Found 0 research tasks" in result.root.content[0].text
+        assert f"Found 0 {expected_label} tasks" in result.root.content[0].text
 
     async def test_delete_scout_dispatches_with_scout_id(self):
         handler = _call_tool_handler()


### PR DESCRIPTION
## Problem

`tests/test_server.py::TestCallToolErrorContract` had two near-identical end-to-end dispatch tests:

- `test_list_browsing_tasks_dispatches_with_filters`
- `test_list_research_tasks_dispatches_with_filters`

They exercised the exact same call path (`_call_tool_handler()` → `_patched_adapter()` → assert forwarded kwargs → assert "Found 0 `<label>` tasks" in output) and differed only in tool name, request args, expected forwarded kwargs, and the label text in the assertion. This is the same browsing/research duplication shape that PR #161 parametrized in `tests/test_adapter.py` (`TestBrowsingAndResearchForwarding`) — it just wasn't caught there since it lives in a different test class in a different file, testing the FastMCP dispatch path rather than the adapter's argument-forwarding.

## Fix

Collapsed the two tests into a single parametrized `test_list_tasks_dispatches_with_filters`, following the exact same `pytest.param(..., id=...)` style already used elsewhere in this file (e.g. `TestRegisteredToolLimitDefaults`, `TestMainStatusExitCode`). No behavior change — same mocking, same assertions, same two concrete scenarios (browsing with full pagination args, research relying on the default limit).

## Safety

- Diff touches exactly one file (`tests/test_server.py`), no source/functionality changes.
- Full suite: **222 passed** before and after the change (verified via `python -m pytest -q`).
- Verified both parametrized cases (`dispatches_with_filters and browsing` / `and research`) still individually pass via `pytest -k dispatches_with_filters -v`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01MfdtG5SM382bETNdWTuDxj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test structure changes in one file; scenarios and expectations are unchanged.
> 
> **Overview**
> **Test-only refactor** in `TestCallToolErrorContract`: the separate `test_list_browsing_tasks_dispatches_with_filters` and `test_list_research_tasks_dispatches_with_filters` cases are merged into one **`test_list_tasks_dispatches_with_filters`** driven by `@pytest.mark.parametrize` (`id="browsing"` / `id="research"`).
> 
> Each case still hits the FastMCP `tools/call` handler with a patched `MCPClientAdapter`, checks the matching `list_*_tasks` method is awaited with the expected kwargs, and asserts the success text includes `Found 0 <label> tasks`. **No production or MCP behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f9f8ce22b6a7c1289fe947dcfe1bdd1897f4d22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->