### PR TITLE
Tighten _make_handler's context type to the specific input schema

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Awaitable, Callable
-from typing import Any, NoReturn
+from typing import Any, NoReturn, TypeVar
 
 from mcp.server.fastmcp import FastMCP
 from mcp.server.fastmcp.exceptions import ToolError
@@ -337,6 +337,11 @@ ToolHandler = Callable[
     Awaitable[tuple[dict[str, Any], dict[str, Any]]],
 ]
 
+# Bound to BaseModel so _make_handler can tie its `context` callable's
+# parameter type to the specific input_class passed at each call site
+# (see _make_handler below), instead of widening it to plain BaseModel.
+_InputT = TypeVar("_InputT", bound=BaseModel)
+
 
 def _output_schema_kwargs(
     params: BaseModel, extra_exclude: set[str] | None = None
@@ -355,8 +360,9 @@ def _output_schema_kwargs(
     """
     exclude = {"output_fields"} | (extra_exclude or set())
     kwargs = params.model_dump(exclude=exclude, exclude_none=True)
-    if getattr(params, "output_fields", None) is not None:
-        kwargs["output_schema"] = output_fields_to_output_schema(params.output_fields)
+    output_fields = getattr(params, "output_fields", None)
+    if output_fields is not None:
+        kwargs["output_schema"] = output_fields_to_output_schema(output_fields)
     return kwargs
 
 
@@ -368,9 +374,9 @@ def _output_schema_kwargs(
 
 
 def _make_handler(
-    input_class: type[BaseModel],
+    input_class: type[_InputT],
     client_method: str,
-    context: dict[str, Any] | Callable[[BaseModel], dict[str, Any]] | None = None,
+    context: dict[str, Any] | Callable[[_InputT], dict[str, Any]] | None = None,
 ) -> ToolHandler:
     """Build a handler that parses an input schema and forwards it as adapter kwargs.
 
@@ -385,6 +391,12 @@ def _make_handler(
     ``create_scout``, which has no task-type concept). Generating these from
     one factory keeps the registry as the single place that pairs the tool
     name with its input schema, adapter method, and context.
+
+    ``input_class``/``context`` share the ``_InputT`` type variable so a
+    context callable can access fields specific to the ``input_class`` passed
+    at the same call site (e.g. ``lambda params: {"browser": params.browser}``
+    for ``BrowsingTaskInput``) without a type checker widening ``params`` to
+    plain ``BaseModel``.
     """
 
     async def handler(
@@ -475,7 +487,7 @@ _TOOL_HANDLERS: dict[str, ToolHandler] = {
     "delete_scout": _make_handler(
         ScoutIdInput,
         "delete_scout",
-        lambda params: {"scout_id": params.scout_id},  # type: ignore[attr-defined]
+        lambda params: {"scout_id": params.scout_id},
     ),
     "list_browsing_tasks": _make_handler(
         ListTasksInput, "list_browsing_tasks", {"task_type": TASK_TYPE_BROWSING}
@@ -483,7 +495,7 @@ _TOOL_HANDLERS: dict[str, ToolHandler] = {
     "run_browsing_task": _make_handler(
         BrowsingTaskInput,
         "run_browsing_task",
-        lambda params: {"task_type": TASK_TYPE_BROWSING, "browser": params.browser},  # type: ignore[attr-defined]
+        lambda params: {"task_type": TASK_TYPE_BROWSING, "browser": params.browser},
     ),
     "get_browsing_task_result": _make_handler(
         TaskIdInput, "get_browsing_task", {"task_type": TASK_TYPE_BROWSING}


### PR DESCRIPTION
## What

`server.py`'s `_make_handler` factory had this signature:

```python
def _make_handler(
    input_class: type[BaseModel],
    client_method: str,
    context: dict[str, Any] | Callable[[BaseModel], dict[str, Any]] | None = None,
) -> ToolHandler:
```

`input_class` and `context` are always paired at each call site in `_TOOL_HANDLERS` (e.g. `ScoutIdInput` with a lambda reading `params.scout_id`, `BrowsingTaskInput` with a lambda reading `params.browser`), but the signature typed `context`'s parameter as plain `BaseModel`, which doesn't have those fields. The two call sites that needed field access papered over this with `# type: ignore[attr-defined]` instead of the interface being correct.

This PR parametrizes `_make_handler` over a `TypeVar` bound to `BaseModel` (`_InputT`) so the `context` callable's parameter type follows whichever `input_class` was passed at that same call site, and removes both `# type: ignore` comments. Also tightened `_output_schema_kwargs` to reuse its `getattr(params, "output_fields", None)` result instead of a second direct `params.output_fields` access right below it — same underlying pattern, a third (previously unsuppressed) instance.

## Why this is safe

- Pure typing change — `TypeVar` is erased at runtime, so there is no behavior change. `_make_handler`'s returned `ToolHandler` type is unchanged.
- Full test suite passes unmodified: `pytest -q` → 228 passed.
- This repo has no `mypy`/`ruff` config wired into CI today, so these were latent errors nobody was seeing. I verified the fix is real by stripping the two `# type: ignore` comments and running `mypy` against `server.py` on the pre-change code: it reports 3 `attr-defined` errors (the two suppressed ones, plus the previously-unsuppressed `_output_schema_kwargs` one). After this change, `mypy src/yutori_mcp/ --ignore-missing-imports` reports 0 errors across all 6 source files.

## Test plan

- [x] `pytest -q` — 228 passed
- [x] `mypy src/yutori_mcp/ --ignore-missing-imports` — clean (0 errors, previously 3 attr-defined errors once the suppressions are removed)
- [x] `python -m py_compile src/yutori_mcp/server.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F4kmiaFrae9AB2gScgTcEp

---
_Generated by [Claude Code](https://claude.ai/code/session_01F4kmiaFrae9AB2gScgTcEp)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime behavior change; TypeVar is erased at runtime and the public `ToolHandler` contract is unchanged.
> 
> **Overview**
> **Typing-only** update to `_make_handler` in `server.py`: adds `_InputT` (`TypeVar` bound to `BaseModel`) so `input_class` and optional `context` callables share the same concrete Pydantic input type at each `_TOOL_HANDLERS` registration site.
> 
> That removes two `# type: ignore[attr-defined]` comments on lambdas that read `params.scout_id` and `params.browser`, and documents the pattern in `_make_handler`'s docstring.
> 
> `_output_schema_kwargs` now reuses a single `getattr(params, "output_fields", None)` result instead of accessing `params.output_fields` again for the schema transform.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e0dbb28493e3301402442f5f13cdca9758ef722. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->