### PR TITLE
refactor(adapter): tighten _call's fn parameter to a proper Callable type

### DIFF
--- a/src/yutori_mcp/adapter.py
+++ b/src/yutori_mcp/adapter.py
@@ -9,6 +9,7 @@ used so slow Yutori API calls never block the MCP server's event loop.
 from __future__ import annotations
 
 import logging
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from yutori import AsyncYutoriClient
@@ -121,7 +122,9 @@ class MCPClientAdapter:
     # -------------------------------------------------------------------------
 
     @staticmethod
-    async def _call(fn: Any, *args: Any, **kwargs: Any) -> dict[str, Any]:
+    async def _call(
+        fn: Callable[..., Awaitable[dict[str, Any]]], *args: Any, **kwargs: Any
+    ) -> dict[str, Any]:
         """Await an SDK method, converting SDK APIError to MCP YutoriAPIError.
 
         Filters None-valued kwargs before forwarding so callers can pass


### PR DESCRIPTION
## What

`MCPClientAdapter._call` (in `src/yutori_mcp/adapter.py`) forwards every SDK namespace method it's called with (`scouts.list`, `scouts.create`, `browsing.create`, `get_usage`, etc. — 12 call sites), all of which are async methods returning `dict[str, Any]`. The `fn` parameter was typed as bare `Any`, hiding a real, checkable contract.

Changed the signature to `fn: Callable[..., Awaitable[dict[str, Any]]]`, adding `from collections.abc import Awaitable, Callable`. `*args`/`**kwargs` stay `Any` since call sites pass heterogeneous positional/keyword values.

This mirrors the same "tighten an overly broad interface" fix PR #165 made for `_make_handler`'s `context` parameter.

## Why it's safe

- Type-only change, erased at runtime — no behavioral difference.
- All 12 existing call sites already satisfy the new type (verified against the actual SDK method signatures, which all return `dict[str, Any]` coroutines).
- Full test suite passes unchanged: `pytest tests/` — 228 passed (including all 34 in `tests/test_adapter.py`, which directly exercises `_call`'s error mapping and forwarding).
- `ruff check`, `ruff format --check`, and `mypy` all clean.

## Scope

Single file, single function signature.


---
_Generated by [Claude Code](https://claude.ai/code/session_0143tDC2FScrLKaUccNHadNZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static typing only; all existing call sites already match the new contract and tests are unchanged.
> 
> **Overview**
> **`MCPClientAdapter._call`** now types its `fn` argument as `Callable[..., Awaitable[dict[str, Any]]]` instead of `Any`, matching the async SDK methods every adapter method passes through.
> 
> Adds `Awaitable` and `Callable` from `collections.abc`. `*args` and `**kwargs` remain `Any`. No runtime behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8752df2db5f59ccbf6188194baeef0498060323. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->