### PR TITLE
refactor(formatters): extract _append_external_block for the blank-line/header/external-body pattern

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -182,6 +182,17 @@ def _append_more_indicator(
         lines.append(f"{indent}... and {remaining} more")
 
 
+def _append_external_block(lines: list[str], body: list[str], *, header: str | None = None) -> None:
+    """Append a blank line, an optional header, then ``body`` wrapped in external-content markers.
+
+    Shared by ``format_scout_updates``'s content block and ``_append_result_content``.
+    """
+    lines.append("")
+    if header:
+        lines.append(header)
+    lines.extend(_wrap_external(body))
+
+
 def _pagination_state(response: dict[str, Any]) -> tuple[bool, str | None]:
     """Return the shared `(has_more, next_cursor)` pagination pair from a list-style response.
 
@@ -526,8 +537,7 @@ def format_scout_updates(response: dict[str, Any], **context: Any) -> str:
                     body.append("  ... (truncated)")
             elif isinstance(content, dict):
                 body.append(dict_to_markdown(content, level=1))
-            lines.append("")
-            lines.extend(_wrap_external(body))
+            _append_external_block(lines, body)
 
         findings = update.get("findings", [])
         if findings:
@@ -853,9 +863,7 @@ def _append_result_content(lines: list[str], response: dict[str, Any]) -> None:
                     body.append("")
                 else:
                     body.append(f"- {item}")
-        lines.append("")
-        lines.append("Result:")
-        lines.extend(_wrap_external(body))
+        _append_external_block(lines, body, header="Result:")
 
     lines.extend(_format_sources(response, indent=""))
 


### PR DESCRIPTION
## What

`format_scout_updates`'s content block and `_append_result_content` both independently did the same three-step append: a blank line, then an optional header, then the body wrapped in external-content markers (`lines.append(""); [lines.append(header);] lines.extend(_wrap_external(body))`). Extracted into a single `_append_external_block(lines, body, *, header=None)` helper, placed next to the file's existing small mutation helpers (`_append_more_indicator`, `_append_rejection_reason`) to match that established style.

## Why it's safe

- Output text is byte-identical — this is a pure helper extraction, not a formatting change.
- `tests/test_formatters.py` (71 tests) passes unchanged.
- `ruff check` passes.
- Single file touched, no signature changes to any public formatter function.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HauDbyvqDezsv7H1Z3iuVw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file refactor with no public API changes; behavior should be identical to the inlined logic.
> 
> **Overview**
> Introduces **`_append_external_block`** in `formatters.py` next to other small line-mutation helpers (`_append_more_indicator`, `_append_rejection_reason`). It centralizes the repeated pattern: blank line, optional header, then body lines wrapped in external-content markers via `_wrap_external`.
> 
> **`format_scout_updates`** (update content) and **`_append_result_content`** (task results with `header="Result:"`) now call this helper instead of duplicating those three append steps. Formatter output is intended to stay the same; this is structural deduplication only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 909429833820ca314ca9ffb66f5e5504d4d97009. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->