### PR TITLE
refactor(formatters): type the _TOOL_FORMATTERS dispatch table with a ResponseFormatter Protocol

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Protocol
 
 from .schema_utils import output_schema_field_names
 
@@ -912,10 +912,25 @@ _TASK_TOOLS: dict[str, tuple[str, str]] = {
     TASK_TYPE_BROWSING: ("list_browsing_tasks", "get_browsing_task_result"),
 }
 
+
+class ResponseFormatter(Protocol):
+    """Shape shared by every tool-name -> formatter mapping in `_TOOL_FORMATTERS`.
+
+    Each formatter takes the raw API response dict plus arbitrary per-tool
+    context kwargs (e.g. `task_type`, `browser`) stamped by server.py's
+    `_make_handler`, and renders the MCP tool result text. Mirrors
+    server.py's `ToolHandler` type on the dispatch/handler side, so both
+    halves of the tool-name -> function registry pattern are typed the same
+    way instead of only one being annotated.
+    """
+
+    def __call__(self, response: dict[str, Any], **context: Any) -> str: ...
+
+
 # Tool-name -> formatter registry, referenced by format_response() above.
 # Defined at module scope (after all formatters) so the dict is built once at
 # import time rather than rebuilt on every call.
-_TOOL_FORMATTERS = {
+_TOOL_FORMATTERS: dict[str, ResponseFormatter] = {
     "list_api_usage": format_usage,
     "list_scouts": format_list_scouts,
     "get_scout_detail": format_scout_detail,


### PR DESCRIPTION
## What

`server.py` has two tool-name -> function registries: `_TOOL_HANDLERS` (typed with `ToolHandler`, a `Callable` alias) and, on the formatting side, `formatters.py`'s `_TOOL_FORMATTERS`. The latter was left untyped even though all 10 of its entries (`format_usage`, `format_list_scouts`, `format_scout_detail`, etc.) share the identical shape `(response: dict[str, Any], **context: Any) -> str`.

Added a `ResponseFormatter` `Protocol` capturing that shape (a plain `Callable` alias can't express "one positional dict arg plus arbitrary kwargs"), and annotated `_TOOL_FORMATTERS: dict[str, ResponseFormatter]`. `format_response()`'s `formatter` local now resolves to `ResponseFormatter | None` instead of an untyped/inferred type.

This mirrors the same "type the registry" treatment `ToolHandler` already got on the handler/dispatch side (#131, #165) — just applied to the other half of the tool-name -> function mapping that hadn't been touched yet.

## Why it's safe

- Type-only addition (a `Protocol`, erased at runtime) — no behavioral change.
- All 10 existing formatter functions already satisfy the protocol's shape as-is; no call sites changed.
- Full test suite passes unchanged: 228 passed.
- `ruff check` clean on the changed file.

## Scope

Single file (`src/yutori_mcp/formatters.py`), additive type annotation only.


---
_Generated by [Claude Code](https://claude.ai/code/session_016pCwymiCMikDwBus3TTkcr)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only annotation in formatters.py; no call-site or runtime logic changes.
> 
> **Overview**
> Introduces a **`ResponseFormatter`** `Protocol` for formatters that take `(response: dict[str, Any], **context: Any) -> str`, and types **`_TOOL_FORMATTERS`** as `dict[str, ResponseFormatter]` instead of an untyped dict.
> 
> This aligns the formatter registry with **`server.py`**’s typed **`ToolHandler`** / **`_TOOL_HANDLERS`** pattern so static checkers can validate registry entries and **`format_response()`** lookups without changing runtime behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fe0fdd3ebcfc7e11cb6312c680e127f4025033f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->