### PR TITLE
fix: remove stray scripts/* gitignore rule that silently swallows new scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,5 +211,3 @@ __marimo__/
 
 # Local skill symlinks (for development testing)
 .claude/skills/
-
-scripts/*


### PR DESCRIPTION
## What

`.gitignore`'s last line, `scripts/*`, silently ignores any new file added under `scripts/`.

## Why it's there / why it's a bug

The line was swept in incidentally by an unrelated PR (#117, "forward tool wrapper params via locals() instead of hand-written dicts") — every other block in this `.gitignore` has a `#` comment explaining its purpose; this line has none, unlike its neighbor (`.claude/skills/`, which does).

It never surfaced in 150+ rounds of automated repo auditing because the one file currently under `scripts/` (`package-claude-desktop.sh`) was already tracked before the rule was added, and git ignore rules don't apply to already-tracked paths. But any *new* script added under `scripts/` (a directory that exists specifically to hold repo-maintenance scripts) would be silently invisible to `git status` and dropped by `git add -A`/`git add .`, only added if someone remembers `git add -f`.

## Fix

Removed the `scripts/*` line (and its now-orphaned blank line). Left the `.claude/skills/` line above it untouched — it has a clear, deliberate rationale.

## Why it's safe

Removing an ignore rule can only make git see *more* files, never fewer — it can't delete, move, or alter any tracked file's content or history. Single-line, purely additive-visibility change with no runtime/behavioral effect on the package, tests, or CI.

## Verification

```
$ touch scripts/test_new_script_dummy.sh
$ git check-ignore -v scripts/test_new_script_dummy.sh   # before fix: matched .gitignore:215
$ git check-ignore -v scripts/test_new_script_dummy.sh   # after fix: no match (exit 1)
$ git status --porcelain scripts/                         # after fix: new file now shows up
```

🤖 Generated by an automated refactor cronjob.


---
_Generated by [Claude Code](https://claude.ai/code/session_01T4d1y3ZfxWTxHRk3RyvKgh)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line gitignore cleanup with no runtime or CI behavior change; only increases what git can track under `scripts/`.
> 
> **Overview**
> Removes the stray **`scripts/*`** entry from **`.gitignore`** (and a blank line next to it), so new files under **`scripts/`** are no longer ignored by default.
> 
> That rule had no comment and could make new repo-maintenance scripts invisible to **`git status`** and easy to miss on **`git add`**, while already-tracked files like **`scripts/package-claude-desktop.sh`** were unaffected. **`.claude/skills/`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8f094c50c2fc8c1fe87db557a8cea01aad88957. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->