### PR TITLE
Add --env flag / YUTORI_ENV to switch between prod and dev API environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,36 @@ yutori-mcp login    # authenticate (one-time)
 yutori-mcp          # run the server (or: python -m yutori_mcp.server)
 ```
 
+### Targeting the dev environment
+
+The server hits the production API (`https://api.yutori.com/v1`) by default.
+For testing, point it at the dev stack (`https://api.dev.yutori.com/v1`) with
+the `--env` flag or the `YUTORI_ENV` environment variable (the flag wins if
+both are set):
+
+```bash
+yutori-mcp --env dev
+```
+
+Or in an MCP client config:
+
+```json
+{
+  "mcpServers": {
+    "yutori-dev": {
+      "command": "uvx",
+      "args": ["yutori-mcp", "--env", "dev"]
+    }
+  }
+}
+```
+
+Setting `"env": {"YUTORI_ENV": "dev"}` in the server config works too. An
+unknown environment name fails at startup rather than silently falling back
+to production. Note that the `login`/`logout`/`status` auth subcommands
+always talk to production; use a `YUTORI_API_KEY` valid for dev when
+targeting it.
+
 ### Debugging with MCP Inspector
 
 ```bash

--- a/src/yutori_mcp/adapter.py
+++ b/src/yutori_mcp/adapter.py
@@ -9,16 +9,48 @@ used so slow Yutori API calls never block the MCP server's event loop.
 from __future__ import annotations
 
 import logging
+import os
 from collections.abc import Awaitable, Callable
 from typing import Any
 
 from yutori import AsyncYutoriClient
 from yutori.auth.credentials import resolve_api_key
+from yutori.config import DEFAULT_BASE_URL
 from yutori.exceptions import APIConnectionError, APIError, AuthenticationError
 
 logger = logging.getLogger(__name__)
 
 ERROR_NO_API_KEY = "API key required. Run 'uvx yutori-mcp login' or set YUTORI_API_KEY."
+
+# Environment selection: name -> API base URL. `prod` must stay the default
+# so existing installs keep hitting the production API unchanged; `dev` exists
+# to point the server at the development stack for testing. server.py's
+# `--env` flag derives its choices from this dict, so adding an environment
+# here is the only change needed to expose it on the CLI.
+ENVIRONMENT_BASE_URLS: dict[str, str] = {
+    "prod": DEFAULT_BASE_URL,
+    "dev": "https://api.dev.yutori.com/v1",
+}
+DEFAULT_ENVIRONMENT = "prod"
+ENV_VAR_ENVIRONMENT = "YUTORI_ENV"
+
+
+def resolve_base_url(environment: str | None = None) -> str:
+    """Return the API base URL for an environment name.
+
+    Resolution order: explicit ``environment`` argument, then the
+    ``YUTORI_ENV`` environment variable, then prod. Raises ``ValueError``
+    for names not in ENVIRONMENT_BASE_URLS so a typo fails loudly instead
+    of silently targeting production.
+    """
+    name = environment or os.environ.get(ENV_VAR_ENVIRONMENT) or DEFAULT_ENVIRONMENT
+    try:
+        return ENVIRONMENT_BASE_URLS[name]
+    except KeyError:
+        valid = ", ".join(sorted(ENVIRONMENT_BASE_URLS))
+        raise ValueError(
+            f"Unknown Yutori environment {name!r}; expected one of: {valid}"
+        ) from None
 
 
 class YutoriAPIError(Exception):
@@ -38,11 +70,13 @@ class MCPClientAdapter:
     can't accidentally skip the filter.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, base_url: str | None = None) -> None:
         api_key = resolve_api_key()
         if not api_key:
             raise ValueError(ERROR_NO_API_KEY)
-        self._client = AsyncYutoriClient(api_key=api_key)
+        self._client = AsyncYutoriClient(
+            api_key=api_key, base_url=base_url or resolve_base_url()
+        )
 
     async def close(self) -> None:
         await self._client.close()

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -12,7 +12,14 @@ from mcp.types import ToolAnnotations
 from pydantic import BaseModel, ValidationError
 
 from . import __version__
-from .adapter import MCPClientAdapter, YutoriAPIError
+from .adapter import (
+    DEFAULT_ENVIRONMENT,
+    ENV_VAR_ENVIRONMENT,
+    ENVIRONMENT_BASE_URLS,
+    MCPClientAdapter,
+    YutoriAPIError,
+    resolve_base_url,
+)
 from .formatters import TASK_TYPE_BROWSING, TASK_TYPE_RESEARCH, format_response
 from .schema_utils import output_fields_to_output_schema
 from .schemas import (
@@ -567,6 +574,8 @@ def _handle_auth_command(command: str) -> NoReturn:
 def main() -> None:
     """Entry point for the yutori-mcp command."""
     import argparse
+    import os
+    import sys
 
     parser = argparse.ArgumentParser(prog="yutori-mcp")
     parser.add_argument(
@@ -574,6 +583,16 @@ def main() -> None:
         action="version",
         version=f"%(prog)s {__version__}",
         help="Show version and exit",
+    )
+    parser.add_argument(
+        "--env",
+        choices=tuple(ENVIRONMENT_BASE_URLS),
+        help=(
+            f"Yutori environment to target (default: {DEFAULT_ENVIRONMENT}). "
+            f"Overrides the {ENV_VAR_ENVIRONMENT} environment variable. "
+            "Applies to the MCP server's API calls; the login/logout/status "
+            "auth subcommands always use production."
+        ),
     )
     subparsers = parser.add_subparsers(dest="command")
     for name, help_text in _AUTH_SUBCOMMANDS.items():
@@ -583,6 +602,22 @@ def main() -> None:
 
     if args.command in _AUTH_SUBCOMMANDS:
         _handle_auth_command(args.command)
+
+    # The flag is forwarded via the env var (rather than threaded through to
+    # each per-call MCPClientAdapter()) so adapter.resolve_base_url() stays
+    # the single resolution point whether the environment came from the CLI
+    # or from an MCP client config's `env` block.
+    if args.env:
+        os.environ[ENV_VAR_ENVIRONMENT] = args.env
+    try:
+        base_url = resolve_base_url()
+    except ValueError as e:
+        # An invalid YUTORI_ENV must fail at startup, not on the first tool
+        # call — and never fall back silently to production.
+        parser.error(str(e))
+    if base_url != ENVIRONMENT_BASE_URLS[DEFAULT_ENVIRONMENT]:
+        # stdout carries the stdio MCP transport; stderr is safe for humans.
+        print(f"yutori-mcp: targeting non-default API {base_url}", file=sys.stderr)
 
     mcp.run(transport="stdio")
 

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -5,7 +5,15 @@ from unittest.mock import AsyncMock, patch
 import pytest
 
 from yutori.exceptions import APIConnectionError, APIError, AuthenticationError
-from yutori_mcp.adapter import MCPClientAdapter, YutoriAPIError, _strip_none
+from yutori_mcp.adapter import (
+    DEFAULT_ENVIRONMENT,
+    ENV_VAR_ENVIRONMENT,
+    ENVIRONMENT_BASE_URLS,
+    MCPClientAdapter,
+    YutoriAPIError,
+    _strip_none,
+    resolve_base_url,
+)
 from yutori_mcp.server import _format_api_error
 
 
@@ -114,19 +122,79 @@ class TestAdapterInit:
             with pytest.raises(ValueError, match="API key required"):
                 MCPClientAdapter()
 
-    def test_creates_client_with_resolved_key(self):
+    def test_creates_client_with_resolved_key(self, monkeypatch):
+        monkeypatch.delenv(ENV_VAR_ENVIRONMENT, raising=False)
         with (
             patch("yutori_mcp.adapter.resolve_api_key", return_value="yt-key"),
             patch("yutori_mcp.adapter.AsyncYutoriClient") as mock_client_cls,
         ):
             MCPClientAdapter()
-            mock_client_cls.assert_called_once_with(api_key="yt-key")
+            mock_client_cls.assert_called_once_with(
+                api_key="yt-key",
+                base_url=ENVIRONMENT_BASE_URLS[DEFAULT_ENVIRONMENT],
+            )
+
+    def test_env_var_selects_dev_base_url(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR_ENVIRONMENT, "dev")
+        with (
+            patch("yutori_mcp.adapter.resolve_api_key", return_value="yt-key"),
+            patch("yutori_mcp.adapter.AsyncYutoriClient") as mock_client_cls,
+        ):
+            MCPClientAdapter()
+            mock_client_cls.assert_called_once_with(
+                api_key="yt-key", base_url=ENVIRONMENT_BASE_URLS["dev"]
+            )
+
+    def test_explicit_base_url_wins_over_env_var(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR_ENVIRONMENT, "dev")
+        with (
+            patch("yutori_mcp.adapter.resolve_api_key", return_value="yt-key"),
+            patch("yutori_mcp.adapter.AsyncYutoriClient") as mock_client_cls,
+        ):
+            MCPClientAdapter(base_url="http://localhost:8000/v1")
+            mock_client_cls.assert_called_once_with(
+                api_key="yt-key", base_url="http://localhost:8000/v1"
+            )
 
     async def test_context_manager_closes_client(self, adapter):
         adapter._client.close = AsyncMock()
         async with adapter:
             pass
         adapter._client.close.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# resolve_base_url
+# ---------------------------------------------------------------------------
+
+
+class TestResolveBaseUrl:
+    """Environment-name -> base-URL resolution used to switch prod/dev."""
+
+    def test_defaults_to_prod(self, monkeypatch):
+        monkeypatch.delenv(ENV_VAR_ENVIRONMENT, raising=False)
+        assert resolve_base_url() == ENVIRONMENT_BASE_URLS["prod"]
+
+    @pytest.mark.parametrize("env", sorted(ENVIRONMENT_BASE_URLS))
+    def test_explicit_argument_maps_to_url(self, env):
+        assert resolve_base_url(env) == ENVIRONMENT_BASE_URLS[env]
+
+    def test_env_var_used_when_no_argument(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR_ENVIRONMENT, "dev")
+        assert resolve_base_url() == ENVIRONMENT_BASE_URLS["dev"]
+
+    def test_argument_overrides_env_var(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR_ENVIRONMENT, "dev")
+        assert resolve_base_url("prod") == ENVIRONMENT_BASE_URLS["prod"]
+
+    def test_empty_env_var_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR_ENVIRONMENT, "")
+        assert resolve_base_url() == ENVIRONMENT_BASE_URLS[DEFAULT_ENVIRONMENT]
+
+    def test_unknown_environment_raises_instead_of_hitting_prod(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR_ENVIRONMENT, "staging")
+        with pytest.raises(ValueError, match="Unknown Yutori environment 'staging'"):
+            resolve_base_url()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -218,6 +218,58 @@ class TestMainVersionFlag:
         assert output == f"yutori-mcp {__version__}"
 
 
+class TestMainEnvSelection:
+    """`--env` / YUTORI_ENV select the API environment before the server runs."""
+
+    @staticmethod
+    @contextmanager
+    def _run_main(argv, env=None):
+        """Run main() with a patched mcp.run and a scrubbed YUTORI_ENV.
+
+        Yields the mcp.run mock. patch.dict restores os.environ afterwards,
+        so the env-var write main() performs never leaks into other tests.
+        """
+        import os
+
+        environ = {k: v for k, v in os.environ.items() if k != "YUTORI_ENV"}
+        environ.update(env or {})
+        with (
+            patch.dict("os.environ", environ, clear=True),
+            patch("sys.argv", ["yutori-mcp", *argv]),
+            patch.object(mcp, "run") as mock_run,
+        ):
+            yield mock_run
+
+    def test_env_flag_sets_env_var_and_runs_server(self):
+        import os
+
+        with self._run_main(["--env", "dev"]) as mock_run:
+            main()
+            assert os.environ["YUTORI_ENV"] == "dev"
+        mock_run.assert_called_once_with(transport="stdio")
+
+    def test_dev_env_prints_target_notice_to_stderr(self, capsys):
+        with self._run_main(["--env", "dev"]):
+            main()
+        assert "api.dev.yutori.com" in capsys.readouterr().err
+
+    def test_prod_default_prints_no_notice(self, capsys):
+        with self._run_main([]) as mock_run:
+            main()
+        assert capsys.readouterr().err == ""
+        mock_run.assert_called_once_with(transport="stdio")
+
+    def test_invalid_env_flag_rejected_by_argparse(self):
+        with self._run_main(["--env", "staging"]):
+            _assert_main_exits(2)
+
+    def test_invalid_env_var_fails_at_startup(self, capsys):
+        with self._run_main([], env={"YUTORI_ENV": "staging"}) as mock_run:
+            _assert_main_exits(2)
+        mock_run.assert_not_called()
+        assert "Unknown Yutori environment 'staging'" in capsys.readouterr().err
+
+
 class TestEditScoutPartialFailure:
     """The API needs separate config/status calls, so a mid-sequence failure
     must report that the config portion was already applied."""


### PR DESCRIPTION
## What

Adds an environment selector so the MCP server can target the dev API stack instead of production, to facilitate testing:

```bash
uvx yutori-mcp --env dev
```

or via `"env": {"YUTORI_ENV": "dev"}` in an MCP client config. The CLI flag wins if both are set; the default remains `prod`, so existing installs are unaffected.

## How

- **adapter.py**: new `ENVIRONMENT_BASE_URLS` map (`prod` → `https://api.yutori.com/v1`, `dev` → `https://api.dev.yutori.com/v1`) and `resolve_base_url()`, resolving explicit argument → `YUTORI_ENV` → prod. `MCPClientAdapter` accepts an optional `base_url` and forwards it to `AsyncYutoriClient` (which already supported the parameter), so an arbitrary URL — e.g. localhost — also works programmatically.
- **server.py**: `--env {prod,dev}` flag whose choices derive from the map, so adding a future environment (staging, etc.) is a one-line change in the adapter. The flag is forwarded through the env var so `resolve_base_url()` stays the single resolution point for both the CLI and MCP-config paths.

## Notes for reviewers

- An unknown `YUTORI_ENV` value fails at startup with exit code 2 rather than silently falling back to production.
- A non-prod target prints a one-line notice to **stderr** (stdout carries the stdio MCP transport).
- The `login`/`logout`/`status` auth subcommands still always talk to production — the SDK's auth flow hardcodes the prod URL — so dev use needs a `YUTORI_API_KEY` valid for dev. Documented in `--help` and the README.

## Testing

- New tests: `resolve_base_url` resolution order and unknown-name error; `base_url` reaching `AsyncYutoriClient`; `main()` behavior for the flag, the stderr notice, and startup rejection of a bad env var (env-var writes are isolated via `patch.dict` so nothing leaks between tests).
- Full suite: 242 passed, including the CI-style `uv run --extra dev pytest -q` invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration-only change with prod default preserved; main risk is misconfigured dev keys or env typos, which now fail at startup rather than hitting prod silently.
> 
> **Overview**
> Adds **environment selection** so the MCP server can call the dev API (`api.dev.yutori.com`) instead of production, with **prod remaining the default** for existing installs.
> 
> **`--env {prod,dev}`** and **`YUTORI_ENV`** resolve through a shared `ENVIRONMENT_BASE_URLS` map and `resolve_base_url()` (CLI flag overrides the env var). **`MCPClientAdapter`** forwards the chosen base URL to `AsyncYutoriClient`; an optional explicit `base_url` still wins for local testing. Invalid environment names **fail at startup** (exit 2) instead of silently using prod; non-prod targets log a one-line notice on **stderr**. Auth subcommands **`login`/`logout`/`status`** are unchanged and still use production.
> 
> README documents dev usage and MCP client config examples; new tests cover resolution order, adapter wiring, and `main()` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a27e2c8cbe6944ba1695133df79df76c2a59dfc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->