### PR TITLE
refactor(formatters): fold rejection-reason append into _task_status_lines

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -664,15 +664,25 @@ def format_scout_deleted(response: dict[str, Any], **context: Any) -> str:
 # -----------------------------------------------------------------------------
 
 
-def _task_status_lines(message: str, *, task_id: str, footer: str) -> list[str]:
+def _task_status_lines(
+    message: str, *, task_id: str, footer: str, rejection_reason: str | None = None
+) -> list[str]:
     """Build the shared `<message>` / blank / `Task ID: ...` / `<footer>` preamble.
 
     Used by both task formatters (``format_task_started`` and
     ``format_task_result``) where this 4-line block repeats verbatim across
     every status branch. ``footer`` is typically ``f"Status: {status}"`` or
     ``f"Error: {error}"``.
+
+    ``rejection_reason`` folds in the ``_append_rejection_reason`` call that
+    otherwise immediately follows this helper in every branch that reports
+    one; branches with no rejection reason to show simply omit the argument,
+    and ``_append_rejection_reason``'s own no-op-when-falsy behavior keeps
+    that a plain no-op.
     """
-    return [message, "", f"Task ID: {task_id}", footer]
+    lines = [message, "", f"Task ID: {task_id}", footer]
+    _append_rejection_reason(lines, rejection_reason)
+    return lines
 
 
 def format_task_started(response: dict[str, Any], **context: Any) -> str:
@@ -696,8 +706,8 @@ def format_task_started(response: dict[str, Any], **context: Any) -> str:
             f"{task_type} task failed to start{browser_note}.",
             task_id=task_id,
             footer=f"Status: {status}",
+            rejection_reason=response.get("rejection_reason"),
         )
-        _append_rejection_reason(lines, response.get("rejection_reason"))
         if view_url:
             lines.append(f"View details: {view_url}")
         return "\n".join(lines)
@@ -706,8 +716,8 @@ def format_task_started(response: dict[str, Any], **context: Any) -> str:
         f"{task_type} task started{browser_note}.",
         task_id=task_id,
         footer=f"Status: {status}",
+        rejection_reason=response.get("rejection_reason"),
     )
-    _append_rejection_reason(lines, response.get("rejection_reason"))
 
     if view_url:
         lines.append(f"View progress: {view_url}")
@@ -747,8 +757,8 @@ def format_task_result(response: dict[str, Any], **context: Any) -> str:
             "Task failed.",
             task_id=task_id,
             footer=f"Error: {error}",
+            rejection_reason=response.get("rejection_reason"),
         )
-        _append_rejection_reason(lines, response.get("rejection_reason"))
         return "\n".join(lines)
 
     # Handle completed state
@@ -767,8 +777,8 @@ def format_task_result(response: dict[str, Any], **context: Any) -> str:
         f"Task ended with unrecognized status '{status}' (not completed).",
         task_id=task_id,
         footer=f"Status: {status}",
+        rejection_reason=response.get("rejection_reason"),
     )
-    _append_rejection_reason(lines, response.get("rejection_reason"))
     error = _get_first(response, "error", "message")
     if error:
         lines.append(f"Error: {error}")


### PR DESCRIPTION
## What

`format_task_started` and `format_task_result` each build their status preamble via `_task_status_lines(...)`, and in every branch that reports a rejection reason, the very next line was always the same follow-up call:

```python
lines = _task_status_lines(message, task_id=task_id, footer=footer)
_append_rejection_reason(lines, response.get("rejection_reason"))
```

This exact two-statement pairing was repeated at 4 call sites across the two formatters (2 in `format_task_started`, 2 in `format_task_result`).

## Why this is an improvement

This adds an optional `rejection_reason` keyword argument to `_task_status_lines` itself, so the pairing lives in one place instead of being hand-repeated at each call site. Branches that have nothing to report simply omit the argument — `_append_rejection_reason`'s existing no-op-when-falsy behavior means passing `rejection_reason=None` (the default) is a plain no-op, identical to today's behavior at those 2 unaffected call sites (`format_task_result`'s in-progress and completed branches).

This follows the same "extract the shared line-building helper" pattern already used elsewhere in this file (e.g. `_append_external_block`, `_scout_identity_lines`, `_id_url_lines`).

## Why this is safe

- No behavior change: the rendered text is byte-for-byte identical for every status branch — the helper now does internally what each call site did explicitly before.
- Confirmed by the existing test suite: all 242 tests pass unchanged, including rejection-reason-specific coverage in `TestFormatTaskResultUnrecognizedStatusDetails` and the rejection-reason assertions in `TestFormatTaskStarted`.
- Change is scoped to a single file (`src/yutori_mcp/formatters.py`), touches only internal formatting helpers, and does not change any MCP tool schema or client-visible behavior.
- `ruff check`, `ruff format --check` (on the touched lines), and `mypy` all pass clean on the changed file.


---
_Generated by [Claude Code](https://claude.ai/code/session_016NDmqGABNX2g1vzu5boMnQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal formatting refactor with no schema or output behavior change intended; scope is a single helper and its call sites.
> 
> **Overview**
> **`_task_status_lines`** now accepts an optional **`rejection_reason`** and calls **`_append_rejection_reason`** internally, so **`format_task_started`** and **`format_task_result`** no longer repeat the same two-step pattern at every branch that surfaces a rejection reason.
> 
> Call sites that need it pass **`response.get("rejection_reason")`** into the helper (failed start, successful start, failed result, unrecognized status). In-progress and completed result branches still omit the argument; behavior stays the same because **`_append_rejection_reason`** is a no-op when the value is missing.
> 
> Rendered MCP tool text should be unchanged; this is internal deduplication in **`formatters.py`** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf7f63764995c6ac3de3a030484d61fb1798cf63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->