### PR TITLE
refactor(formatters): route every external-content block through one _external_block helper

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -182,15 +182,27 @@ def _append_more_indicator(
         lines.append(f"{indent}... and {remaining} more")
 
 
-def _append_external_block(lines: list[str], body: list[str], *, header: str | None = None) -> None:
-    """Append a blank line, an optional header, then ``body`` wrapped in external-content markers.
+def _external_block(body: list[str], *, header: str | None = None) -> list[str]:
+    """Build a blank line, an optional header, then ``body`` wrapped in external-content markers.
 
-    Shared by ``format_scout_updates``'s content block and ``_append_result_content``.
+    Single source of truth for the "separator + label + marker-wrapped payload"
+    shape used by every block that surfaces remote text: the scout-update
+    content and findings blocks, task result bodies, and the sources list.
+    Callers that append to a running ``lines`` list use
+    ``_append_external_block``; ``_format_sources`` returns its block instead,
+    so it stays composable via ``lines.extend(...)``.
+
+    Keeping the marker wrap inside this one helper means no call site can
+    render web-derived text while forgetting the markers that tell the
+    downstream LLM the payload is data, not instructions.
     """
-    lines.append("")
-    if header:
-        lines.append(header)
-    lines.extend(_wrap_external(body))
+    header_lines = [header] if header else []
+    return ["", *header_lines, *_wrap_external(body)]
+
+
+def _append_external_block(lines: list[str], body: list[str], *, header: str | None = None) -> None:
+    """Append ``_external_block(body, header=header)`` to ``lines``."""
+    lines.extend(_external_block(body, header=header))
 
 
 def _pagination_state(response: dict[str, Any]) -> tuple[bool, str | None]:
@@ -336,7 +348,7 @@ def _format_sources(
         else:
             body.append(f"{indent}- {source}")
     _append_more_indicator(body, len(sources), max_items, indent=indent)
-    return ["", "Sources:", *_wrap_external(body)]
+    return _external_block(body, header="Sources:")
 
 
 # -----------------------------------------------------------------------------
@@ -549,8 +561,7 @@ def format_scout_updates(response: dict[str, Any], **context: Any) -> str:
                 else:
                     body.append(f"  • {_truncate(str(finding), 80)}")
             _append_more_indicator(body, len(findings), 5)
-            lines.append(f"\nFindings ({len(findings)}):")
-            lines.extend(_wrap_external(body))
+            _append_external_block(lines, body, header=f"Findings ({len(findings)}):")
 
         lines.extend(_format_sources(update))
 


### PR DESCRIPTION
## Issue

Every block in `formatters.py` that surfaces remote (user/web-controlled) text renders the same three-part shape: a blank separator line, an optional header label, then the payload wrapped in the `_EXTERNAL_CONTENT_START` / `_EXTERNAL_CONTENT_END` markers. That shape was spelled **four different ways** across the module:

| Site | How it was written |
|---|---|
| scout-update content | `_append_external_block(lines, body)` |
| task result body | `_append_external_block(lines, body, header="Result:")` |
| scout-update **findings** | `lines.append(f"\nFindings ({n}):")` + `lines.extend(_wrap_external(body))` |
| **sources/citations** | `return ["", "Sources:", *_wrap_external(body)]` |

`#167` extracted `_append_external_block` but only converted the first two sites, leaving the other two to re-derive the identical layout inline — the leading `""`, the header placement, and the marker wrap each hand-rolled a second and third time.

## Improvement

Add `_external_block(body, *, header=None) -> list[str]` as the single source of truth for the shape, and route all four sites through it:

- `_append_external_block` becomes a one-line `lines.extend(...)` wrapper, still used by the three call sites that append to a running `lines` list.
- `_format_sources` returns `_external_block(body, header="Sources:")`, so it stays composable via `lines.extend(_format_sources(...))`.
- the findings block uses `_append_external_block(..., header=f"Findings ({len(findings)}):")` instead of embedding the separator in a `"\n"`-prefixed string.

## Safety

**Output is byte-identical.** The `"\nFindings (N):"` spelling and the `["", header, ...]` spelling render the same text once joined with `"\n"`, so this is purely a call-site consolidation. Verified two ways:

1. Rendered-output diff between `main` and this branch over payloads that exercise all four block sites — findings truncation (`... and N more`), `sources` and `citations`, str/dict/list result bodies, the unrecognized-status branch, and the empty-sources early return. 128 lines of rendered output, zero differences.
2. Existing suite: **242 passed**, including `TestSourcesExternalContentMarkers` (asserts source entries sit between the markers) and the task-result body tests.

Beyond dedup, this tightens a small safety boundary: the external-content markers are what tells the downstream LLM client that a payload is remote data rather than instructions. With the wrap reachable only through `_external_block`, a future block that surfaces remote text can't render it while forgetting the markers — previously two of the four sites called `_wrap_external` directly and a third spelling would have been the path of least resistance.

Scope: 1 file, no behavior change, no API/interface change.

Note for reviewers: the findings branch had no direct test coverage before or after this change (equivalence was established by the output diff above). Adding that coverage is worth doing but is new test surface rather than part of this refactor, so it is deliberately left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0126BGesadgXMjCrXjju5iZH

---
_Generated by [Claude Code](https://claude.ai/code/session_0126BGesadgXMjCrXjju5iZH)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file refactor with byte-identical formatter output and no API changes.
> 
> **Overview**
> Introduces **`_external_block`** as the single builder for the shared pattern (blank line, optional header, marker-wrapped remote text) and makes **`_append_external_block`** delegate with `lines.extend(...)`.
> 
> **Sources** and **scout-update findings** no longer hand-roll that layout (`_wrap_external` / `"\nFindings"`); they use `_external_block` or `_append_external_block` like content and task result bodies. Rendered output is unchanged; marker wrapping stays on one path so new remote-text blocks are less likely to omit external-content markers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6225bc6ae778521839bdcf1ab606efc7cf29549d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->