### PR TITLE
refactor(formatters): extract _GET_SCOUT_DETAIL_HINT shared constant

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -420,6 +420,12 @@ def format_usage(response: dict[str, Any], **context: Any) -> str:
 # -----------------------------------------------------------------------------
 
 
+# Shared across format_list_scouts (appended standalone, after the pagination
+# hints) and format_scout_edited (extended with a leading blank line, in the
+# no-diff-available branch) so the two call sites can't drift on the wording.
+_GET_SCOUT_DETAIL_HINT = "Use get_scout_detail(scout_id) for full details."
+
+
 def format_list_scouts(response: dict[str, Any], **context: Any) -> str:
     """Format list_scouts response as readable text."""
     scouts = response.get("scouts", [])
@@ -466,7 +472,7 @@ def format_list_scouts(response: dict[str, Any], **context: Any) -> str:
     elif has_more:
         lines.append("Use list_scouts(limit=50) to see more.")
     lines.append('Use list_scouts(status="active") to filter by status.')
-    lines.append("Use get_scout_detail(scout_id) for full details.")
+    lines.append(_GET_SCOUT_DETAIL_HINT)
 
     return "\n".join(lines)
 
@@ -616,7 +622,7 @@ def format_scout_edited(response: dict[str, Any], **context: Any) -> str:
             _scout_identity_lines(**identity, status=new.get("status", "unknown"))
         )
         _append_rejection_reason(lines, new.get("rejection_reason"))
-        lines.extend(["", "Use get_scout_detail(scout_id) for full details."])
+        lines.extend(["", _GET_SCOUT_DETAIL_HINT])
         return "\n".join(lines)
 
     # Edit succeeded but the post-edit read-back failed: report success


### PR DESCRIPTION
## Summary
- The hint string `"Use get_scout_detail(scout_id) for full details."` was spelled out verbatim at two call sites: `format_list_scouts`'s trailing hints and `format_scout_edited`'s no-diff-available branch.
- Extract it into a single `_GET_SCOUT_DETAIL_HINT` module constant so the wording can't drift between the two formatters, mirroring existing precedent in this module for extracting even 2-site repeats (e.g. `_id_url_lines`).
- No behavior change — rendered output is byte-identical.

## Test plan
- [x] `uv run --extra dev pytest -q` — 242 passed
- [x] `uv run --extra dev ruff check .` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011HdrJpTvRdGzSZ7mMHX7Mm


---
_Generated by [Claude Code](https://claude.ai/code/session_011HdrJpTvRdGzSZ7mMHX7Mm)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only string deduplication in display formatters with no logic or output changes.
> 
> **Overview**
> **Deduplicates** the repeated user hint `"Use get_scout_detail(scout_id) for full details."` by introducing module constant `_GET_SCOUT_DETAIL_HINT` in `formatters.py`, following the same pattern as `_id_url_lines` and other shared formatter strings.
> 
> `format_list_scouts` and `format_scout_edited` (no-old-state branch) now reference the constant instead of inline literals. **Rendered MCP text is unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59bf0efe2c4813722bd3629a32fe624656144852. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->