### PR TITLE
Reuse a process-lifetime MCPClientAdapter singleton

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
 from typing import Any, NoReturn, TypeVar
 
 from mcp.server.fastmcp import FastMCP
@@ -80,7 +81,48 @@ class _StrictArgsFastMCP(FastMCP):
         return await super().call_tool(name, arguments)
 
 
-mcp = _StrictArgsFastMCP("yutori-mcp")
+# Process-lifetime MCPClientAdapter singleton. Constructing MCPClientAdapter
+# spins up an httpx.AsyncClient, so a fresh one per tool call means a fresh
+# connection pool per call in what is otherwise a long-running stdio session.
+# get_adapter() lazily creates it once and reuses it for every subsequent
+# call; _lifespan() closes it when the server shuts down. Sharing one
+# instance across calls is safe: mcp.server.lowlevel.Server.run() starts one
+# asyncio task per incoming request (so tool calls can run concurrently), and
+# httpx.AsyncClient is designed to be shared and used concurrently across
+# tasks in the same event loop (that's what its connection pooling is for).
+_adapter: MCPClientAdapter | None = None
+
+
+def get_adapter() -> MCPClientAdapter:
+    """Return the shared MCPClientAdapter, creating it on first use."""
+    global _adapter
+    if _adapter is None:
+        _adapter = MCPClientAdapter()
+    return _adapter
+
+
+@asynccontextmanager
+async def _lifespan(_: FastMCP) -> AsyncIterator[None]:
+    """Close the shared adapter when the server shuts down.
+
+    Registered as FastMCP's `lifespan` so it runs inside the same event loop
+    as `mcp.run()` (the low-level Server enters this context manager once,
+    around the whole request loop). A plain try/finally wrapped around the
+    synchronous `mcp.run()` call in main() would not work here: `mcp.run()`
+    drives `anyio.run(...)`, which tears its event loop down before returning
+    control to the caller, leaving no valid loop left to close an
+    asyncio-bound httpx client from.
+    """
+    try:
+        yield
+    finally:
+        global _adapter
+        if _adapter is not None:
+            await _adapter.close()
+            _adapter = None
+
+
+mcp = _StrictArgsFastMCP("yutori-mcp", lifespan=_lifespan)
 
 
 def _format_api_error(e: YutoriAPIError) -> str:
@@ -103,9 +145,9 @@ async def _invoke(tool_name: str, args: dict[str, Any]) -> str:
     unexpected exceptions logged and re-raised.
     """
     handler = _TOOL_HANDLERS[tool_name]
+    client = get_adapter()
     try:
-        async with MCPClientAdapter() as client:
-            result, context = await handler(client, args)
+        result, context = await handler(client, args)
         return format_response(tool_name, result, **context)
     except YutoriAPIError as e:
         raise RuntimeError(_format_api_error(e)) from e

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -322,11 +322,15 @@ def _call_tool_request(name, arguments):
 
 @contextmanager
 def _patched_adapter():
-    """Patch MCPClientAdapter and yield the mock used as the async-with client."""
-    with patch("yutori_mcp.server.MCPClientAdapter") as adapter_cls:
+    """Patch server.get_adapter and yield the mock instance it returns.
+
+    _invoke() reuses a process-lifetime adapter singleton via get_adapter()
+    instead of constructing a fresh MCPClientAdapter per call, so tests patch
+    the accessor function rather than the MCPClientAdapter class.
+    """
+    with patch("yutori_mcp.server.get_adapter") as get_adapter_mock:
         instance = AsyncMock()
-        adapter_cls.return_value = instance
-        instance.__aenter__.return_value = instance
+        get_adapter_mock.return_value = instance
         yield instance
 
 


### PR DESCRIPTION
## Summary

- `server.py::_invoke()` previously constructed a brand-new `MCPClientAdapter` (and therefore a brand-new `httpx.AsyncClient`) on **every** tool call, paying connection-setup cost repeatedly inside what is otherwise a long-running stdio MCP session.
- Adds a lazily-created, process-lifetime adapter singleton: `get_adapter()` creates it once and reuses it for every subsequent call.
- Closes it via FastMCP's `lifespan` hook (`_lifespan`), not a `try/finally` around the synchronous `mcp.run()` call in `main()`. `mcp.run()` drives `anyio.run(...)`, which tears its event loop down before returning control to the caller — a plain try/finally there would try to close an asyncio-bound httpx client from a dead/different loop. `lifespan` runs *inside* the same event loop as the whole server request loop, so cleanup is safe.
- Sharing one adapter across calls is safe: `mcp.server.lowlevel.Server.run()` starts one asyncio task per incoming request (tool calls can be concurrently in flight), and `httpx.AsyncClient` is explicitly designed to be shared and used concurrently across tasks in one event loop (that's what its connection pooling is for).

This was previously deferred twice as "too large for a mechanical pass" over concerns about (a) needing a lifecycle hook, (b) interaction with `--env`/`YUTORI_ENV`, and (c) reworking test fixtures that patch the adapter class directly. On inspection:
- (a) is solved cleanly via FastMCP's existing `lifespan=` constructor param — no need to touch `main()`'s `mcp.run(transport="stdio")` call at all, so the existing `TestMainEnvSelection` tests (which mock `mcp.run` directly) needed zero changes.
- (b) is a non-issue: `--env` only ever mutates `os.environ` once at process startup in `main()`, before `mcp.run()`, so the base URL was already effectively fixed for the process's lifetime.
- (c) only required updating `tests/test_server.py`'s `_patched_adapter()` fixture to patch `get_adapter` instead of the `MCPClientAdapter` class — `tests/test_adapter.py` tests the adapter class directly and needed no changes.

Net diff is 2 files (smaller than the ~5-file estimate in the original deferral).

## Test plan

- [x] `uv run --extra dev pytest -q` — all 242 tests pass, zero regressions
- [x] `ruff check .` — clean (pre-existing `ruff format` drift in 3 unrelated files, unchanged by this PR)
- [x] Manual verification script confirming `get_adapter()` returns the same instance across calls, and the `lifespan` context manager closes it and resets the singleton on exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Z3jV9HHsWft3yffqxzk6a


---
_Generated by [Claude Code](https://claude.ai/code/session_012Z3jV9HHsWft3yffqxzk6a)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes HTTP client lifecycle for all API tool calls in a long-lived process; sharing one `httpx.AsyncClient` across concurrent requests is intentional but affects connection behavior and shutdown ordering.
> 
> **Overview**
> **Reuses one `MCPClientAdapter` (and its `httpx` connection pool) for the whole stdio MCP session** instead of creating a new adapter on every tool call.
> 
> `_invoke()` now calls `get_adapter()` for a lazily created singleton. Shutdown cleanup runs through a new FastMCP **`lifespan`** hook (`_lifespan`) that `await`s `adapter.close()` on the same event loop as the server—avoiding cleanup after `mcp.run()` returns, when the asyncio loop is already gone.
> 
> Tests update `_patched_adapter()` to mock **`get_adapter`** instead of constructing `MCPClientAdapter` per call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 475947376f7ba07ce01e47505c2075e5150842b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->