### PR TITLE
refactor(server): fix stale comment referencing per-call MCPClientAdapter()

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -646,9 +646,10 @@ def main() -> None:
         _handle_auth_command(args.command)
 
     # The flag is forwarded via the env var (rather than threaded through to
-    # each per-call MCPClientAdapter()) so adapter.resolve_base_url() stays
-    # the single resolution point whether the environment came from the CLI
-    # or from an MCP client config's `env` block.
+    # get_adapter()'s lazily-constructed, process-lifetime MCPClientAdapter)
+    # so adapter.resolve_base_url() stays the single resolution point
+    # whether the environment came from the CLI or from an MCP client
+    # config's `env` block.
     if args.env:
         os.environ[ENV_VAR_ENVIRONMENT] = args.env
     try:


### PR DESCRIPTION
## Summary

- `main()`'s comment explaining why the `--env` CLI flag is forwarded via an env var (rather than threaded into the adapter constructor) still said "each per-call `MCPClientAdapter()`".
- PR #174 (2026-07-27) replaced per-call adapter construction with a process-lifetime singleton via `get_adapter()`, but this comment — written 2026-07-22, before #174 landed — was never updated to match, so it now describes stale behavior.
- Updated the comment to reflect the current singleton (`get_adapter()`'s lazily-constructed, process-lifetime `MCPClientAdapter`) reality. No behavior change — comment only.

## Test plan

- [x] `uv run pytest -q` — 239 passed
- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ruff format --check src/yutori_mcp/server.py` — already formatted


---
_Generated by [Claude Code](https://claude.ai/code/session_015FLuQenQdVXwxfiEiM34uF)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only comment update with no code or behavior changes.
> 
> **Overview**
> Updates the comment in `main()` that explains why `--env` is written to `YUTORI_ENV` instead of passed into the adapter constructor. It previously referred to **per-call** `MCPClientAdapter()` construction, which no longer matches the code after the process-lifetime singleton via `get_adapter()`.
> 
> The wording now describes **`get_adapter()`'s lazily-constructed, process-lifetime `MCPClientAdapter`**, while keeping the same intent: `resolve_base_url()` remains the single place that resolves the API base URL from CLI or MCP client `env` config. **No runtime behavior changes.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e21d1084ab34297f1c4b7f5010799845b6690d28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->