### PR TITLE
refactor(formatters): extract _format_truncated_block for the sources/findings truncate-render-wrap pattern

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -182,6 +182,28 @@ def _append_more_indicator(
         lines.append(f"{indent}... and {remaining} more")
 
 
+def _format_truncated_block(
+    items: list[Any],
+    *,
+    header: str,
+    max_items: int,
+    render_item: Callable[[Any], str],
+    indent: str = "  ",
+) -> list[str]:
+    """Build an external-content block listing up to ``max_items`` of ``items``.
+
+    Shared shape behind ``_format_sources`` (bullet: ``- title: url``) and
+    ``format_scout_updates``'s findings block (bullet: ``• title``): render
+    each of the first ``max_items`` entries via ``render_item``, append the
+    ``... and N more`` indicator when truncated, then wrap the result in the
+    external-content markers under ``header``. Centralizing this keeps the
+    truncate/render/wrap sequence from drifting between the two call sites.
+    """
+    body = [render_item(item) for item in items[:max_items]]
+    _append_more_indicator(body, len(items), max_items, indent=indent)
+    return _external_block(body, header=header)
+
+
 def _external_block(body: list[str], *, header: str | None = None) -> list[str]:
     """Build a blank line, an optional header, then ``body`` wrapped in external-content markers.
 
@@ -339,16 +361,16 @@ def _format_sources(
     if not sources:
         return []
 
-    body: list[str] = []
-    for source in sources[:max_items]:
+    def render(source: Any) -> str:
         if isinstance(source, dict):
             url = source.get("url", "")
             title = source.get("title", url)
-            body.append(f"{indent}- {title}: {url}")
-        else:
-            body.append(f"{indent}- {source}")
-    _append_more_indicator(body, len(sources), max_items, indent=indent)
-    return _external_block(body, header="Sources:")
+            return f"{indent}- {title}: {url}"
+        return f"{indent}- {source}"
+
+    return _format_truncated_block(
+        sources, header="Sources:", max_items=max_items, render_item=render, indent=indent
+    )
 
 
 # -----------------------------------------------------------------------------
@@ -559,15 +581,23 @@ def format_scout_updates(response: dict[str, Any], **context: Any) -> str:
 
         findings = update.get("findings", [])
         if findings:
-            body = []
-            for finding in findings[:5]:  # Limit to 5
-                if isinstance(finding, dict):
-                    title = _get_first(finding, "title", "summary", default="")
-                    body.append(f"  • {_truncate(title, 80)}")
-                else:
-                    body.append(f"  • {_truncate(str(finding), 80)}")
-            _append_more_indicator(body, len(findings), 5)
-            _append_external_block(lines, body, header=f"Findings ({len(findings)}):")
+
+            def render_finding(finding: Any) -> str:
+                title = (
+                    _get_first(finding, "title", "summary", default="")
+                    if isinstance(finding, dict)
+                    else str(finding)
+                )
+                return f"  • {_truncate(title, 80)}"
+
+            lines.extend(
+                _format_truncated_block(
+                    findings,
+                    header=f"Findings ({len(findings)}):",
+                    max_items=5,
+                    render_item=render_finding,
+                )
+            )
 
         lines.extend(_format_sources(update))
 


### PR DESCRIPTION
## What

`_format_sources` and the "findings" block inside `format_scout_updates` shared the exact same shape — truncate a list to N items, render each item as a bullet line with dict-vs-plain-string branching, append the `... and N more` indicator, then wrap the result in an external-content block with a header — but that shape was hand-rolled independently at both call sites (different bullet style, item fields, and max item count).

This extracts the shared shape into a new helper, `_format_truncated_block(items, *, header, max_items, render_item, indent)`, and rewrites both call sites to supply only what differs (their `render_item` closure and `max_items`/`indent`).

## Why

Keeps the truncate/render/wrap sequence from silently drifting between the two call sites (e.g. one gaining a truncation-indicator tweak the other misses), mirroring the existing `_external_block`/`_append_more_indicator` extraction pattern already used elsewhere in this file.

## Scope

- Behavior-preserving: output text is byte-identical for both call sites (verified against the existing `TestFormatSources` and `TestFormatScoutUpdates` test suites, which pin exact rendered strings).
- Single file changed: `src/yutori_mcp/formatters.py`.
- No public API changes, no test changes needed — full suite passes unchanged.

## Testing

```
uv run --extra dev pytest -q
239 passed in 2.56s
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01WozpiEzPE2x2kXB27S97gc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal formatter refactor with behavior pinned by existing tests; no public API or security-sensitive logic changes.
> 
> **Overview**
> Introduces **`_format_truncated_block`**, which centralizes the shared “take first N items → render bullets → `... and N more` → wrap in external-content markers” flow already used for sources and scout-update findings.
> 
> **`_format_sources`** and the findings section in **`format_scout_updates`** now only supply per-site **`render_item`** closures (and their **`max_items`** / indent), instead of duplicating truncate/render/wrap logic.
> 
> Refactor only: rendered MCP text stays the same per existing formatter tests; no API or test changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bf7927d439c113f9216ff110b3f5a3d440444f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->