### PR TITLE
refactor(server): hoist stdlib imports in main() to module level

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import argparse
 import logging
+import os
+import sys
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import asynccontextmanager
 from typing import Any, NoReturn, TypeVar
@@ -615,10 +618,6 @@ def _handle_auth_command(command: str) -> NoReturn:
 
 def main() -> None:
     """Entry point for the yutori-mcp command."""
-    import argparse
-    import os
-    import sys
-
     parser = argparse.ArgumentParser(prog="yutori-mcp")
     parser.add_argument(
         "--version",


### PR DESCRIPTION
## What

`main()` in `src/yutori_mcp/server.py` imported `argparse`, `os`, and `sys` inside the function body. All three are plain stdlib modules used unconditionally within the CLI entry point, with no circular-import, conditional, or performance-lazy justification. This moves them to the module-level import block.

```diff
 from __future__ import annotations

+import argparse
 import logging
+import os
+import sys
 from collections.abc import AsyncIterator, Awaitable, Callable
 ...
 def main() -> None:
     """Entry point for the yutori-mcp command."""
-    import argparse
-    import os
-    import sys
-
     parser = argparse.ArgumentParser(prog="yutori-mcp")
```

## Why

- Matches the repo's de-facto convention — `adapter.py` already imports `os` at module level — and the "imports at the top of the file" default.
- Same function-local-stdlib-import cleanup pattern applied repeatedly across the sibling monorepo.

## Verification

- Behavior-preserving; no runtime behavior change.
- `ruff check` and `ruff format --check` pass (import order accepted).
- All 10 `main()` CLI tests pass: `--version` flag, `--env` env-var selection (`os.environ`), non-default target stderr notice (`sys.stderr`), and invalid-env argparse rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeqogMNnkCtKX4HJanFazm)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only refactor in the CLI entry point; no logic, API, or auth-path changes.
> 
> **Overview**
> Moves **`argparse`**, **`os`**, and **`sys`** from inside **`main()`** in `server.py` to the top-level import block so the CLI entry point matches the usual “imports at top of file” style (same pattern as **`os`** in `adapter.py`).
> 
> **No runtime behavior change** — `main()` still uses those modules for `--env` / `os.environ`, stderr notices, and argparse. The lazy **`yutori.auth`** import in **`_handle_auth_command`** is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b54ba0341042c0bc9d9aa9ec4507ac67d8ea6691. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->