### PR TITLE
refactor(formatters): extract _render_truncated shared by _format_truncated_block and format_usage

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -173,13 +173,34 @@ def _append_more_indicator(
     """Append a ``{indent}... and N more`` line when ``total`` exceeds ``shown``.
 
     Centralizes the "iterate first N items, then summarize the remainder"
-    truncation message used by ``_format_sources``, ``format_usage``'s active
-    scout list, and ``format_scout_updates``'s findings block. No-op when
-    nothing was truncated.
+    truncation message. No-op when nothing was truncated. Used by
+    ``_render_truncated`` below, the single call site every truncated list in
+    this module now goes through.
     """
     remaining = total - shown
     if remaining > 0:
         lines.append(f"{indent}... and {remaining} more")
+
+
+def _render_truncated(
+    items: list[Any],
+    *,
+    max_items: int,
+    render_item: Callable[[Any], str],
+    indent: str = "  ",
+) -> list[str]:
+    """Render up to ``max_items`` of ``items`` plus a trailing ``... and N more`` line.
+
+    Shared truncate/render/summarize sequence behind every "show the first N,
+    then say how many more" list in this module: ``_format_sources`` (bullet:
+    ``- title: url``), ``format_scout_updates``'s findings block (bullet:
+    ``• title``) via ``_format_truncated_block`` below, and ``format_usage``'s
+    active-scout-id list, which has no external-content wrapping to apply.
+    Centralizing this keeps the three call sites from drifting apart.
+    """
+    body = [render_item(item) for item in items[:max_items]]
+    _append_more_indicator(body, len(items), max_items, indent=indent)
+    return body
 
 
 def _format_truncated_block(
@@ -192,15 +213,14 @@ def _format_truncated_block(
 ) -> list[str]:
     """Build an external-content block listing up to ``max_items`` of ``items``.
 
-    Shared shape behind ``_format_sources`` (bullet: ``- title: url``) and
-    ``format_scout_updates``'s findings block (bullet: ``• title``): render
-    each of the first ``max_items`` entries via ``render_item``, append the
-    ``... and N more`` indicator when truncated, then wrap the result in the
-    external-content markers under ``header``. Centralizing this keeps the
-    truncate/render/wrap sequence from drifting between the two call sites.
+    Wraps ``_render_truncated`` in the external-content markers under
+    ``header``, for the two call sites (``_format_sources`` and
+    ``format_scout_updates``'s findings block) whose items are remote,
+    user-controlled text.
     """
-    body = [render_item(item) for item in items[:max_items]]
-    _append_more_indicator(body, len(items), max_items, indent=indent)
+    body = _render_truncated(
+        items, max_items=max_items, render_item=render_item, indent=indent
+    )
     return _external_block(body, header=header)
 
 
@@ -395,9 +415,11 @@ def format_usage(response: dict[str, Any], **context: Any) -> str:
     lines = [f"Active Scouts: {num_active}"]
 
     if active_ids:
-        for sid in active_ids[:5]:
-            lines.append(f"  - {sid}")
-        _append_more_indicator(lines, len(active_ids), 5)
+        lines.extend(
+            _render_truncated(
+                active_ids, max_items=5, render_item=lambda sid: f"  - {sid}"
+            )
+        )
 
     # Rate limits
     rate_limits = response.get("rate_limits", {})


### PR DESCRIPTION
## Issue

`_format_truncated_block` already centralizes the "render the first N items, then append an `... and N more` line" sequence for two call sites (`_format_sources` and `format_scout_updates`'s findings block) — its own docstring says so explicitly. But `format_usage`'s active-scout-id list hand-rolled the exact same sequence inline instead of going through it:

```python
if active_ids:
    for sid in active_ids[:5]:
        lines.append(f"  - {sid}")
    _append_more_indicator(lines, len(active_ids), 5)
```

It couldn't just call `_format_truncated_block` directly, though, because that helper always wraps its output in the `[EXTERNAL CONTENT START/END]` markers used for remote/user-controlled text (sources, findings) — and a scout's own active-task IDs aren't external content, so wrapping them would be a behavior change.

## Change

Extracted the truncate/render/summarize core (no external-content wrapping) into a new `_render_truncated` helper. `_format_truncated_block` now composes it with `_external_block`; `format_usage` calls it directly. All three truncated lists in `formatters.py` now share one implementation instead of one being an inline duplicate of the mechanism.

Pure structural refactor — no behavior change, no public API change. `_append_more_indicator` is unchanged, just now only reached through `_render_truncated`.

## Why this is safe

- Diff is confined to `src/yutori_mcp/formatters.py`, ~36 lines added / 14 removed.
- Output text is byte-for-byte identical for every existing call site (verified by the full test suite, including `test_formatters.py::TestFormatUsage::test_many_active_scouts_truncated`, which pins the exact `"... and 3 more"` truncation text `format_usage` produces).
- Full test suite: `pytest -q` → **239 passed**.
- Lint: `ruff check src tests` → **All checks passed**.
- `ruff format --check` flags 3 files (`formatters.py`, `test_adapter.py`, `test_formatters.py`), but I confirmed via `git stash` that this formatting drift is pre-existing on `main` (likely a local ruff-version difference from CI) and unrelated to this change — my new lines aren't part of that diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01SY7g2RRtFvnC9psFVLsDch)_