### PR TITLE
refactor(server): consult formatters.TASK_TOOLS instead of re-spelling tool names

### DIFF
--- a/src/yutori_mcp/formatters.py
+++ b/src/yutori_mcp/formatters.py
@@ -791,7 +791,7 @@ def format_task_started(response: dict[str, Any], **context: Any) -> str:
     if view_url:
         lines.append(f"View progress: {view_url}")
 
-    _, get_tool = _TASK_TOOLS[task_type]
+    _, get_tool = TASK_TOOLS[task_type]
     lines.append("")
     lines.append(f'Poll with {get_tool}(task_id="{task_id}") to check status.')
 
@@ -872,7 +872,7 @@ def format_task_list(response: dict[str, Any], **context: Any) -> str:
     filtered_total = response.get("filtered_total", total)
     summary = response.get("summary") or {}
     has_more, next_cursor = _pagination_state(response)
-    list_tool, get_tool = _TASK_TOOLS[task_type]
+    list_tool, get_tool = TASK_TOOLS[task_type]
 
     breakdown = (
         [
@@ -974,7 +974,7 @@ _SCOUT_EDIT_FIELDS = (
 )
 
 # Canonical task_type labels stamped into the formatter context by server.py's
-# tool handlers (via _make_handler) and consumed as _TASK_TOOLS keys below.
+# tool handlers (via _make_handler) and consumed as TASK_TOOLS keys below.
 # Defined once so server.py and this module can't drift on the literal
 # spelling -- a mismatch would surface as a KeyError in
 # format_task_started()/format_task_list() rather than a statically-checkable
@@ -984,9 +984,10 @@ TASK_TYPE_RESEARCH = "Research"
 
 # Map task_type to its (list_tool, get_tool) names, surfaced in the
 # user-facing hints emitted by format_task_started() and format_task_list().
-# A single table keeps the two formatters from drifting if a tool is ever
-# renamed.
-_TASK_TOOLS: dict[str, tuple[str, str]] = {
+# A single table keeps these formatters, and server.py's tool descriptions
+# (which import this table rather than re-spelling the names), from drifting
+# if a tool is ever renamed.
+TASK_TOOLS: dict[str, tuple[str, str]] = {
     TASK_TYPE_RESEARCH: ("list_research_tasks", "get_research_task_result"),
     TASK_TYPE_BROWSING: ("list_browsing_tasks", "get_browsing_task_result"),
 }

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -24,7 +24,12 @@ from .adapter import (
     YutoriAPIError,
     resolve_base_url,
 )
-from .formatters import TASK_TYPE_BROWSING, TASK_TYPE_RESEARCH, format_response
+from .formatters import (
+    TASK_TOOLS,
+    TASK_TYPE_BROWSING,
+    TASK_TYPE_RESEARCH,
+    format_response,
+)
 from .schema_utils import output_fields_to_output_schema
 from .schemas import (
     DEFAULT_LIST_LIMIT,
@@ -188,6 +193,9 @@ def _list_tasks_description(task_label: str, get_tool: str) -> str:
     get_*_task_result tool for authoritative status; only the task label and
     get-tool name differ. Mirrors the ``_output_fields_description`` helper
     in schemas.py, which extracts the same kind of repeated tool-facing prose.
+    Callers should pass ``get_tool`` from ``formatters.TASK_TOOLS`` rather
+    than a fresh literal, so this description text can't drift from the
+    tool-name hints formatters.py renders into tool results.
     """
     return (
         f"List one-time {task_label} tasks for the authenticated user. "
@@ -326,7 +334,7 @@ async def run_browsing_task(
 
 
 @mcp.tool(
-    description=_list_tasks_description("browsing", "get_browsing_task_result"),
+    description=_list_tasks_description("browsing", TASK_TOOLS[TASK_TYPE_BROWSING][1]),
     annotations=_READ_ONLY,
 )
 async def list_browsing_tasks(
@@ -364,7 +372,7 @@ async def run_research_task(
 
 
 @mcp.tool(
-    description=_list_tasks_description("research", "get_research_task_result"),
+    description=_list_tasks_description("research", TASK_TOOLS[TASK_TYPE_RESEARCH][1]),
     annotations=_READ_ONLY,
 )
 async def list_research_tasks(


### PR DESCRIPTION
## Structural issue

`formatters.py` already has a single source of truth for task-tool names — `_TASK_TOOLS: dict[task_type, (list_tool, get_tool)]` — used by `format_task_started`/`format_task_list` to render the "poll with `get_*_task_result`" hints, with a docstring explicitly noting it exists so the two formatters "can't drift on the literal spelling."

But `server.py`'s `@mcp.tool` descriptions for `list_browsing_tasks`/`list_research_tasks` independently hardcoded the same tool-name strings as a second, disconnected literal:

```python
description=_list_tasks_description("browsing", "get_browsing_task_result"),
...
description=_list_tasks_description("research", "get_research_task_result"),
```

Nothing ties these two spellings together — if a task tool were ever renamed (updating `_TOOL_HANDLERS`/`_TOOL_FORMATTERS`/the `@mcp.tool` function itself, all of which live right next to each other), it would be easy to forget the copy in `server.py`'s tool description, silently leaving user-facing text pointing at a stale/wrong tool name. This is the cross-file tool-name-literal duplication flagged as an open lead in a prior audit of this repo.

## Fix

- Renamed `formatters._TASK_TOOLS` → `formatters.TASK_TOOLS` (dropping the leading underscore, matching the existing `TASK_TYPE_BROWSING`/`TASK_TYPE_RESEARCH` constants from the same module that `server.py` already imports).
- `server.py` now imports `TASK_TOOLS` and reads `TASK_TOOLS[TASK_TYPE_BROWSING][1]` / `TASK_TOOLS[TASK_TYPE_RESEARCH][1]` instead of re-spelling the tool name literal.
- Updated the two touched docstrings to explain the single-source-of-truth relationship.

This only touches the two `list_*_tasks` description-builder call sites — it intentionally does **not** attempt the larger `_TOOL_HANDLERS`/`_TOOL_FORMATTERS` dispatch-table cross-file consolidation (that mirrors the actual `@mcp.tool` function names 1:1 by design and is a separate, larger question).

## Why this is safe

- Pure internal refactor, no behavior change: verified the rendered tool description text is byte-identical before/after (`get_browsing_task_result`/`get_research_task_result` resolve to the exact same strings via the table lookup).
- Full test suite: 239/239 passing.
- `ruff check` / `ruff format --check` clean on both touched files.
- 2 files changed, 18 insertions / 9 deletions — small, mechanical, easily reviewable.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YQxpMMAxxjHRw9ERaFbgMc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor of string sourcing for tool metadata only; no API, auth, or execution path changes.
> 
> **Overview**
> **Centralizes task tool names** so MCP `list_*_tasks` descriptions and formatter poll hints stay aligned.
> 
> `formatters._TASK_TOOLS` is renamed to public **`TASK_TOOLS`**, and `server.py` now passes `TASK_TOOLS[TASK_TYPE_BROWSING][1]` / `TASK_TOOLS[TASK_TYPE_RESEARCH][1]` into `_list_tasks_description` instead of hardcoding `get_browsing_task_result` and `get_research_task_result`. Docstrings note that this table is the single source of truth for those strings.
> 
> No runtime behavior change—the rendered descriptions and hints should be identical.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 454b7536c3c7955b771aba455f341385e9a84bff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->