### PR TITLE
refactor(server): derive list/get task tool descriptions from the task type

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -185,33 +185,43 @@ _IDEMPOTENT = ToolAnnotations(idempotentHint=True)
 _DESTRUCTIVE = ToolAnnotations(destructiveHint=True)
 
 
-def _list_tasks_description(task_label: str, get_tool: str) -> str:
+def _list_tasks_description(task_type: str) -> str:
     """Build the shared list_*_tasks tool description.
 
     list_browsing_tasks and list_research_tasks share identical boilerplate
     describing pagination/status filtering and pointing at the matching
     get_*_task_result tool for authoritative status; only the task label and
-    get-tool name differ. Mirrors the ``_output_fields_description`` helper
-    in schemas.py, which extracts the same kind of repeated tool-facing prose.
-    Callers should pass ``get_tool`` from ``formatters.TASK_TOOLS`` rather
-    than a fresh literal, so this description text can't drift from the
-    tool-name hints formatters.py renders into tool results.
+    get-tool name differ, and both are derivable from the task type. Mirrors
+    the ``_output_fields_description`` helper in schemas.py, which extracts
+    the same kind of repeated tool-facing prose.
+
+    ``task_type`` is a ``formatters.TASK_TOOLS`` key (``TASK_TYPE_BROWSING``
+    or ``TASK_TYPE_RESEARCH``). The prose label and the get-tool name are
+    derived from it here, exactly as ``formatters.format_task_list`` does, so
+    a caller cannot pair one task type's label with another type's tool name,
+    and this text can't drift from the tool-name hints formatters.py renders
+    into tool results.
     """
+    _, get_tool = TASK_TOOLS[task_type]
     return (
-        f"List one-time {task_label} tasks for the authenticated user. "
+        f"List one-time {task_type.lower()} tasks for the authenticated user. "
         "Supports cursor pagination and status filtering. List status is approximate "
         f"(running also covers queued and not-yet-reconciled tasks); call "
         f"{get_tool} for a task's authoritative status."
     )
 
 
-def _get_task_result_description(task_label: str) -> str:
+def _get_task_result_description(task_type: str) -> str:
     """Build the shared get_*_task_result tool description.
 
     get_browsing_task_result and get_research_task_result share identical
-    text apart from the task label.
+    text apart from the task label, derived from the same ``task_type`` key
+    ``_list_tasks_description`` above takes.
     """
-    return f"Poll for {task_label} task status and result. Call until status is 'succeeded' or 'failed'."
+    return (
+        f"Poll for {task_type.lower()} task status and result. "
+        "Call until status is 'succeeded' or 'failed'."
+    )
 
 
 @mcp.tool(
@@ -334,7 +344,7 @@ async def run_browsing_task(
 
 
 @mcp.tool(
-    description=_list_tasks_description("browsing", TASK_TOOLS[TASK_TYPE_BROWSING][1]),
+    description=_list_tasks_description(TASK_TYPE_BROWSING),
     annotations=_READ_ONLY,
 )
 async def list_browsing_tasks(
@@ -346,7 +356,7 @@ async def list_browsing_tasks(
 
 
 @mcp.tool(
-    description=_get_task_result_description("browsing"),
+    description=_get_task_result_description(TASK_TYPE_BROWSING),
     annotations=_READ_ONLY,
 )
 async def get_browsing_task_result(task_id: str) -> str:
@@ -372,7 +382,7 @@ async def run_research_task(
 
 
 @mcp.tool(
-    description=_list_tasks_description("research", TASK_TOOLS[TASK_TYPE_RESEARCH][1]),
+    description=_list_tasks_description(TASK_TYPE_RESEARCH),
     annotations=_READ_ONLY,
 )
 async def list_research_tasks(
@@ -384,7 +394,7 @@ async def list_research_tasks(
 
 
 @mcp.tool(
-    description=_get_task_result_description("research"),
+    description=_get_task_result_description(TASK_TYPE_RESEARCH),
     annotations=_READ_ONLY,
 )
 async def get_research_task_result(task_id: str) -> str:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -10,7 +10,11 @@ from mcp.types import CallToolRequest, CallToolRequestParams
 from yutori.auth.types import AuthStatus, LoginResult
 from yutori_mcp import __version__
 from yutori_mcp.adapter import YutoriAPIError
-from yutori_mcp.formatters import format_scout_edited
+from yutori_mcp.formatters import (
+    TASK_TYPE_BROWSING,
+    TASK_TYPE_RESEARCH,
+    format_scout_edited,
+)
 from yutori_mcp.schema_utils import (
     output_fields_to_output_schema,
     output_schema_field_names,
@@ -87,8 +91,8 @@ class TestTaskDescriptionHelpers:
     so the browsing and research tool descriptions cannot drift out of sync
     with each other (mirrors `_output_fields_description` in schemas.py)."""
 
-    def test_list_tasks_description_substitutes_label_and_get_tool(self):
-        result = _list_tasks_description("browsing", "get_browsing_task_result")
+    def test_list_tasks_description_derives_label_and_get_tool(self):
+        result = _list_tasks_description(TASK_TYPE_BROWSING)
         assert result == (
             "List one-time browsing tasks for the authenticated user. "
             "Supports cursor pagination and status filtering. List status is approximate "
@@ -96,8 +100,15 @@ class TestTaskDescriptionHelpers:
             "get_browsing_task_result for a task's authoritative status."
         )
 
+    def test_list_tasks_description_derives_research_get_tool(self):
+        """Each task type derives its own get-tool name, so the label and the
+        tool name it points at can never come from different task types."""
+        result = _list_tasks_description(TASK_TYPE_RESEARCH)
+        assert result.startswith("List one-time research tasks")
+        assert "get_research_task_result for a task's authoritative status." in result
+
     def test_get_task_result_description_substitutes_label(self):
-        result = _get_task_result_description("research")
+        result = _get_task_result_description(TASK_TYPE_RESEARCH)
         assert (
             result
             == "Poll for research task status and result. Call until status is 'succeeded' or 'failed'."
@@ -108,16 +119,16 @@ class TestTaskDescriptionHelpers:
         hand-written duplicates that could diverge from the browsing variant."""
         tools = {t.name: t.description for t in await mcp.list_tools()}
         assert tools["list_browsing_tasks"] == _list_tasks_description(
-            "browsing", "get_browsing_task_result"
+            TASK_TYPE_BROWSING
         )
         assert tools["list_research_tasks"] == _list_tasks_description(
-            "research", "get_research_task_result"
+            TASK_TYPE_RESEARCH
         )
         assert tools["get_browsing_task_result"] == _get_task_result_description(
-            "browsing"
+            TASK_TYPE_BROWSING
         )
         assert tools["get_research_task_result"] == _get_task_result_description(
-            "research"
+            TASK_TYPE_RESEARCH
         )
 
 


### PR DESCRIPTION
## The structural issue

`server._list_tasks_description(task_label, get_tool)` took two arguments that had to agree with each other but were supplied independently at each call site:

```python
description=_list_tasks_description("browsing", TASK_TOOLS[TASK_TYPE_BROWSING][1]),
```

The lowercase prose label (`"browsing"`) and the matching `get_*_task_result` tool name were passed separately, with the caller doing the `TASK_TOOLS` lookup itself. Nothing tied the pair together, so a call site could pair one task type's label with another type's tool name — e.g. `_list_tasks_description("browsing", TASK_TOOLS[TASK_TYPE_RESEARCH][1])` — and the advertised tool description would be silently wrong, with no type error and no test failure. `_get_task_result_description` had the same loose `task_label` parameter.

## Why this is an improvement

Both helpers now take the single canonical `formatters.TASK_TOOLS` key (`TASK_TYPE_BROWSING` / `TASK_TYPE_RESEARCH`) and derive the prose label and the get-tool name from it internally — exactly the derivation `formatters.format_task_list` already performs on the same key:

```python
_, get_tool = TASK_TOOLS[task_type]
... f"List one-time {task_type.lower()} tasks ..."
```

- The mismatched-pair failure mode is now unrepresentable: one argument drives both derived values.
- An unknown task type raises `KeyError` at import time instead of producing plausible-looking but wrong prose.
- The two derivations of "task type → label / tool name" now live in one shape across `server.py` and `formatters.py`, continuing the direction of #184 (which made `server.py` consult `formatters.TASK_TOOLS` instead of re-spelling tool names).
- Four call sites get shorter and stop reaching into `TASK_TOOLS` tuple indices (`[...][1]`).

No tool names, schemas, parameters, annotations, or description text change — the tool surface is untouched.

## Why it's safe

Purely behavior-preserving; `"Browsing".lower() == "browsing"` and `"Research".lower() == "research"` are precisely the labels the call sites previously spelled by hand.

Verified:

- **Byte-identical tool surface:** dumped `{t.name: t.description for t in await mcp.list_tools()}` for all 13 tools on `main` and on this branch — `diff` is empty.
- **Tests:** full suite passes, 240 passed (239 baseline + 1 added test asserting the research variant derives its own get-tool name, preserving the coverage the drift-guard test previously got from its hand-spelled literal).
- **Lint/format:** `ruff check` and `ruff format --check` clean on both touched files.
- **Compile:** `python -m py_compile` on both touched files.

Files touched: `src/yutori_mcp/server.py`, `tests/test_server.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KCjrHU3qPdo1bdmAYchKnM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCjrHU3qPdo1bdmAYchKnM)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor of description-string helpers only; no tool surface, auth, or data-handling changes.
> 
> **Overview**
> Makes `_list_tasks_description` and `_get_task_result_description` take a single `TASK_TOOLS` key (`TASK_TYPE_BROWSING` / `TASK_TYPE_RESEARCH`) instead of a separately supplied prose label and get-tool name.
> 
> The helpers now look up the get-tool and lowercase the task type internally, matching `formatters.format_task_list`, so a call site cannot pair one type’s label with another type’s tool name. Advertised MCP tool text is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3adbad5e39060ca617f5ae385a02b0459c31c99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->