### PR TITLE
refactor(server): pair each auth subcommand's help text with its handler

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -582,56 +582,72 @@ _TOOL_HANDLERS: dict[str, ToolHandler] = {
 }
 
 
-# CLI auth subcommand name -> argparse `help` text. Iterated over to register
-# subparsers and consulted to decide whether to dispatch to _handle_auth_command.
-_AUTH_SUBCOMMANDS: dict[str, str] = {
-    "login": "Log in and save API key",
-    "logout": "Remove saved API key",
-    "status": "Show authentication status",
+# Each auth subcommand below imports ``yutori.auth`` lazily so the default
+# ``yutori-mcp`` server-startup path does not pay the auth-flow import cost,
+# and always raises ``SystemExit``; the ``NoReturn`` annotation lets callers
+# rely on that contract instead of guarding the call with a ``return``.
+
+
+def _auth_login() -> NoReturn:
+    """Run the interactive login flow and exit with its success status."""
+    from yutori.auth import run_login_flow
+
+    result = run_login_flow(key_source="yutori-mcp")
+    if result.success:
+        print("Successfully authenticated!")
+    else:
+        print(f"Authentication failed: {result.error}")
+        if result.auth_url:
+            print(f"\nIf the browser didn't open, visit:\n  {result.auth_url}")
+    raise SystemExit(0 if result.success else 1)
+
+
+def _auth_logout() -> NoReturn:
+    """Clear the saved API key and exit."""
+    from yutori.auth import clear_config
+
+    clear_config()
+    print("Logged out successfully.")
+    raise SystemExit(0)
+
+
+def _auth_status() -> NoReturn:
+    """Print the current authentication status and exit non-zero if unauthenticated."""
+    from yutori.auth import get_auth_status
+
+    status = get_auth_status()
+    if status.authenticated:
+        print(f"Authenticated (API key: {status.masked_key})")
+        if status.source == "config_file":
+            print(f"  Source: {status.config_path}")
+        elif status.source == "env_var":
+            print("  Source: YUTORI_API_KEY environment variable")
+    else:
+        print("Not authenticated. Run 'uvx yutori-mcp login' to authenticate.")
+        raise SystemExit(1)
+    raise SystemExit(0)
+
+
+# CLI auth subcommand name -> (argparse `help` text, handler). Iterated over to
+# register subparsers, and consulted by _handle_auth_command to dispatch.
+# Pairing the help text with the handler in one table means a subcommand
+# cannot be advertised on the CLI without an implementation (or vice versa),
+# mirroring the _TOOL_HANDLERS / _TOOL_FORMATTERS registries above.
+_AUTH_SUBCOMMANDS: dict[str, tuple[str, Callable[[], NoReturn]]] = {
+    "login": ("Log in and save API key", _auth_login),
+    "logout": ("Remove saved API key", _auth_logout),
+    "status": ("Show authentication status", _auth_status),
 }
 
 
 def _handle_auth_command(command: str) -> NoReturn:
     """Run an auth subcommand (login/logout/status) and exit.
 
-    Imports ``yutori.auth`` lazily so the default ``yutori-mcp`` server-startup
-    path does not pay the auth-flow import cost. Always raises ``SystemExit``;
-    the ``NoReturn`` annotation lets ``main()`` rely on that contract instead
-    of guarding the call with a ``return``.
+    ``command`` must be a ``_AUTH_SUBCOMMANDS`` key; ``main()`` only calls
+    this for names argparse accepted from that same table.
     """
-    from yutori.auth import clear_config, get_auth_status, run_login_flow
-
-    if command == "login":
-        result = run_login_flow(key_source="yutori-mcp")
-        if result.success:
-            print("Successfully authenticated!")
-        else:
-            print(f"Authentication failed: {result.error}")
-            if result.auth_url:
-                print(f"\nIf the browser didn't open, visit:\n  {result.auth_url}")
-        raise SystemExit(0 if result.success else 1)
-
-    if command == "logout":
-        clear_config()
-        print("Logged out successfully.")
-        raise SystemExit(0)
-
-    if command == "status":
-        status = get_auth_status()
-        if status.authenticated:
-            print(f"Authenticated (API key: {status.masked_key})")
-            if status.source == "config_file":
-                print(f"  Source: {status.config_path}")
-            elif status.source == "env_var":
-                print("  Source: YUTORI_API_KEY environment variable")
-        else:
-            print("Not authenticated. Run 'uvx yutori-mcp login' to authenticate.")
-            raise SystemExit(1)
-        raise SystemExit(0)
-
-    # Defensive: every name in _AUTH_SUBCOMMANDS must have a branch above.
-    # Reaching here means the dispatch table and this helper drifted apart.
-    raise ValueError(f"Unhandled auth subcommand: {command!r}")
+    _, run_command = _AUTH_SUBCOMMANDS[command]
+    run_command()
 
 
 def main() -> None:
@@ -654,7 +670,7 @@ def main() -> None:
         ),
     )
     subparsers = parser.add_subparsers(dest="command")
-    for name, help_text in _AUTH_SUBCOMMANDS.items():
+    for name, (help_text, _) in _AUTH_SUBCOMMANDS.items():
         subparsers.add_parser(name, help=help_text)
 
     args = parser.parse_args()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -21,6 +21,7 @@ from yutori_mcp.schema_utils import (
 )
 from yutori_mcp.schemas import DEFAULT_LIST_LIMIT
 from yutori_mcp.server import (
+    _AUTH_SUBCOMMANDS,
     _get_task_result_description,
     _handle_edit_scout,
     _list_tasks_description,
@@ -184,6 +185,29 @@ class TestMainStatusExitCode:
             patch("yutori.auth.get_auth_status", return_value=status),
         ):
             _assert_main_exits(expected_exit_code)
+
+
+class TestMainAuthDispatch:
+    """Every registered auth subcommand runs the handler paired with it in
+    `_AUTH_SUBCOMMANDS`, so the table is the only place a subcommand's CLI
+    help text and its implementation are tied together."""
+
+    @pytest.mark.parametrize("name", sorted(_AUTH_SUBCOMMANDS))
+    def test_subcommand_runs_its_table_handler(self, name):
+        calls = []
+
+        def fake_handler():
+            calls.append(name)
+            raise SystemExit(0)
+
+        help_text, _ = _AUTH_SUBCOMMANDS[name]
+        table = {**_AUTH_SUBCOMMANDS, name: (help_text, fake_handler)}
+        with (
+            patch("sys.argv", ["yutori-mcp", name]),
+            patch.dict("yutori_mcp.server._AUTH_SUBCOMMANDS", table, clear=True),
+        ):
+            _assert_main_exits(0)
+        assert calls == [name]
 
 
 class TestMainLoginAuthUrl:


### PR DESCRIPTION
## The structural issue

The CLI auth subcommands were described by two parallel, name-keyed structures in `server.py`:

- `_AUTH_SUBCOMMANDS: dict[str, str]` — subcommand name → argparse `help` text, iterated in `main()` to register subparsers.
- `_handle_auth_command()` — a name → behavior `if command == "login" / "logout" / "status"` chain.

Adding, renaming, or removing a subcommand required editing both. Nothing structurally forced them to agree; the only thing catching disagreement was a defensive tail branch whose own comment said as much:

```python
# Defensive: every name in _AUTH_SUBCOMMANDS must have a branch above.
# Reaching here means the dispatch table and this helper drifted apart.
raise ValueError(f"Unhandled auth subcommand: {command!r}")
```

That branch is unreachable unless the two structures drift — i.e. the failure mode it guards surfaces at runtime, in a user's terminal, after argparse has already advertised the subcommand.

## Why this refactor improves it

The three branch bodies become three module-level functions (`_auth_login`, `_auth_logout`, `_auth_status`), and each is stored alongside its help text in a single table:

```python
_AUTH_SUBCOMMANDS: dict[str, tuple[str, Callable[[], NoReturn]]] = {
    "login": ("Log in and save API key", _auth_login),
    "logout": ("Remove saved API key", _auth_logout),
    "status": ("Show authentication status", _auth_status),
}
```

- A subcommand can no longer be advertised on the CLI without an implementation, or vice versa — the two are one entry.
- `_handle_auth_command` becomes a two-line table lookup, and the drift-only `ValueError` branch disappears rather than being maintained.
- Each subcommand's body is now independently findable and testable, and its lazy `yutori.auth` import lives next to the code that uses it (the reason for the lazy import — not paying auth-flow import cost on the server-startup path — is preserved).
- The shape matches the registries this codebase already uses for the same purpose: `_TOOL_HANDLERS`, `_TOOL_FORMATTERS`, and `formatters.TASK_TOOLS` (whose `_, get_tool = TASK_TOOLS[...]` unpacking this mirrors).

No tool names, descriptions, schemas, or output shapes are touched — this is entirely the `yutori-mcp login|logout|status` CLI path, not the MCP tool surface.

## Why it is safe

- **Bodies moved verbatim.** Every `print(...)` string, the `key_source="yutori-mcp"` argument, the `config_file`/`env_var` source branches, and every `SystemExit` code are unchanged.
- **CLI output pinned before/after.** Ran all seven auth cases (login success, login failure with `auth_url`, login failure without `auth_url`, logout, status authenticated-from-config-file, status authenticated-from-env-var, status unauthenticated) with `yutori.auth` patched, capturing stdout + exit code for each. `diff` of the before/after captures is empty. `yutori-mcp --help` output (which renders the per-subcommand help text from the table) is also byte-identical.
- **Tests.** `pytest -q`: 240 passed before, 243 passed after (3 added). Added `TestMainAuthDispatch`, a parametrized test asserting `main()` runs the handler paired with each name in `_AUTH_SUBCOMMANDS`, which pins the table-as-dispatch contract and gives `logout` its first coverage. Verified the test is load-bearing: reintroducing a hardcoded dispatch chain makes it stop passing.
- **Lint/format.** `ruff check` and `ruff format --diff` clean on both changed files.

One intentional, unobservable difference to flag: `_handle_auth_command("bogus")` now raises `KeyError` (from the table lookup) instead of the hand-written `ValueError`. This path is unreachable through the CLI — `main()` only calls it for `args.command in _AUTH_SUBCOMMANDS`, and argparse rejects anything else with exit code 2 first — and the helper is private with no other callers in the repo.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nn1DmtDNAp5x1aLGoc2GVC

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nn1DmtDNAp5x1aLGoc2GVC)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal CLI dispatch refactor with unchanged auth behavior and output; no MCP tool or credential-handling logic changes.
> 
> **Overview**
> Pairs each `yutori-mcp` auth subcommand’s argparse help text with its handler in a single `_AUTH_SUBCOMMANDS` table, so a command cannot be advertised without an implementation.
> 
> Login, logout, and status move into `_auth_login` / `_auth_logout` / `_auth_status` (lazy `yutori.auth` imports preserved). `_handle_auth_command` is a table lookup; the defensive `ValueError` for unhandled names is gone. Behavior and CLI output are unchanged.
> 
> Adds a parametrized test that `main()` runs the handler stored next to each registered name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8ce074f6f14cee6db37891dbdedd62caa039e2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->