### PR TITLE
Pin the corrected macOS SDK runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,7 @@ precedence over both when set.
 ## Computer-use preview: runtime dependency
 
 The SDK-owned `yutori.navigator.N2ComputerAgent` and `MacOSComputer` provide the complete
-runtime. The MCP package pins SDK 0.9.1 and verifies the installed files against the immutable
+runtime. The MCP package pins SDK 0.9.2 and verifies the installed files against the immutable
 published wheel plus its packaged provenance during `computer-use doctor`. There is no
 TypeScript bundle, Node executable, or alternate harness. A normal source checkout needs no
 private dependency access:
@@ -452,6 +452,6 @@ private dependency access:
 uv sync --extra dev
 ```
 
-SDK contributors may deliberately test an editable 0.9.1 checkout by setting
+SDK contributors may deliberately test an editable 0.9.2 checkout by setting
 `YUTORI_MCP_ALLOW_EDITABLE_SDK=1`; without that explicit override, doctor rejects editable or
 modified SDK installations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.0"
+version = "0.5.1"
 description = "MCP server for Yutori - web monitoring, deep research, and browser automation"
 readme = "README.md"
 license = "Apache-2.0"
@@ -30,9 +30,9 @@ dependencies = [
     # breaks the install as soon as 2.x resolves.
     "mcp>=1.0.0,<2.0.0",
     "pydantic>=2.0.0",
-    # SDK 0.9.1 owns the complete Python/Swift macOS runtime. Doctor verifies
+    # SDK 0.9.2 owns the complete Python/Swift macOS runtime. Doctor verifies
     # the installed payload against the exact published wheel before use.
-    "yutori==0.9.1",
+    "yutori==0.9.2",
 ]
 
 [project.optional-dependencies]

--- a/src/yutori_mcp/computer_use/app.py
+++ b/src/yutori_mcp/computer_use/app.py
@@ -63,7 +63,7 @@ def _find_running_app(payload: dict[str, Any], requested: str) -> dict[str, Any]
 
 
 async def _running_app(computer: MacOSComputer, requested: str) -> dict[str, Any] | None:
-    # SDK 0.9.1 has no public list_apps convenience method. Its generic hook
+    # The pinned SDK has no public list_apps convenience method. Its generic hook
     # retains deadline/Stop cancellation while keeping the transport SDK-owned.
     result = await computer._call_tool("list_apps", {}, read_only=True)
     payload = result.get("structuredContent") or result.get("structured_content") or {}

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -8,12 +8,12 @@ PROTOCOL_VERSION = 1
 MCP_VERSION = __version__
 MODEL = "n2-preview"
 TOOL_SET = "computer_use_tools-20260815"
-SDK_VERSION = "0.9.1"
+SDK_VERSION = "0.9.2"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.
-SDK_ARTIFACT_SHA256 = "f29f7281e7f4664657d86db622d453c0f824c74b4b8c08e8dcef0e51004d354a"
-SDK_INSTALLATION_SHA256 = "f30ae52505f674d3842add33f7912ad4e647ce5afc2c7a84e5a84571dc4cb28c"
-SDK_PROVENANCE_SHA256 = "c496f00cc9db293dfbef0fea37e896eba0262205b66577d5fcfa0b243ed8e339"
+SDK_ARTIFACT_SHA256 = "bb2de3d77e73be6abe8e27663e425518dc6fe0170502a7337c5b59456a9e8cad"
+SDK_INSTALLATION_SHA256 = "19af218c916ad34efd8212377ed9b540b87b825fda8e42b98066f8bd723f7d64"
+SDK_PROVENANCE_SHA256 = "aa3c8b58281f0dcde3446cc87cfd8b9c4e57b6c5e0b2be56450eef33c09dd59c"
 
 # The cua-driver release that implements this tool contract, and the checksum
 # of its installer script. Both are hard gates.

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -614,12 +614,12 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 
 def test_runtime_constants_select_latest_python_surface():
     assert TOOL_SET == "computer_use_tools-20260815"
-    assert SDK_VERSION == "0.9.1"
+    assert SDK_VERSION == "0.9.2"
     assert all(
         len(digest) == 64
         for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256)
     )
-    assert '"yutori==0.9.1"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
+    assert '"yutori==0.9.2"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
 
 
 def test_installed_sdk_matches_the_published_artifact():


### PR DESCRIPTION
## Summary

- bump yutori-mcp to 0.5.1 and pin public `yutori==0.9.2`
- attest the exact published SDK wheel, stable installed payload, and packaged provenance
- preserve the existing public release workflow unchanged

## Validation

- 332 passed, 1 skipped locally
- private canonical suite: 327 passed, 1 skipped on Python 3.12 and Python 3.10
- Ruff clean on changed Python files
- wheel/sdist build and Twine validation
- doctor all PASS against the public 0.9.2 wheel
- live Calculator smoke completed 9×9=81 with the native overlay active

Canonical private PR: yutori-ai/yutori-mcp-private#16.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped dependency and checksum bump for the macOS computer-use preview; behavior is unchanged except requiring the attested 0.9.2 wheel.
> 
> **Overview**
> **Release 0.5.1** moves the macOS computer-use stack from **`yutori==0.9.1`** to **`yutori==0.9.2`**, with matching updates in README and dependency comments.
> 
> **Runtime attestation** in `constants.py` now records **0.9.2** and new **artifact**, **installation**, and **provenance** SHA-256 digests so `computer-use doctor` / preflight still reject wrong or tampered SDK installs. Tests assert the new pin and `pyproject.toml` alignment; a comment in `app.py` refers to “the pinned SDK” instead of a fixed version number.
> 
> No new APIs or workflow changes beyond the corrected SDK pin and integrity gates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38a40c42e4b5a49821f8d35eb7103669e1272506. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->