### PR TITLE
refactor(credentials): extract shared atomic-config-write helper

### DIFF
--- a/src/yutori_mcp/credentials.py
+++ b/src/yutori_mcp/credentials.py
@@ -67,13 +67,30 @@ def resolve_api_key_for_environment(environment: str) -> str | None:
     return stored_environment_key(environment) or resolve_api_key()
 
 
+def _write_config_atomic(config_path: Path, config: dict[str, Any]) -> None:
+    """Write ``config`` to ``config_path`` atomically via a same-directory temp file.
+
+    A crash mid-write cannot leave a half-written config: the temp file is written in full and
+    only then swapped in with ``os.replace``. The file is created 0600 before any secret reaches
+    it, rather than chmod'ed afterwards.
+    """
+    handle, temporary = tempfile.mkstemp(dir=config_path.parent, prefix=".config-")
+    try:
+        os.fchmod(handle, stat.S_IRUSR | stat.S_IWUSR)
+        with os.fdopen(handle, "w") as stream:
+            json.dump(config, stream, indent=2)
+            stream.write("\n")
+        os.replace(temporary, config_path)
+    except BaseException:
+        Path(temporary).unlink(missing_ok=True)
+        raise
+
+
 def save_environment_key(environment: str, api_key: str) -> Path:
     """Store ``api_key`` for ``environment`` and return the config path.
 
     Merges rather than replaces: the SDK's top-level key and any other environment's entry
-    survive, which is the whole point of holding prod and dev side by side. Written through a
-    temporary file in the same directory so a crash cannot leave a half-written config, and the
-    file is created 0600 before any secret reaches it rather than chmod'ed afterwards.
+    survive, which is the whole point of holding prod and dev side by side.
     """
     if not api_key.strip():
         raise ValueError("Refusing to store an empty API key")
@@ -88,16 +105,7 @@ def save_environment_key(environment: str, api_key: str) -> Path:
     environments[environment] = {API_KEY_FIELD: api_key.strip()}
     config[ENVIRONMENTS_FIELD] = environments
 
-    handle, temporary = tempfile.mkstemp(dir=config_path.parent, prefix=".config-")
-    try:
-        os.fchmod(handle, stat.S_IRUSR | stat.S_IWUSR)
-        with os.fdopen(handle, "w") as stream:
-            json.dump(config, stream, indent=2)
-            stream.write("\n")
-        os.replace(temporary, config_path)
-    except BaseException:
-        Path(temporary).unlink(missing_ok=True)
-        raise
+    _write_config_atomic(config_path, config)
     return config_path
 
 
@@ -113,17 +121,7 @@ def clear_environment_key(environment: str) -> bool:
     else:
         config.pop(ENVIRONMENTS_FIELD, None)
 
-    config_path = get_config_path()
-    handle, temporary = tempfile.mkstemp(dir=config_path.parent, prefix=".config-")
-    try:
-        os.fchmod(handle, stat.S_IRUSR | stat.S_IWUSR)
-        with os.fdopen(handle, "w") as stream:
-            json.dump(config, stream, indent=2)
-            stream.write("\n")
-        os.replace(temporary, config_path)
-    except BaseException:
-        Path(temporary).unlink(missing_ok=True)
-        raise
+    _write_config_atomic(get_config_path(), config)
     return True
 
 


### PR DESCRIPTION
## The structural issue

`src/yutori_mcp/credentials.py` landed today in #187 (the macOS computer-use runtime release) with per-environment API key storage. Its two mutating functions, `save_environment_key` and `clear_environment_key`, each hand-rolled the identical sequence for writing `~/.yutori/config.json`:

```python
handle, temporary = tempfile.mkstemp(dir=config_path.parent, prefix=".config-")
try:
    os.fchmod(handle, stat.S_IRUSR | stat.S_IWUSR)
    with os.fdopen(handle, "w") as stream:
        json.dump(config, stream, indent=2)
        stream.write("\n")
    os.replace(temporary, config_path)
except BaseException:
    Path(temporary).unlink(missing_ok=True)
    raise
```

This is a security-relevant sequence — it exists specifically to keep the file 0600 before any secret reaches it and to make the write atomic (no half-written config on a crash) — copied verbatim into two functions in the same file. Nothing ties the two copies together, so a future edit (e.g. tightening the permission bits, changing the temp-file prefix, or adding an `fsync`) could easily update one call site and miss the other.

## Why this is an improvement

Extracted the shared body into `_write_config_atomic(config_path: Path, config: dict[str, Any]) -> None`. Both `save_environment_key` and `clear_environment_key` now call it instead of duplicating the mkstemp/fchmod/write/replace/cleanup-on-exception sequence. The atomic-write contract now has exactly one implementation to read, test, and change.

## Why it's safe

- Purely mechanical: the extracted function's body is byte-identical to what both call sites ran before, in the same order, with the same exception handling.
- Single file touched, 22 insertions / 24 deletions, easy to eyeball the equivalence directly in the diff.
- No tool schema, CLI surface, or public behavior changes — this is an internal implementation detail of on-disk config writes.
- Full test suite: `pytest -q` → **332 passed, 1 skipped** (matches the baseline on `main` after #187), including `tests/test_credentials.py`'s coverage of the 0600 permission (`test_the_config_is_owner_only`), the merge-not-replace behavior, and the per-environment clear/save round trips.
- `ruff check` and `ruff format --check` clean on the touched file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_0168poipJhT8otCtN8zNH6bi)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical deduplication with identical write semantics; no public API or credential behavior changes.
> 
> **Overview**
> **Refactors** duplicated on-disk config writes in `credentials.py` by introducing `_write_config_atomic`, which performs the same-directory temp file write, `0600` permissions before secrets are written, and `os.replace` swap.
> 
> `save_environment_key` and `clear_environment_key` now call this helper instead of each embedding the full `mkstemp` / `fchmod` / JSON dump / cleanup-on-failure sequence. **No change** to merge semantics, CLI, or credential resolution—only a single place to maintain the security-sensitive atomic write contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ac18529e39542c1822e9397779b44cd70b97317. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->