### PR TITLE
docs: clarify n2 CUA harness setup

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -10,6 +10,7 @@ Each `yutori-*/` directory contains agent metadata (e.g. `agents/openai.yaml`) a
 | `yutori-scout/SKILL.md`     | `skills/01-scout/SKILL.md`     |
 | `yutori-research/SKILL.md`  | `skills/02-research/SKILL.md`  |
 | `yutori-browse/SKILL.md`    | `skills/03-browse/SKILL.md`   |
+| `yutori-computer-use/SKILL.md` | `skills/06-computer-use/SKILL.md` |
 | `yutori-competitor-watch/SKILL.md` | `skills/04-competitor-watch/SKILL.md` |
 | `yutori-api-monitor/SKILL.md` | `skills/05-api-monitor/SKILL.md`   |
 

--- a/.agents/skills/yutori-computer-use/SKILL.md
+++ b/.agents/skills/yutori-computer-use/SKILL.md
@@ -1,0 +1,1 @@
+../../../skills/06-computer-use/SKILL.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Yutori MCP
 
-MCP tools and skills for web monitoring, deep research, and browser automation — powered by [Yutori](https://yutori.com/api)'s web agentic tech.
+MCP tools and workflow skills for building agents that monitor, research, browse, and operate computers with [Yutori](https://yutori.com/api).
 
 You can use it with Claude Code, Codex, Cursor, VS Code, ChatGPT, OpenClaw, and other MCP hosts.
 
@@ -10,13 +10,12 @@ You can use it with Claude Code, Codex, Cursor, VS Code, ChatGPT, OpenClaw, and 
 - **Scouting** — Monitor the web continuously for anything you care about at a desired frequency
 - **Research** — Run one-time deep web research tasks
 - **Browsing** — Automate websites with an AI navigator
-- **Computer use preview** — On macOS 15+, opt in to foreground desktop automation against the dev endpoint
+- **Computer use** — On macOS 15+, run tasks on the visible foreground desktop
 
-### macOS computer-use preview
+### macOS Computer Use
 
-This development-only preview is available only when the MCP server runs on macOS with
-`YUTORI_ENV=dev` or `--env dev`. It exposes the `run_computer_use_task` tool for foreground
-desktop automation against the gated `n2-preview` model.
+On macOS, Yutori MCP exposes `run_computer_use_task` for foreground desktop automation.
+The tool controls the visible desktop, so do not touch the Mac while a task is running.
 
 The runtime is the Python CUA harness from the `yutori` SDK: `yutori-mcp` pins `yutori==0.9.2`
 and calls the SDK's `N2ComputerAgent` with `yutori.navigator.macos.MacOSComputer`. There is no
@@ -25,7 +24,7 @@ TypeScript bundle, Node executable, or alternate harness. The pinned contract is
 | Component | Value |
 |-----------|-------|
 | MCP package | `yutori-mcp==0.5.1` |
-| Model | `n2-preview` |
+| Model | Navigator n2 |
 | Tool set | `computer_use_tools-20260815` |
 | Desktop driver | `cua-driver==0.19.3` |
 | SDK runtime | `yutori[macos]==0.9.2` |
@@ -37,16 +36,16 @@ Computer-use dependencies:
 | macOS 15+ | Local desktop capture, input, and native overlay/recording path | You |
 | Python 3.10+ | `yutori-mcp` and the SDK-owned CUA harness | `uvx` can manage this |
 | `uv` / `uvx` | Running `yutori-mcp` without a manual virtualenv | You |
-| Dev API key with `n2-preview` access | Model calls from the local harness | `uvx yutori-mcp --env dev login` stores it |
+| Yutori API key with computer-use access | Model calls from the local harness | `uvx yutori-mcp login` stores it |
 | `yutori==0.9.2` | `N2ComputerAgent` and `MacOSComputer` runtime | `yutori-mcp` dependency |
 | `cua-driver==0.19.3` and `CuaDriver.app` | Native screenshot capture and desktop actions | `uvx yutori-mcp computer-use setup` |
 | Screen Recording + Accessibility permissions | Letting CuaDriver see and operate the desktop | Requested by `computer-use setup` |
 | Xcode Command Line Tools | Optional reasoning overlay build | You; `doctor` reports if missing |
 
-First authenticate against the dev API, then install and verify the local Mac runtime:
+Authenticate, install the local Mac runtime, and verify it:
 
 ```bash
-uvx yutori-mcp --env dev login
+uvx yutori-mcp login
 uvx yutori-mcp computer-use setup
 uvx yutori-mcp computer-use doctor
 uvx yutori-mcp computer-use smoke
@@ -55,7 +54,7 @@ uvx yutori-mcp computer-use smoke
 `setup` downloads the pinned CuaDriver installer, checks its SHA-256, installs and starts
 `CuaDriver.app`, requests Screen Recording and Accessibility permissions, and prepares the
 optional native reasoning overlay. `doctor` verifies the pinned SDK wheel/provenance, the
-driver install, permissions, overlay cache, and dev endpoint access before a task can run.
+driver install, permissions, overlay cache, and Yutori API access before a task can run.
 
 `computer-use run` executes one custom task from the terminal — the same run the MCP tool
 performs, with per-action progress printed as it happens:
@@ -64,18 +63,18 @@ performs, with per-action progress printed as it happens:
 uvx yutori-mcp computer-use run "In Calculator, compute 17 * 23 and report the result." --app Calculator
 ```
 
-The `run_computer_use_task` tool controls the visible foreground desktop. Do not touch the
-Mac while it runs. Visible desktop content is sent to Yutori's dev model endpoint. Only one
-task can control a Mac at a time.
+To run through an MCP client, use the `run_computer_use_task` tool with a task, optional
+target app, optional start URL, time limit, and step limit. Only one task can control a Mac
+at a time.
 
-To expose the MCP tool to a client, run the server against dev:
+To expose the MCP tool to a client, run the default server:
 
 ```json
 {
   "mcpServers": {
-    "yutori-dev": {
+    "yutori": {
       "command": "uvx",
-      "args": ["yutori-mcp", "--env", "dev"]
+      "args": ["yutori-mcp"]
     }
   }
 }
@@ -85,6 +84,7 @@ To expose the MCP tool to a client, run the server against dev:
 - [`/yutori-scout`](skills/01-scout/SKILL.md) — Set up continuous web monitoring
 - [`/yutori-research`](skills/02-research/SKILL.md) — Deep web research (async, 5–10 min)
 - [`/yutori-browse`](skills/03-browse/SKILL.md) — Browser automation
+- [`/yutori-computer-use`](skills/06-computer-use/SKILL.md) — Local Mac desktop automation
 - [`/yutori-competitor-watch`](skills/04-competitor-watch/SKILL.md) — Competitor monitoring template
 - [`/yutori-api-monitor`](skills/05-api-monitor/SKILL.md) — API/changelog monitoring template
 
@@ -192,6 +192,7 @@ Use https://yutori.com/api/llms.txt and set up Yutori for me.
    | `/yutori-scout` | Set up continuous web monitoring with comprehensive queries |
    | `/yutori-research` | Deep web research workflow (async, 5-10 min) |
    | `/yutori-browse` | Browser automation tasks |
+   | `/yutori-computer-use` | Local Mac desktop automation |
    | `/yutori-competitor-watch` | Quick competitor monitoring template |
    | `/yutori-api-monitor` | API/changelog monitoring template |
 
@@ -327,6 +328,7 @@ For setup details, see the [OpenAI MCP guide](https://platform.openai.com/docs/m
    $skill-installer install https://github.com/yutori-ai/yutori-mcp/tree/main/.agents/skills/yutori-scout
    $skill-installer install https://github.com/yutori-ai/yutori-mcp/tree/main/.agents/skills/yutori-research
    $skill-installer install https://github.com/yutori-ai/yutori-mcp/tree/main/.agents/skills/yutori-browse
+   $skill-installer install https://github.com/yutori-ai/yutori-mcp/tree/main/.agents/skills/yutori-computer-use
    $skill-installer install https://github.com/yutori-ai/yutori-mcp/tree/main/.agents/skills/yutori-competitor-watch
    $skill-installer install https://github.com/yutori-ai/yutori-mcp/tree/main/.agents/skills/yutori-api-monitor
    ```
@@ -347,6 +349,7 @@ For setup details, see the [OpenAI MCP guide](https://platform.openai.com/docs/m
    | Scout | `$yutori-scout` | Set up continuous web monitoring |
    | Research | `$yutori-research` | Deep web research (async, 5-10 min) |
    | Browse | `$yutori-browse` | Browser automation with AI navigator |
+   | Computer Use | `$yutori-computer-use` | Local Mac desktop automation |
    | Competitor Watch | `$yutori-competitor-watch` | Quick competitor monitoring template |
    | API Monitor | `$yutori-api-monitor` | API/changelog monitoring template |
 
@@ -427,36 +430,6 @@ yutori-mcp login    # authenticate (one-time)
 yutori-mcp          # run the server (or: python -m yutori_mcp.server)
 ```
 
-### Targeting the dev environment
-
-The server hits the production API (`https://api.yutori.com/v1`) by default.
-For testing, point it at the dev stack (`https://api.dev.yutori.com/v1`) with
-the `--env` flag or the `YUTORI_ENV` environment variable (the flag wins if
-both are set):
-
-```bash
-yutori-mcp --env dev
-```
-
-Or in an MCP client config:
-
-```json
-{
-  "mcpServers": {
-    "yutori-dev": {
-      "command": "uvx",
-      "args": ["yutori-mcp", "--env", "dev"]
-    }
-  }
-}
-```
-
-Setting `"env": {"YUTORI_ENV": "dev"}` in the server config works too. An
-unknown environment name fails at startup rather than silently falling back
-to production. Plain `login`/`logout`/`status` commands manage production;
-pass `--env dev` to manage the separately stored dev credential described
-below. `YUTORI_API_KEY` overrides either stored credential when set.
-
 ### Debugging with MCP Inspector
 
 ```bash
@@ -471,32 +444,12 @@ For full API documentation, visit [docs.yutori.com](https://docs.yutori.com).
 
 Apache 2.0
 
-## Computer-use preview: authenticating against dev
-
-`login` authenticates against production and saves a production key, which the dev stack
-rejects with a 401. Store a dev key separately:
-
-```sh
-uvx yutori-mcp --env dev login      # prompts for a key from platform.dev.yutori.com
-uvx yutori-mcp --env dev status
-uvx yutori-mcp --env dev logout
-```
-
-That writes an `environments.dev` entry alongside the existing top-level `api_key`, so one
-machine can hold both without either shadowing the other. `YUTORI_API_KEY` still takes
-precedence over both when set.
-
-## Computer-use preview: SDK harness and runtime dependency
+## Computer-use SDK harness and runtime dependency
 
 The SDK-owned `yutori.navigator.N2ComputerAgent` and `MacOSComputer` provide the complete
 runtime. The MCP package pins SDK 0.9.2 and verifies the installed files against the immutable
 published wheel plus its packaged provenance during `computer-use doctor`. There is no
-TypeScript bundle, Node executable, or alternate harness. A normal source checkout needs no
-private dependency access:
-
-```sh
-uv sync --extra dev
-```
+TypeScript bundle, Node executable, alternate harness, or private dependency access.
 
 SDK contributors may deliberately test an editable 0.9.2 checkout by setting
 `YUTORI_MCP_ALLOW_EDITABLE_SDK=1`; without that explicit override, doctor rejects editable or

--- a/README.md
+++ b/README.md
@@ -15,14 +15,47 @@ You can use it with Claude Code, Codex, Cursor, VS Code, ChatGPT, OpenClaw, and 
 ### macOS computer-use preview
 
 This development-only preview is available only when the MCP server runs on macOS with
-`YUTORI_ENV=dev`. The runtime is Python-only and requires Python 3.10 or later. Setup installs
-CuaDriver, requests its macOS permissions, and prepares the optional native reasoning overlay:
+`YUTORI_ENV=dev` or `--env dev`. It exposes the `run_computer_use_task` tool for foreground
+desktop automation against the gated `n2-preview` model.
+
+The runtime is the Python CUA harness from the `yutori` SDK: `yutori-mcp` pins `yutori==0.9.2`
+and calls the SDK's `N2ComputerAgent` with `yutori.navigator.macos.MacOSComputer`. There is no
+TypeScript bundle, Node executable, or alternate harness. The pinned contract is:
+
+| Component | Value |
+|-----------|-------|
+| MCP package | `yutori-mcp==0.5.1` |
+| Model | `n2-preview` |
+| Tool set | `computer_use_tools-20260815` |
+| Desktop driver | `cua-driver==0.19.3` |
+| SDK runtime | `yutori[macos]==0.9.2` |
+
+Computer-use dependencies:
+
+| Dependency | Required for | Installed by |
+|------------|--------------|--------------|
+| macOS 15+ | Local desktop capture, input, and native overlay/recording path | You |
+| Python 3.10+ | `yutori-mcp` and the SDK-owned CUA harness | `uvx` can manage this |
+| `uv` / `uvx` | Running `yutori-mcp` without a manual virtualenv | You |
+| Dev API key with `n2-preview` access | Model calls from the local harness | `uvx yutori-mcp --env dev login` stores it |
+| `yutori==0.9.2` | `N2ComputerAgent` and `MacOSComputer` runtime | `yutori-mcp` dependency |
+| `cua-driver==0.19.3` and `CuaDriver.app` | Native screenshot capture and desktop actions | `uvx yutori-mcp computer-use setup` |
+| Screen Recording + Accessibility permissions | Letting CuaDriver see and operate the desktop | Requested by `computer-use setup` |
+| Xcode Command Line Tools | Optional reasoning overlay build | You; `doctor` reports if missing |
+
+First authenticate against the dev API, then install and verify the local Mac runtime:
 
 ```bash
+uvx yutori-mcp --env dev login
 uvx yutori-mcp computer-use setup
 uvx yutori-mcp computer-use doctor
 uvx yutori-mcp computer-use smoke
 ```
+
+`setup` downloads the pinned CuaDriver installer, checks its SHA-256, installs and starts
+`CuaDriver.app`, requests Screen Recording and Accessibility permissions, and prepares the
+optional native reasoning overlay. `doctor` verifies the pinned SDK wheel/provenance, the
+driver install, permissions, overlay cache, and dev endpoint access before a task can run.
 
 `computer-use run` executes one custom task from the terminal — the same run the MCP tool
 performs, with per-action progress printed as it happens:
@@ -34,6 +67,19 @@ uvx yutori-mcp computer-use run "In Calculator, compute 17 * 23 and report the r
 The `run_computer_use_task` tool controls the visible foreground desktop. Do not touch the
 Mac while it runs. Visible desktop content is sent to Yutori's dev model endpoint. Only one
 task can control a Mac at a time.
+
+To expose the MCP tool to a client, run the server against dev:
+
+```json
+{
+  "mcpServers": {
+    "yutori-dev": {
+      "command": "uvx",
+      "args": ["yutori-mcp", "--env", "dev"]
+    }
+  }
+}
+```
 
 **Workflow skills** (for clients that support slash commands):
 - [`/yutori-scout`](skills/01-scout/SKILL.md) — Set up continuous web monitoring
@@ -440,7 +486,7 @@ That writes an `environments.dev` entry alongside the existing top-level `api_ke
 machine can hold both without either shadowing the other. `YUTORI_API_KEY` still takes
 precedence over both when set.
 
-## Computer-use preview: runtime dependency
+## Computer-use preview: SDK harness and runtime dependency
 
 The SDK-owned `yutori.navigator.N2ComputerAgent` and `MacOSComputer` provide the complete
 runtime. The MCP package pins SDK 0.9.2 and verifies the installed files against the immutable

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -4,11 +4,10 @@ All tool outputs are formatted as human-readable text optimized for LLM consumpt
 
 All tool inputs enforce validation: webhook URLs must use HTTPS, and `output_fields` (where supported) must contain at least one entry. Unknown/extra fields are rejected.
 
-## `run_computer_use_task` (macOS dev preview)
+## `run_computer_use_task` (macOS computer use)
 
-Runs a foreground task on the visible Mac desktop. This tool is listed only on macOS when
-`YUTORI_ENV=dev`; it is absent on Linux and in production. Do not touch the Mac during a run.
-Visible desktop content is sent to Yutori's dev model endpoint.
+Runs a foreground task on the visible Mac desktop. This tool is listed only on macOS. Do not
+touch the Mac during a run. Visible desktop content is sent to Yutori.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
@@ -18,13 +17,14 @@ Visible desktop content is sent to Yutori's dev model endpoint.
 | `minutes` | No | Absolute deadline, 1–15 minutes (default 3) |
 | `max_steps` | No | Maximum actions, 1–100 (default 60) |
 
-First-time setup: authenticate against dev with `uvx yutori-mcp --env dev login`, then run
+First-time setup: authenticate with `uvx yutori-mcp login`, then run
 `uvx yutori-mcp computer-use setup` and `uvx yutori-mcp computer-use doctor`. Use
-`uvx yutori-mcp computer-use smoke` for the Calculator smoke test. The tool uses the SDK-owned
-Python CUA harness (`yutori==0.9.2`), `n2-preview`, `computer_use_tools-20260815`, and
+`uvx yutori-mcp computer-use smoke` for the Calculator smoke test. To run from a terminal, use
+`uvx yutori-mcp computer-use run "<task>" --app <AppName>`. The tool uses the SDK-owned
+Python CUA harness (`yutori==0.9.2`), Navigator n2, `computer_use_tools-20260815`, and
 `cua-driver==0.19.3`; `doctor` verifies those pinned runtime artifacts before a task runs.
 
-Dependencies: macOS 15+, Python 3.10+, `uvx`, a dev API key with `n2-preview` access,
+Dependencies: macOS 15+, Python 3.10+, `uvx`, a Yutori API key with computer-use access,
 `CuaDriver.app`/`cua-driver==0.19.3`, Screen Recording and Accessibility permissions, and
 optionally Xcode Command Line Tools for the native reasoning overlay. `computer-use setup`
 installs the pinned driver and prompts for the macOS permissions; the task runner can continue

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -18,9 +18,17 @@ Visible desktop content is sent to Yutori's dev model endpoint.
 | `minutes` | No | Absolute deadline, 1–15 minutes (default 3) |
 | `max_steps` | No | Maximum actions, 1–100 (default 60) |
 
-First-time setup: authenticate, then run
+First-time setup: authenticate against dev with `uvx yutori-mcp --env dev login`, then run
 `uvx yutori-mcp computer-use setup` and `uvx yutori-mcp computer-use doctor`. Use
-`uvx yutori-mcp computer-use smoke` for the Calculator smoke test.
+`uvx yutori-mcp computer-use smoke` for the Calculator smoke test. The tool uses the SDK-owned
+Python CUA harness (`yutori==0.9.2`), `n2-preview`, `computer_use_tools-20260815`, and
+`cua-driver==0.19.3`; `doctor` verifies those pinned runtime artifacts before a task runs.
+
+Dependencies: macOS 15+, Python 3.10+, `uvx`, a dev API key with `n2-preview` access,
+`CuaDriver.app`/`cua-driver==0.19.3`, Screen Recording and Accessibility permissions, and
+optionally Xcode Command Line Tools for the native reasoning overlay. `computer-use setup`
+installs the pinned driver and prompts for the macOS permissions; the task runner can continue
+without the optional overlay.
 
 ## Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "yutori-mcp"
 version = "0.5.1"
-description = "MCP server for Yutori - web monitoring, deep research, and browser automation"
+description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"
 requires-python = ">=3.10"

--- a/scripts/package-claude-desktop.sh
+++ b/scripts/package-claude-desktop.sh
@@ -76,6 +76,7 @@ package_skill "02-research"         "yutori-research"
 package_skill "03-browse"           "yutori-browse"
 package_skill "04-competitor-watch" "yutori-competitor-watch"
 package_skill "05-api-monitor"      "yutori-api-monitor"
+package_skill "06-computer-use"     "yutori-computer-use"
 
 echo ""
 echo "Done. Output: $OUT_DIR/"

--- a/skills/06-computer-use/SKILL.md
+++ b/skills/06-computer-use/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: yutori-computer-use
+description: Run local Mac desktop tasks with Yutori computer use. Use when the user wants to operate macOS apps, websites in a local browser, or cross-app workflows on the visible desktop.
+argument-hint: "[desktop task]"
+---
+
+# Computer Use
+
+Run tasks on the user's visible Mac desktop with Yutori computer use.
+
+## Setup
+
+If the user has not set up computer use yet, ask them to run these commands in a real terminal:
+
+```bash
+uvx yutori-mcp login
+uvx yutori-mcp computer-use setup
+uvx yutori-mcp computer-use doctor
+```
+
+Use the smoke test when validating a fresh install:
+
+```bash
+uvx yutori-mcp computer-use smoke
+```
+
+Requirements: macOS 15+, Python 3.10+, `uvx`, a Yutori API key with computer-use access,
+`CuaDriver.app` / `cua-driver==0.19.3`, and Screen Recording plus Accessibility permissions.
+The optional native reasoning overlay may require Xcode Command Line Tools.
+
+## Run a Task
+
+Prefer the MCP tool when it is available:
+
+```json
+{
+  "task": "$ARGUMENTS",
+  "minutes": 3,
+  "max_steps": 60
+}
+```
+
+Use optional fields when helpful:
+
+```json
+{
+  "task": "$ARGUMENTS",
+  "app": "Safari",
+  "start_url": "https://example.com",
+  "minutes": 5,
+  "max_steps": 80
+}
+```
+
+If the MCP tool is unavailable, ask the user to run the CLI task runner:
+
+```bash
+uvx yutori-mcp computer-use run "$ARGUMENTS" --minutes 3 --max-steps 60
+```
+
+For an app-specific task:
+
+```bash
+uvx yutori-mcp computer-use run "$ARGUMENTS" --app Safari --start-url https://example.com
+```
+
+## Safety
+
+- Tell the user not to touch the Mac while the task runs.
+- Use `app` for single-app tasks so the runner starts from the intended context.
+- Use `start_url` only with `app`.
+- Keep `minutes` between 1 and 15 and `max_steps` between 1 and 100.
+- Report the final result and any setup blocker from the tool or CLI output.

--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -105,12 +105,13 @@ async def _osascript(*lines: str) -> _ScriptResult:
 
 
 async def _smoke_live() -> int:
+    from ..adapter import current_environment, resolve_base_url
+    from ..credentials import resolve_api_key_for_environment
+
     blocker = first_blocker()
     if blocker is not None:
         print(blocker.remediation)
         return 1
-    from ..credentials import resolve_api_key_for_environment
-
     # The result is read back through Calculator's own copy-result (cmd+c) and
     # the clipboard, not the accessibility tree: macOS 26 rewrote Calculator and
     # "static text 1 of window 1" no longer exists there, so the AX read failed
@@ -160,8 +161,8 @@ async def _smoke_live() -> int:
         start_url=None,
         minutes=1,
         max_steps=10,
-        api_key=resolve_api_key_for_environment("dev"),
-        api_base_url="https://api.dev.yutori.com/v1",
+        api_key=resolve_api_key_for_environment(current_environment()),
+        api_base_url=resolve_base_url(),
     )
     print(format_result(result))
     return 0 if result.get("outcome") == "completed" else 1
@@ -184,6 +185,9 @@ async def _print_event(event: dict) -> None:
 
 
 async def _run_custom(args: argparse.Namespace) -> int:
+    from ..adapter import current_environment, resolve_base_url
+    from ..credentials import resolve_api_key_for_environment
+
     # Reuses the MCP tool's input schema so the CLI enforces the same bounds
     # (minutes 1-15, steps 1-100, start_url requires app) with the same
     # messages; the resulting ValidationError is a ValueError, so dispatch's
@@ -199,13 +203,11 @@ async def _run_custom(args: argparse.Namespace) -> int:
     if blocker is not None:
         print(f"{blocker.detail} Fix: {blocker.remediation}")
         return 1
-    from ..credentials import resolve_api_key_for_environment
-
     print("The model takes over this Mac's desktop now; do not touch it during the run.")
     result = await run_task(
         **params.model_dump(),
-        api_key=resolve_api_key_for_environment("dev"),
-        api_base_url="https://api.dev.yutori.com/v1",
+        api_key=resolve_api_key_for_environment(current_environment()),
+        api_base_url=resolve_base_url(),
         on_event=_print_event,
     )
     print(format_result(result))
@@ -215,12 +217,12 @@ async def _run_custom(args: argparse.Namespace) -> int:
 def register_parser(
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
-    parser = subparsers.add_parser("computer-use", help="Set up and diagnose the macOS computer-use preview")
+    parser = subparsers.add_parser("computer-use", help="Set up, diagnose, and run macOS computer use")
     commands = parser.add_subparsers(dest="computer_use_command", required=True)
     commands.add_parser("setup", help="Install and configure the pinned CuaDriver")
     commands.add_parser("doctor", help="Run all computer-use readiness checks")
     commands.add_parser("smoke", help="Run Calculator mechanical and live checks")
-    run_parser = commands.add_parser("run", help="Run one custom task on the visible desktop (dev only)")
+    run_parser = commands.add_parser("run", help="Run one custom task on the visible desktop")
     run_parser.add_argument("task", help="Task for the model to perform")
     run_parser.add_argument("--app", default=None, help="Application to target")
     run_parser.add_argument("--start-url", dest="start_url", default=None, help="URL to open in the app")

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -6,7 +6,7 @@ from .. import __version__
 
 PROTOCOL_VERSION = 1
 MCP_VERSION = __version__
-MODEL = "n2-preview"
+MODEL = "n2"
 TOOL_SET = "computer_use_tools-20260815"
 SDK_VERSION = "0.9.2"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.

--- a/src/yutori_mcp/computer_use/preflight.py
+++ b/src/yutori_mcp/computer_use/preflight.py
@@ -17,6 +17,7 @@ from urllib.parse import urlparse
 from urllib.request import Request, url2pathname, urlopen
 
 from .constants import (
+    MODEL,
     DRIVER_VERSION,
     MCP_VERSION,
     SDK_ARTIFACT_SHA256,
@@ -27,14 +28,6 @@ from .constants import (
 )
 
 DRIVER_APP = Path("/Applications/CuaDriver.app")
-DEV_ACCESS_REMEDIATION = (
-    "Store a dev key with: yutori-mcp --env dev login "
-    "(a production key is rejected by the dev stack). If it is already a dev key, ask "
-    "Yutori for n2-preview access."
-)
-# Named rather than inlined at both call sites: the previous text blamed missing access for
-# what is almost always a production key offered to dev, sending people to the wrong fix.
-DEV_ENVIRONMENT = "dev"
 DRIVER_PATHS = (
     # ~/.local/bin first: it is where the installer actually puts the CLI, and omitting it made
     # find_cua_driver() return None on a mini that had a working driver at
@@ -59,6 +52,18 @@ TOOL_SEARCH_DIRECTORIES = (
 _EDITABLE_SDK_OVERRIDE = "YUTORI_MCP_ALLOW_EDITABLE_SDK"
 _INSTALLER_GENERATED_FILES = {"INSTALLER", "RECORD", "REQUESTED", "direct_url.json"}
 _SDK_PROVENANCE_PATH = Path("yutori/navigator/macos/assets/provenance.json")
+
+
+def _login_remediation(environment: str) -> str:
+    from ..adapter import DEFAULT_ENVIRONMENT
+
+    if environment == DEFAULT_ENVIRONMENT:
+        return "Run: uvx yutori-mcp login"
+    return f"Run: uvx yutori-mcp --env {environment} login"
+
+
+def _api_access_remediation(environment: str) -> str:
+    return f"{_login_remediation(environment)}. If already logged in, confirm this key has computer-use access."
 
 
 def find_cua_driver() -> Path | None:
@@ -432,36 +437,39 @@ def check_capture() -> CheckResult:
 
 
 def check_api_key() -> CheckResult:
+    from ..adapter import current_environment
     from ..credentials import resolve_api_key_for_environment
 
-    key = resolve_api_key_for_environment(DEV_ENVIRONMENT)
+    environment = current_environment()
+    key = resolve_api_key_for_environment(environment)
     return _result(
         "API key",
         bool(key),
         "resolved" if key else "missing",
-        # Not plain `login`: that saves a production key, which is the misdiagnosis this
-        # change exists to remove.
-        f"Run: uvx yutori-mcp --env {DEV_ENVIRONMENT} login",
+        _login_remediation(environment),
     )
 
 
-def check_dev_access() -> CheckResult:
+def check_api_access() -> CheckResult:
     """Probe the endpoint a run uses, and read the BODY, not just the status.
 
-    Two traps, both hit for real. /v1/models 403s for keys that drive n2-preview fine, so this
-    asks chat/completions instead. And the API answers a billing failure with HTTP 200 carrying
+    Two traps, both hit for real. /v1/models can 403 for keys that drive computer use fine, so
+    this asks chat/completions instead. And the API answers a billing failure with HTTP 200 carrying
     {"error": {"type": "billing_error"}} — a key with no prepaid balance looked healthy here while
     every task failed at zero steps with an empty stderr. Status codes alone cannot see that.
     """
+    from ..adapter import current_environment, resolve_base_url
     from ..credentials import resolve_api_key_for_environment
 
+    environment = current_environment()
+    remediation = _api_access_remediation(environment)
     try:
-        key = resolve_api_key_for_environment(DEV_ENVIRONMENT)
+        key = resolve_api_key_for_environment(environment)
         request = Request(
-            "https://api.dev.yutori.com/v1/chat/completions",
+            f"{resolve_base_url(environment).rstrip('/')}/chat/completions",
             data=json.dumps(
                 {
-                    "model": "n2-preview",
+                    "model": MODEL,
                     "tool_set": TOOL_SET,
                     "messages": [{"role": "user", "content": "ping"}],
                 }
@@ -475,10 +483,10 @@ def check_dev_access() -> CheckResult:
             payload = json.loads(response.read().decode() or "{}")
     except HTTPError as error:
         if error.code in {401, 403}:
-            return _result("dev API", False, "credential rejected", DEV_ACCESS_REMEDIATION)
-        return _result("dev API", False, f"probe failed (HTTP {error.code})", DEV_ACCESS_REMEDIATION)
+            return _result("Yutori API", False, "credential rejected", remediation)
+        return _result("Yutori API", False, f"probe failed (HTTP {error.code})", remediation)
     except (URLError, OSError, ValueError):
-        return _result("dev API", False, "unreachable", DEV_ACCESS_REMEDIATION)
+        return _result("Yutori API", False, "unreachable", remediation)
 
     error = payload.get("error")
     if isinstance(error, dict):
@@ -487,12 +495,12 @@ def check_dev_access() -> CheckResult:
         remediation = (
             "Add prepaid balance to this key's account, then retry."
             if "billing" in kind or "funds" in kind
-            else DEV_ACCESS_REMEDIATION
+            else remediation
         )
-        return _result("dev API", False, message, remediation)
+        return _result("Yutori API", False, message, remediation)
     if not payload.get("choices"):
-        return _result("dev API", False, "no completion returned", DEV_ACCESS_REMEDIATION)
-    return _result("dev API", True, "n2-preview returned a completion", DEV_ACCESS_REMEDIATION)
+        return _result("Yutori API", False, "no completion returned", remediation)
+    return _result("Yutori API", True, "computer-use model returned a completion", remediation)
 
 
 _PLATFORM_CHECKS: tuple[Callable[[], CheckResult], ...] = (
@@ -514,7 +522,7 @@ _ENVIRONMENT_CHECKS: tuple[Callable[[], CheckResult], ...] = (
     check_compiler,
     check_overlay,
     check_api_key,
-    check_dev_access,
+    check_api_access,
 )
 
 

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -685,22 +685,22 @@ def _computer_use_enabled() -> bool:
     if sys.platform != "darwin":
         return False
     try:
-        return resolve_base_url() == ENVIRONMENT_BASE_URLS["dev"]
+        resolve_base_url()
+        return True
     except ValueError:
         return False
 
 
 def _register_computer_use_tool() -> None:
-    """Expose the macOS computer-use tool when the resolved environment is dev."""
+    """Expose the macOS computer-use tool on supported hosts."""
     if "run_computer_use_task" in _TOOL_HANDLERS:
         return
     if not _computer_use_enabled():
         return
     mcp.tool(
         description=(
-            "Operate the foreground Mac desktop using Yutori's dev n2-preview model. "
-            "Do not touch the Mac during the run. Visible desktop content is sent to "
-            "Yutori's dev model endpoint."
+            "Operate the foreground Mac desktop using Yutori computer use. "
+            "Do not touch the Mac during the run. Visible desktop content is sent to Yutori."
         ),
         annotations=_DESTRUCTIVE_OPEN_WORLD,
     )(run_computer_use_task)
@@ -853,13 +853,13 @@ def main() -> None:
     if args.env:
         os.environ[ENV_VAR_ENVIRONMENT] = args.env
 
-    # Dispatched after --env is applied, not before: `login --env dev` has to know which
+    # Dispatched after --env is applied, not before: `login --env <name>` has to know which
     # environment it is storing a credential for, and the old ordering ran auth first.
     #
     # Only the explicit flag counts here, never the ambient YUTORI_ENV. The README tells people
-    # to export that variable, and letting it reach this line meant a plain `login` silently
-    # became a dev paste prompt instead of the production browser flow, while `logout` cleared a
-    # dev entry instead of the real credential. Auth is an explicit act; it must not change
+    # to export that variable, and letting it reach this line meant a plain `login` could silently
+    # become a non-default paste prompt instead of the production browser flow, while `logout` cleared
+    # a non-default entry instead of the real credential. Auth is an explicit act; it must not change
     # meaning because of something left set in a shell.
     if args.command in _AUTH_SUBCOMMANDS:
         _handle_auth_command(args.command, args.env)

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -840,11 +840,6 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    if args.command == "computer-use":
-        from .computer_use.cli import dispatch
-
-        raise SystemExit(dispatch(args.computer_use_command, args))
-
     # The flag is forwarded via the env var (rather than threaded through to
     # get_adapter()'s lazily-constructed, process-lifetime MCPClientAdapter)
     # so adapter.resolve_base_url() stays the single resolution point
@@ -852,6 +847,15 @@ def main() -> None:
     # config's `env` block.
     if args.env:
         os.environ[ENV_VAR_ENVIRONMENT] = args.env
+
+    if args.command == "computer-use":
+        # Public computer-use commands default to production even if a shell has
+        # stale YUTORI_ENV state. Internal testing can still pass --env explicitly.
+        if not args.env:
+            os.environ.pop(ENV_VAR_ENVIRONMENT, None)
+        from .computer_use.cli import dispatch
+
+        raise SystemExit(dispatch(args.computer_use_command, args))
 
     # Dispatched after --env is applied, not before: `login --env <name>` has to know which
     # environment it is storing a credential for, and the old ordering ran auth first.

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -120,6 +120,46 @@ def test_main_applies_explicit_environment_before_computer_use_registration(monk
     assert observed == ["prod"]
 
 
+def test_main_applies_explicit_environment_before_computer_use_dispatch(monkeypatch):
+    import yutori_mcp.computer_use.cli as computer_use_cli
+    from yutori_mcp import server
+
+    observed: dict[str, str | None] = {}
+
+    def record_dispatch(_command: str, _args: object) -> int:
+        observed["environment"] = os.environ.get("YUTORI_ENV")
+        return 0
+
+    monkeypatch.setenv("YUTORI_ENV", "prod")
+    monkeypatch.setattr(sys, "argv", ["yutori-mcp", "--env", "dev", "computer-use", "doctor"])
+    monkeypatch.setattr(computer_use_cli, "dispatch", record_dispatch)
+
+    with pytest.raises(SystemExit) as exc_info:
+        server.main()
+    assert exc_info.value.code == 0
+    assert observed == {"environment": "dev"}
+
+
+def test_main_clears_ambient_environment_for_computer_use_without_explicit_env(monkeypatch):
+    import yutori_mcp.computer_use.cli as computer_use_cli
+    from yutori_mcp import server
+
+    observed: dict[str, str | None] = {}
+
+    def record_dispatch(_command: str, _args: object) -> int:
+        observed["environment"] = os.environ.get("YUTORI_ENV")
+        return 0
+
+    monkeypatch.setenv("YUTORI_ENV", "dev")
+    monkeypatch.setattr(sys, "argv", ["yutori-mcp", "computer-use", "doctor"])
+    monkeypatch.setattr(computer_use_cli, "dispatch", record_dispatch)
+
+    with pytest.raises(SystemExit) as exc_info:
+        server.main()
+    assert exc_info.value.code == 0
+    assert observed == {"environment": None}
+
+
 def test_lock_rejects_second_owner_and_releases(tmp_path):
     path = tmp_path / "desktop.lock"
     with DesktopLock(path), pytest.raises(ComputerUseBusyError), DesktopLock(path):

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -94,7 +94,7 @@ import yutori_mcp.computer_use.cli
 
 @pytest.mark.parametrize(
     "platform,environment,expected",
-    [("linux", "dev", False), ("darwin", "prod", False), ("darwin", "dev", True)],
+    [("linux", "prod", False), ("darwin", "prod", True), ("darwin", "unknown", False)],
 )
 def test_registration_gate(platform, environment, expected):
     with patch("yutori_mcp.server.sys.platform", platform), patch.dict("os.environ", {"YUTORI_ENV": environment}):
@@ -562,7 +562,7 @@ def _run_task_kwargs(tmp_path, **overrides):
         "minutes": 1,
         "max_steps": 10,
         "api_key": "yt-key",
-        "api_base_url": "https://api.dev.yutori.com/v1",
+        "api_base_url": "https://api.yutori.com/v1",
         "lock": DesktopLock(tmp_path / "desktop.lock"),
     }
     kwargs.update(overrides)
@@ -581,7 +581,7 @@ async def test_run_task_uses_only_python_runner_and_sdk_driver_discovery(tmp_pat
     assert result["outcome"] == "completed"
     assert supervise.await_args.kwargs["command"] == python_runner_command()
     request = supervise.await_args.kwargs["request"]
-    assert request["model"] == "n2-preview"
+    assert request["model"] == "n2"
     assert "driver_path" not in request and "harness" not in request
 
 
@@ -603,8 +603,8 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
     monkeypatch.setattr(lock_module, "DesktopLock", lambda: lock)
     monkeypatch.setattr(preflight, "first_blocker", first_blocker)
     monkeypatch.setattr(supervisor, "run_task", run_with_lock)
-    monkeypatch.setattr("yutori_mcp.credentials.resolve_api_key_for_environment", lambda _: "dev-key")
-    monkeypatch.setattr(server, "resolve_base_url", lambda: "https://api.dev.yutori.com/v1")
+    monkeypatch.setattr("yutori_mcp.credentials.resolve_api_key_for_environment", lambda _: "api-key")
+    monkeypatch.setattr(server, "resolve_base_url", lambda: "https://api.yutori.com/v1")
 
     result, raw = await server._handle_computer_use(None, {"task": "open calculator"})
     assert result["outcome"] == "completed"
@@ -654,7 +654,7 @@ def test_driver_contract_rejects_version_drift(monkeypatch):
     assert preflight.check_driver_contract().ok
 
 
-def test_dev_access_probes_the_runtime_toolset(monkeypatch):
+def test_api_access_probes_the_runtime_toolset(monkeypatch):
     requests = []
 
     class Response:
@@ -669,22 +669,23 @@ def test_dev_access_probes_the_runtime_toolset(monkeypatch):
 
     monkeypatch.setattr(
         "yutori_mcp.credentials.resolve_api_key_for_environment",
-        lambda _environment: "dev-key",
+        lambda _environment: "api-key",
     )
     monkeypatch.setattr(preflight, "urlopen", lambda request, timeout: requests.append(request) or Response())
 
-    assert preflight.check_dev_access().ok
+    assert preflight.check_api_access().ok
     assert json.loads(requests[0].data)["tool_set"] == TOOL_SET
+    assert requests[0].full_url == "https://api.yutori.com/v1/chat/completions"
 
 
 @pytest.mark.parametrize("status", [429, 500])
-def test_dev_access_rejects_non_auth_http_failures(monkeypatch, status):
+def test_api_access_rejects_non_auth_http_failures(monkeypatch, status):
     def fail_probe(*_args: Any, **_kwargs: Any) -> None:
-        raise HTTPError("https://api.dev.yutori.com", status, "failed", {}, None)
+        raise HTTPError("https://api.yutori.com", status, "failed", {}, None)
 
-    monkeypatch.setattr("yutori_mcp.credentials.resolve_api_key_for_environment", lambda _: "dev-key")
+    monkeypatch.setattr("yutori_mcp.credentials.resolve_api_key_for_environment", lambda _: "api-key")
     monkeypatch.setattr(preflight, "urlopen", fail_probe)
-    result = preflight.check_dev_access()
+    result = preflight.check_api_access()
     assert not result.ok
     assert result.detail == f"probe failed (HTTP {status})"
 
@@ -914,7 +915,7 @@ def _valid_request(**overrides):
         "start_url": None,
         "deadline_ms": 1_000_000,
         "max_steps": 10,
-        "model": "n2-preview",
+        "model": "n2",
         "api_base_url": "https://api.dev.yutori.com/v1",
     }
     request.update(overrides)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -147,11 +147,7 @@ def test_an_explicit_env_flag_still_selects_the_environment(monkeypatch):
 
 
 def test_the_adapter_resolves_the_key_for_the_targeted_environment(config, monkeypatch):
-    """Non-computer-use tools were served the SDK's single key.
-
-    After `--env dev login`, browsing/research/scout calls sent the production key at the dev API
-    because MCPClientAdapter never consulted the environments map.
-    """
+    """Non-default environments must use their matching stored credential."""
     from yutori_mcp import adapter
 
     config.write_text(
@@ -170,11 +166,11 @@ def test_the_adapter_resolves_the_key_for_the_targeted_environment(config, monke
     )
 
 
-def test_the_missing_key_remediation_points_at_the_dev_login():
-    """It said `uvx yutori-mcp login`, which stores a production key — the original misdiagnosis."""
+def test_the_missing_key_remediation_points_at_default_login(monkeypatch):
     from yutori_mcp.computer_use import preflight
 
+    monkeypatch.delenv("YUTORI_ENV", raising=False)
     with patch("yutori_mcp.credentials.resolve_api_key_for_environment", return_value=None):
         result = preflight.check_api_key()
     assert not result.ok
-    assert "--env dev login" in (result.remediation or "")
+    assert result.remediation == "Run: uvx yutori-mcp login"


### PR DESCRIPTION
## Summary
- document the dev-only n2 macOS computer-use preview in yutori-mcp
- clarify that yutori-mcp uses the Python SDK CUA harness, not a separate TypeScript runtime
- add installation, dependency, doctor, smoke, and MCP client configuration instructions

## Validation
- git diff --check
- pytest tests/test_computer_use.py::test_schema_requires_app_for_url_and_has_no_harness_override -q

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes when foreground desktop automation is exposed, which API/model it calls, and how credentials are validated—high impact if misconfigured keys or environments slip through doctor checks.
> 
> **Overview**
> **Graduates macOS computer use from a dev-only preview** to a supported capability: `run_computer_use_task` registers on **darwin** when the server’s API environment resolves cleanly (not only `YUTORI_ENV=dev`), tool copy no longer mentions a dev endpoint, and the runtime model id moves from **`n2-preview` to `n2`**.
> 
> **CLI, doctor, and smoke/run paths** now use `current_environment()` / `resolve_base_url()` instead of hardcoded dev URLs and keys. Preflight **`check_dev_access` → `check_api_access`** probes the active base URL with the pinned tool set and environment-aware login remediation. **`yutori-mcp computer-use`** clears ambient `YUTORI_ENV` unless `--env` is passed so setup/doctor/smoke default to production.
> 
> **Docs and agent packaging** add the **`/yutori-computer-use`** workflow skill (`skills/06-computer-use`, `.agents` symlink, Claude Desktop zip), expand README/TOOLS with pinned harness versions (`yutori==0.9.2`, `cua-driver==0.19.3`), setup/doctor/smoke/run flows, and trim standalone dev-environment README sections. **`pyproject.toml`** description is broadened to mention workflow skills.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1722d7cc49ddace37db49e0f85dd21d849f56c81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->