### PR TITLE
fix(computer-use): honor production API environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ You can use it with Claude Code, Codex, Cursor, VS Code, ChatGPT, OpenClaw, and 
 - **Scouting** — Monitor the web continuously for anything you care about at a desired frequency
 - **Research** — Run one-time deep web research tasks
 - **Browsing** — Automate websites with an AI navigator
-- **Computer use preview** — On macOS 15+, opt in to foreground desktop automation against the dev endpoint
+- **Computer use preview** — On macOS 15+, opt in to foreground desktop automation
 
 ### macOS computer-use preview
 
-This development-only preview is available only when the MCP server runs on macOS with
-`YUTORI_ENV=dev`. The runtime is Python-only and requires Python 3.10 or later. Setup installs
-CuaDriver, requests its macOS permissions, and prepares the optional native reasoning overlay:
+This preview is available when the MCP server runs on macOS. It targets production by default
+and follows `--env dev` or `YUTORI_ENV=dev` when you explicitly select the dev stack. The runtime
+is Python-only and requires Python 3.10 or later. Setup installs CuaDriver, requests its macOS
+permissions, and prepares the optional native reasoning overlay:
 
 ```bash
 uvx yutori-mcp computer-use setup
@@ -32,8 +33,8 @@ uvx yutori-mcp computer-use run "In Calculator, compute 17 * 23 and report the r
 ```
 
 The `run_computer_use_task` tool controls the visible foreground desktop. Do not touch the
-Mac while it runs. Visible desktop content is sent to Yutori's dev model endpoint. Only one
-task can control a Mac at a time.
+Mac while it runs. Visible desktop content is sent to the configured Yutori API environment.
+Only one task can control a Mac at a time.
 
 **Workflow skills** (for clients that support slash commands):
 - [`/yutori-scout`](skills/01-scout/SKILL.md) — Set up continuous web monitoring
@@ -425,10 +426,17 @@ For full API documentation, visit [docs.yutori.com](https://docs.yutori.com).
 
 Apache 2.0
 
-## Computer-use preview: authenticating against dev
+## Computer-use preview: choosing an environment
 
-`login` authenticates against production and saves a production key, which the dev stack
-rejects with a 401. Store a dev key separately:
+Production is the default for setup, doctor, smoke, terminal runs, and the MCP tool. A normal
+login saves the production credential they use:
+
+```sh
+uvx yutori-mcp login
+uvx yutori-mcp computer-use doctor
+```
+
+To test against dev, select it consistently and store a dev key separately:
 
 ```sh
 uvx yutori-mcp --env dev login      # prompts for a key from platform.dev.yutori.com
@@ -436,9 +444,10 @@ uvx yutori-mcp --env dev status
 uvx yutori-mcp --env dev logout
 ```
 
-That writes an `environments.dev` entry alongside the existing top-level `api_key`, so one
-machine can hold both without either shadowing the other. `YUTORI_API_KEY` still takes
-precedence over both when set.
+That writes an `environments.dev` entry alongside the existing top-level production `api_key`,
+so one machine can hold both without either shadowing the other. Pass `--env dev` to each
+computer-use command, or set `YUTORI_ENV=dev`. `YUTORI_API_KEY` still takes precedence over both
+stored credentials when set.
 
 ## Computer-use preview: runtime dependency
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -4,11 +4,12 @@ All tool outputs are formatted as human-readable text optimized for LLM consumpt
 
 All tool inputs enforce validation: webhook URLs must use HTTPS, and `output_fields` (where supported) must contain at least one entry. Unknown/extra fields are rejected.
 
-## `run_computer_use_task` (macOS dev preview)
+## `run_computer_use_task` (macOS preview)
 
-Runs a foreground task on the visible Mac desktop. This tool is listed only on macOS when
-`YUTORI_ENV=dev`; it is absent on Linux and in production. Do not touch the Mac during a run.
-Visible desktop content is sent to Yutori's dev model endpoint.
+Runs a foreground task on the visible Mac desktop. This tool is listed on macOS and absent on
+Linux. It targets production by default and follows `--env dev` or `YUTORI_ENV=dev` when
+configured. Do not touch the Mac during a run. Visible desktop content is sent to the selected
+Yutori API environment.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|

--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -23,6 +23,14 @@ from .result import format_result
 from .supervisor import run_task
 
 
+def _runtime_target() -> tuple[str | None, str]:
+    from ..adapter import current_environment, resolve_base_url
+    from ..credentials import resolve_api_key_for_environment
+
+    environment = current_environment()
+    return resolve_api_key_for_environment(environment), resolve_base_url(environment)
+
+
 def _doctor() -> int:
     results = run_checks()
     for result in results:
@@ -109,7 +117,7 @@ async def _smoke_live() -> int:
     if blocker is not None:
         print(blocker.remediation)
         return 1
-    from ..credentials import resolve_api_key_for_environment
+    api_key, api_base_url = _runtime_target()
 
     # The result is read back through Calculator's own copy-result (cmd+c) and
     # the clipboard, not the accessibility tree: macOS 26 rewrote Calculator and
@@ -160,8 +168,8 @@ async def _smoke_live() -> int:
         start_url=None,
         minutes=1,
         max_steps=10,
-        api_key=resolve_api_key_for_environment("dev"),
-        api_base_url="https://api.dev.yutori.com/v1",
+        api_key=api_key,
+        api_base_url=api_base_url,
     )
     print(format_result(result))
     return 0 if result.get("outcome") == "completed" else 1
@@ -199,13 +207,13 @@ async def _run_custom(args: argparse.Namespace) -> int:
     if blocker is not None:
         print(f"{blocker.detail} Fix: {blocker.remediation}")
         return 1
-    from ..credentials import resolve_api_key_for_environment
+    api_key, api_base_url = _runtime_target()
 
     print("The model takes over this Mac's desktop now; do not touch it during the run.")
     result = await run_task(
         **params.model_dump(),
-        api_key=resolve_api_key_for_environment("dev"),
-        api_base_url="https://api.dev.yutori.com/v1",
+        api_key=api_key,
+        api_base_url=api_base_url,
         on_event=_print_event,
     )
     print(format_result(result))
@@ -220,7 +228,7 @@ def register_parser(
     commands.add_parser("setup", help="Install and configure the pinned CuaDriver")
     commands.add_parser("doctor", help="Run all computer-use readiness checks")
     commands.add_parser("smoke", help="Run Calculator mechanical and live checks")
-    run_parser = commands.add_parser("run", help="Run one custom task on the visible desktop (dev only)")
+    run_parser = commands.add_parser("run", help="Run one custom task on the visible desktop")
     run_parser.add_argument("task", help="Task for the model to perform")
     run_parser.add_argument("--app", default=None, help="Application to target")
     run_parser.add_argument("--start-url", dest="start_url", default=None, help="URL to open in the app")

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -6,7 +6,7 @@ from .. import __version__
 
 PROTOCOL_VERSION = 1
 MCP_VERSION = __version__
-MODEL = "n2-preview"
+MODEL = "n2"
 TOOL_SET = "computer_use_tools-20260815"
 SDK_VERSION = "0.9.2"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.

--- a/src/yutori_mcp/computer_use/preflight.py
+++ b/src/yutori_mcp/computer_use/preflight.py
@@ -27,14 +27,6 @@ from .constants import (
 )
 
 DRIVER_APP = Path("/Applications/CuaDriver.app")
-DEV_ACCESS_REMEDIATION = (
-    "Store a dev key with: yutori-mcp --env dev login "
-    "(a production key is rejected by the dev stack). If it is already a dev key, ask "
-    "Yutori for n2-preview access."
-)
-# Named rather than inlined at both call sites: the previous text blamed missing access for
-# what is almost always a production key offered to dev, sending people to the wrong fix.
-DEV_ENVIRONMENT = "dev"
 DRIVER_PATHS = (
     # ~/.local/bin first: it is where the installer actually puts the CLI, and omitting it made
     # find_cua_driver() return None on a mini that had a working driver at
@@ -432,20 +424,33 @@ def check_capture() -> CheckResult:
 
 
 def check_api_key() -> CheckResult:
+    from ..adapter import current_environment
     from ..credentials import resolve_api_key_for_environment
 
-    key = resolve_api_key_for_environment(DEV_ENVIRONMENT)
+    environment = current_environment()
+    key = resolve_api_key_for_environment(environment)
     return _result(
         "API key",
         bool(key),
         "resolved" if key else "missing",
-        # Not plain `login`: that saves a production key, which is the misdiagnosis this
-        # change exists to remove.
-        f"Run: uvx yutori-mcp --env {DEV_ENVIRONMENT} login",
+        f"Run: {_login_command(environment)}",
     )
 
 
-def check_dev_access() -> CheckResult:
+def _login_command(environment: str) -> str:
+    if environment == "prod":
+        return "uvx yutori-mcp login"
+    return f"uvx yutori-mcp --env {environment} login"
+
+
+def _access_remediation(environment: str) -> str:
+    return (
+        f"Refresh the {environment} credential with: {_login_command(environment)}. "
+        "If it is already current, ask Yutori for n2-preview access."
+    )
+
+
+def check_api_access() -> CheckResult:
     """Probe the endpoint a run uses, and read the BODY, not just the status.
 
     Two traps, both hit for real. /v1/models 403s for keys that drive n2-preview fine, so this
@@ -453,12 +458,16 @@ def check_dev_access() -> CheckResult:
     {"error": {"type": "billing_error"}} — a key with no prepaid balance looked healthy here while
     every task failed at zero steps with an empty stderr. Status codes alone cannot see that.
     """
+    from ..adapter import current_environment, resolve_base_url
     from ..credentials import resolve_api_key_for_environment
 
+    environment = current_environment()
+    remediation = _access_remediation(environment)
+    result_name = f"{environment} API"
     try:
-        key = resolve_api_key_for_environment(DEV_ENVIRONMENT)
+        key = resolve_api_key_for_environment(environment)
         request = Request(
-            "https://api.dev.yutori.com/v1/chat/completions",
+            f"{resolve_base_url(environment).rstrip('/')}/chat/completions",
             data=json.dumps(
                 {
                     "model": "n2-preview",
@@ -475,10 +484,10 @@ def check_dev_access() -> CheckResult:
             payload = json.loads(response.read().decode() or "{}")
     except HTTPError as error:
         if error.code in {401, 403}:
-            return _result("dev API", False, "credential rejected", DEV_ACCESS_REMEDIATION)
-        return _result("dev API", False, f"probe failed (HTTP {error.code})", DEV_ACCESS_REMEDIATION)
+            return _result(result_name, False, "credential rejected", remediation)
+        return _result(result_name, False, f"probe failed (HTTP {error.code})", remediation)
     except (URLError, OSError, ValueError):
-        return _result("dev API", False, "unreachable", DEV_ACCESS_REMEDIATION)
+        return _result(result_name, False, "unreachable", remediation)
 
     error = payload.get("error")
     if isinstance(error, dict):
@@ -487,12 +496,12 @@ def check_dev_access() -> CheckResult:
         remediation = (
             "Add prepaid balance to this key's account, then retry."
             if "billing" in kind or "funds" in kind
-            else DEV_ACCESS_REMEDIATION
+            else remediation
         )
-        return _result("dev API", False, message, remediation)
+        return _result(result_name, False, message, remediation)
     if not payload.get("choices"):
-        return _result("dev API", False, "no completion returned", DEV_ACCESS_REMEDIATION)
-    return _result("dev API", True, "n2-preview returned a completion", DEV_ACCESS_REMEDIATION)
+        return _result(result_name, False, "no completion returned", remediation)
+    return _result(result_name, True, "n2-preview returned a completion", remediation)
 
 
 _PLATFORM_CHECKS: tuple[Callable[[], CheckResult], ...] = (
@@ -514,7 +523,7 @@ _ENVIRONMENT_CHECKS: tuple[Callable[[], CheckResult], ...] = (
     check_compiler,
     check_overlay,
     check_api_key,
-    check_dev_access,
+    check_api_access,
 )
 
 

--- a/src/yutori_mcp/computer_use/preflight.py
+++ b/src/yutori_mcp/computer_use/preflight.py
@@ -19,6 +19,7 @@ from urllib.request import Request, url2pathname, urlopen
 from .constants import (
     DRIVER_VERSION,
     MCP_VERSION,
+    MODEL,
     SDK_ARTIFACT_SHA256,
     SDK_INSTALLATION_SHA256,
     SDK_PROVENANCE_SHA256,
@@ -446,14 +447,14 @@ def _login_command(environment: str) -> str:
 def _access_remediation(environment: str) -> str:
     return (
         f"Refresh the {environment} credential with: {_login_command(environment)}. "
-        "If it is already current, ask Yutori for n2-preview access."
+        "If it is already current, ask Yutori for n2 access."
     )
 
 
 def check_api_access() -> CheckResult:
     """Probe the endpoint a run uses, and read the BODY, not just the status.
 
-    Two traps, both hit for real. /v1/models 403s for keys that drive n2-preview fine, so this
+    Two traps, both hit for real. /v1/models 403s for keys that drive n2 fine, so this
     asks chat/completions instead. And the API answers a billing failure with HTTP 200 carrying
     {"error": {"type": "billing_error"}} — a key with no prepaid balance looked healthy here while
     every task failed at zero steps with an empty stderr. Status codes alone cannot see that.
@@ -470,7 +471,7 @@ def check_api_access() -> CheckResult:
             f"{resolve_base_url(environment).rstrip('/')}/chat/completions",
             data=json.dumps(
                 {
-                    "model": "n2-preview",
+                    "model": MODEL,
                     "tool_set": TOOL_SET,
                     "messages": [{"role": "user", "content": "ping"}],
                 }
@@ -501,7 +502,7 @@ def check_api_access() -> CheckResult:
         return _result(result_name, False, message, remediation)
     if not payload.get("choices"):
         return _result(result_name, False, "no completion returned", remediation)
-    return _result(result_name, True, "n2-preview returned a completion", remediation)
+    return _result(result_name, True, f"{MODEL} returned a completion", remediation)
 
 
 _PLATFORM_CHECKS: tuple[Callable[[], CheckResult], ...] = (

--- a/src/yutori_mcp/entrypoint.py
+++ b/src/yutori_mcp/entrypoint.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 
 from . import __version__
+
+_ENVIRONMENTS = ("prod", "dev")
+_DEFAULT_ENVIRONMENT = "prod"
+_ENVIRONMENT_VARIABLE = "YUTORI_ENV"
 
 
 def _computer_use_main() -> None:
@@ -11,10 +16,16 @@ def _computer_use_main() -> None:
 
     parser = argparse.ArgumentParser(prog="yutori-mcp")
     parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
-    parser.add_argument("--env", choices=("prod", "dev"))
+    parser.add_argument("--env", choices=_ENVIRONMENTS)
     subparsers = parser.add_subparsers(dest="command", required=True)
     register_parser(subparsers)
     args = parser.parse_args()
+    if args.env:
+        os.environ[_ENVIRONMENT_VARIABLE] = args.env
+    environment = os.environ.get(_ENVIRONMENT_VARIABLE) or _DEFAULT_ENVIRONMENT
+    if environment not in _ENVIRONMENTS:
+        valid = ", ".join(sorted(_ENVIRONMENTS))
+        parser.error(f"Unknown Yutori environment {environment!r}; expected one of: {valid}")
     raise SystemExit(dispatch(args.computer_use_command, args))
 
 

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -685,22 +685,23 @@ def _computer_use_enabled() -> bool:
     if sys.platform != "darwin":
         return False
     try:
-        return resolve_base_url() == ENVIRONMENT_BASE_URLS["dev"]
+        resolve_base_url()
     except ValueError:
         return False
+    return True
 
 
 def _register_computer_use_tool() -> None:
-    """Expose the macOS computer-use tool when the resolved environment is dev."""
+    """Expose the computer-use tool on macOS for a valid API environment."""
     if "run_computer_use_task" in _TOOL_HANDLERS:
         return
     if not _computer_use_enabled():
         return
     mcp.tool(
         description=(
-            "Operate the foreground Mac desktop using Yutori's dev n2-preview model. "
+            "Operate the foreground Mac desktop using Yutori's n2-preview model. "
             "Do not touch the Mac during the run. Visible desktop content is sent to "
-            "Yutori's dev model endpoint."
+            "the configured Yutori API environment."
         ),
         annotations=_DESTRUCTIVE_OPEN_WORLD,
     )(run_computer_use_task)
@@ -840,18 +841,22 @@ def main() -> None:
 
     args = parser.parse_args()
 
-    if args.command == "computer-use":
-        from .computer_use.cli import dispatch
-
-        raise SystemExit(dispatch(args.computer_use_command, args))
-
     # The flag is forwarded via the env var (rather than threaded through to
     # get_adapter()'s lazily-constructed, process-lifetime MCPClientAdapter)
     # so adapter.resolve_base_url() stays the single resolution point
     # whether the environment came from the CLI or from an MCP client
-    # config's `env` block.
+    # config's `env` block. Apply it before every subcommand, including computer-use.
     if args.env:
         os.environ[ENV_VAR_ENVIRONMENT] = args.env
+
+    if args.command == "computer-use":
+        from .computer_use.cli import dispatch
+
+        try:
+            resolve_base_url()
+        except ValueError as error:
+            parser.error(str(error))
+        raise SystemExit(dispatch(args.computer_use_command, args))
 
     # Dispatched after --env is applied, not before: `login --env dev` has to know which
     # environment it is storing a credential for, and the old ordering ran auth first.

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -699,7 +699,7 @@ def _register_computer_use_tool() -> None:
         return
     mcp.tool(
         description=(
-            "Operate the foreground Mac desktop using Yutori's n2-preview model. "
+            "Operate the foreground Mac desktop using Yutori's n2 model. "
             "Do not touch the Mac during the run. Visible desktop content is sent to "
             "the configured Yutori API environment."
         ),

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -72,7 +72,7 @@ def test_schema_requires_app_for_url_and_has_no_harness_override():
         ComputerUseTaskInput(task="x", harness="node")
 
 
-def test_computer_use_cli_imports_without_executing_the_sdk():
+def test_computer_use_cli_dispatches_without_executing_the_sdk():
     source = Path(__file__).parents[1] / "src"
     script = """
 import importlib.abc
@@ -86,15 +86,57 @@ class BlockSDK(importlib.abc.MetaPathFinder):
 
 sys.meta_path.insert(0, BlockSDK())
 import yutori_mcp.entrypoint
-import yutori_mcp.computer_use.cli
+import yutori_mcp.computer_use.cli as cli
+
+cli.dispatch = lambda command, args: 0
+sys.argv = ["yutori-mcp", "computer-use", "doctor"]
+try:
+    yutori_mcp.entrypoint._computer_use_main()
+except SystemExit as error:
+    assert error.code == 0
 """
-    environment = {**os.environ, "PYTHONPATH": str(source)}
+    environment = {key: value for key, value in os.environ.items() if key != "YUTORI_ENV"}
+    environment["PYTHONPATH"] = str(source)
     subprocess.run([sys.executable, "-c", script], env=environment, check=True)
+
+
+def test_computer_use_entrypoint_applies_explicit_environment(monkeypatch):
+    from yutori_mcp import entrypoint
+    from yutori_mcp.computer_use import cli
+
+    observed = []
+
+    def dispatch(command, args):
+        observed.append((command, args.env, os.environ["YUTORI_ENV"]))
+        return 0
+
+    monkeypatch.setenv("YUTORI_ENV", "dev")
+    monkeypatch.setattr(sys, "argv", ["yutori-mcp", "--env", "prod", "computer-use", "doctor"])
+    monkeypatch.setattr(cli, "dispatch", dispatch)
+    with pytest.raises(SystemExit) as exit_info:
+        entrypoint._computer_use_main()
+
+    assert exit_info.value.code == 0
+    assert observed == [("doctor", "prod", "prod")]
+
+
+def test_computer_use_entrypoint_rejects_invalid_ambient_environment(monkeypatch, capsys):
+    from yutori_mcp import entrypoint
+    from yutori_mcp.computer_use import cli
+
+    monkeypatch.setenv("YUTORI_ENV", "staging")
+    monkeypatch.setattr(sys, "argv", ["yutori-mcp", "computer-use", "setup"])
+    with patch.object(cli, "dispatch") as mock_dispatch, pytest.raises(SystemExit) as exit_info:
+        entrypoint._computer_use_main()
+
+    assert exit_info.value.code == 2
+    mock_dispatch.assert_not_called()
+    assert "Unknown Yutori environment 'staging'" in capsys.readouterr().err
 
 
 @pytest.mark.parametrize(
     "platform,environment,expected",
-    [("linux", "dev", False), ("darwin", "prod", False), ("darwin", "dev", True)],
+    [("linux", "dev", False), ("darwin", "prod", True), ("darwin", "dev", True)],
 )
 def test_registration_gate(platform, environment, expected):
     with patch("yutori_mcp.server.sys.platform", platform), patch.dict("os.environ", {"YUTORI_ENV": environment}):
@@ -118,6 +160,40 @@ def test_main_applies_explicit_environment_before_computer_use_registration(monk
 
     server.main()
     assert observed == ["prod"]
+
+
+def test_server_module_applies_environment_before_computer_use_dispatch(monkeypatch):
+    from yutori_mcp import server
+    from yutori_mcp.computer_use import cli
+
+    observed = []
+
+    def dispatch(command, args):
+        observed.append((command, args.env, os.environ["YUTORI_ENV"]))
+        return 0
+
+    monkeypatch.setenv("YUTORI_ENV", "dev")
+    monkeypatch.setattr(sys, "argv", ["yutori-mcp", "--env", "prod", "computer-use", "doctor"])
+    monkeypatch.setattr(cli, "dispatch", dispatch)
+    with pytest.raises(SystemExit) as exit_info:
+        server.main()
+
+    assert exit_info.value.code == 0
+    assert observed == [("doctor", "prod", "prod")]
+
+
+def test_server_module_rejects_invalid_environment_before_computer_use_dispatch(monkeypatch, capsys):
+    from yutori_mcp import server
+    from yutori_mcp.computer_use import cli
+
+    monkeypatch.setenv("YUTORI_ENV", "staging")
+    monkeypatch.setattr(sys, "argv", ["yutori-mcp", "computer-use", "setup"])
+    with patch.object(cli, "dispatch") as mock_dispatch, pytest.raises(SystemExit) as exit_info:
+        server.main()
+
+    assert exit_info.value.code == 2
+    mock_dispatch.assert_not_called()
+    assert "Unknown Yutori environment 'staging'" in capsys.readouterr().err
 
 
 def test_lock_rejects_second_owner_and_releases(tmp_path):
@@ -654,8 +730,16 @@ def test_driver_contract_rejects_version_drift(monkeypatch):
     assert preflight.check_driver_contract().ok
 
 
-def test_dev_access_probes_the_runtime_toolset(monkeypatch):
+@pytest.mark.parametrize(
+    "environment,expected_url",
+    [
+        ("prod", "https://api.yutori.com/v1/chat/completions"),
+        ("dev", "https://api.dev.yutori.com/v1/chat/completions"),
+    ],
+)
+def test_api_access_probes_the_selected_environment(monkeypatch, environment, expected_url):
     requests = []
+    resolved_environments = []
 
     class Response:
         def __enter__(self):
@@ -669,24 +753,46 @@ def test_dev_access_probes_the_runtime_toolset(monkeypatch):
 
     monkeypatch.setattr(
         "yutori_mcp.credentials.resolve_api_key_for_environment",
-        lambda _environment: "dev-key",
+        lambda selected: resolved_environments.append(selected) or f"{selected}-key",
     )
+    monkeypatch.setenv("YUTORI_ENV", environment)
     monkeypatch.setattr(preflight, "urlopen", lambda request, timeout: requests.append(request) or Response())
 
-    assert preflight.check_dev_access().ok
+    result = preflight.check_api_access()
+    assert result.ok
+    assert result.name == f"{environment} API"
+    assert resolved_environments == [environment]
+    assert requests[0].full_url == expected_url
     assert json.loads(requests[0].data)["tool_set"] == TOOL_SET
 
 
 @pytest.mark.parametrize("status", [429, 500])
-def test_dev_access_rejects_non_auth_http_failures(monkeypatch, status):
+def test_api_access_rejects_non_auth_http_failures(monkeypatch, status):
     def fail_probe(*_args: Any, **_kwargs: Any) -> None:
         raise HTTPError("https://api.dev.yutori.com", status, "failed", {}, None)
 
     monkeypatch.setattr("yutori_mcp.credentials.resolve_api_key_for_environment", lambda _: "dev-key")
     monkeypatch.setattr(preflight, "urlopen", fail_probe)
-    result = preflight.check_dev_access()
+    result = preflight.check_api_access()
     assert not result.ok
     assert result.detail == f"probe failed (HTTP {status})"
+
+
+def test_prod_api_rejection_recommends_prod_login(monkeypatch):
+    def reject_probe(*_args: Any, **_kwargs: Any) -> None:
+        raise HTTPError("https://api.yutori.com", 401, "failed", {}, None)
+
+    monkeypatch.setenv("YUTORI_ENV", "prod")
+    monkeypatch.setattr("yutori_mcp.credentials.resolve_api_key_for_environment", lambda _: "prod-key")
+    monkeypatch.setattr(preflight, "urlopen", reject_probe)
+
+    result = preflight.check_api_access()
+
+    assert not result.ok
+    assert result.name == "prod API"
+    assert result.detail == "credential rejected"
+    assert "uvx yutori-mcp login" in (result.remediation or "")
+    assert "--env dev" not in (result.remediation or "")
 
 
 def test_runtime_check_verifies_version_installation_and_provenance(monkeypatch, tmp_path):
@@ -780,6 +886,35 @@ def test_doctor_labels_nonblocking_failures_as_warnings(monkeypatch, capsys):
     )
     assert cli._doctor() == 0
     assert "WARNING overlay" in capsys.readouterr().out
+
+
+async def test_custom_run_uses_the_selected_environment(monkeypatch):
+    from yutori_mcp.computer_use import cli
+
+    run = AsyncMock(return_value={"outcome": "completed"})
+    resolved_environments = []
+    monkeypatch.setenv("YUTORI_ENV", "prod")
+    monkeypatch.setattr(cli, "first_blocker", lambda: None)
+    monkeypatch.setattr(cli, "run_task", run)
+    monkeypatch.setattr(
+        "yutori_mcp.credentials.resolve_api_key_for_environment",
+        lambda environment: resolved_environments.append(environment) or "prod-key",
+    )
+
+    result = await cli._run_custom(
+        SimpleNamespace(
+            task="open calculator",
+            app="Calculator",
+            start_url=None,
+            minutes=1,
+            max_steps=10,
+        )
+    )
+
+    assert result == 0
+    assert resolved_environments == ["prod"]
+    assert run.await_args.kwargs["api_key"] == "prod-key"
+    assert run.await_args.kwargs["api_base_url"] == "https://api.yutori.com/v1"
 
 
 def test_installer_checksum_aborts_before_execution(monkeypatch):

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -657,7 +657,7 @@ async def test_run_task_uses_only_python_runner_and_sdk_driver_discovery(tmp_pat
     assert result["outcome"] == "completed"
     assert supervise.await_args.kwargs["command"] == python_runner_command()
     request = supervise.await_args.kwargs["request"]
-    assert request["model"] == "n2-preview"
+    assert request["model"] == "n2"
     assert "driver_path" not in request and "harness" not in request
 
 
@@ -763,7 +763,9 @@ def test_api_access_probes_the_selected_environment(monkeypatch, environment, ex
     assert result.name == f"{environment} API"
     assert resolved_environments == [environment]
     assert requests[0].full_url == expected_url
-    assert json.loads(requests[0].data)["tool_set"] == TOOL_SET
+    payload = json.loads(requests[0].data)
+    assert payload["model"] == "n2"
+    assert payload["tool_set"] == TOOL_SET
 
 
 @pytest.mark.parametrize("status", [429, 500])
@@ -1049,7 +1051,7 @@ def _valid_request(**overrides):
         "start_url": None,
         "deadline_ms": 1_000_000,
         "max_steps": 10,
-        "model": "n2-preview",
+        "model": "n2",
         "api_base_url": "https://api.dev.yutori.com/v1",
     }
     request.update(overrides)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -170,11 +170,20 @@ def test_the_adapter_resolves_the_key_for_the_targeted_environment(config, monke
     )
 
 
-def test_the_missing_key_remediation_points_at_the_dev_login():
-    """It said `uvx yutori-mcp login`, which stores a production key — the original misdiagnosis."""
+@pytest.mark.parametrize(
+    "environment,expected_command",
+    [
+        ("prod", "uvx yutori-mcp login"),
+        ("dev", "uvx yutori-mcp --env dev login"),
+    ],
+)
+def test_the_missing_key_remediation_points_at_the_selected_login(
+    monkeypatch, environment, expected_command
+):
     from yutori_mcp.computer_use import preflight
 
+    monkeypatch.setenv("YUTORI_ENV", environment)
     with patch("yutori_mcp.credentials.resolve_api_key_for_environment", return_value=None):
         result = preflight.check_api_key()
     assert not result.ok
-    assert "--env dev login" in (result.remediation or "")
+    assert expected_command in (result.remediation or "")


### PR DESCRIPTION
## Summary

- honor the selected prod or dev environment before dispatching computer-use commands
- use the matching API credential and base URL in setup, doctor, smoke, and run paths
- use the production n2 model consistently with yutori-sdk-python
- make preflight output and remediation name the environment that was actually checked

## Root cause

The top-level CLI parsed --env but dispatched computer-use before applying it. The computer-use preflight and runtime also hardcoded the dev credential, dev API URL, and preview model, so a production key was sent to the dev stack and rejected.

## Validation

- 340 passed, 1 skipped
- Ruff checks passed on touched Python files
- git diff --check
- live macOS production doctor completed every local runtime/driver/permission check and reached the prod API with model n2; the saved credential on the test Mac was rejected and needs login refresh
