### PR TITLE
docs: clarify MCP positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Yutori MCP
 
-MCP tools and workflow skills for building agents that monitor, research, browse, and operate computers with [Yutori](https://yutori.com/api).
+MCP tools and workflow skills for building agents that monitor, research, and browse the web as well as operate computers with [Yutori](https://yutori.com/api).
 
 You can use it with Claude Code, Codex, Cursor, VS Code, ChatGPT, OpenClaw, and other MCP hosts.
 


### PR DESCRIPTION
Updates the README tagline to describe MCP tools and workflow skills for agents that monitor, research, browse the web, and operate computers with Yutori.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edit with no runtime or security impact.
> 
> **Overview**
> Updates the **README** opening line so scouting, research, and browsing are explicitly **web** capabilities, with desktop automation described separately via “as well as operate computers.”
> 
> This is a wording-only change to how Yutori MCP is positioned for readers; no code, config, or tooling behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36211abda99df0d3fc4a2bdd46c2dd7bac9f446f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->