### PR TITLE
docs: fold computer use into the existing README and TOOLS flow

### DIFF
--- a/.agents/skills/README.md
+++ b/.agents/skills/README.md
@@ -7,10 +7,10 @@ Each `yutori-*/` directory contains agent metadata (e.g. `agents/openai.yaml`) a
 
 | This directory              | Canonical source              |
 |----------------------------|-------------------------------|
-| `yutori-scout/SKILL.md`     | `skills/01-scout/SKILL.md`     |
-| `yutori-research/SKILL.md`  | `skills/02-research/SKILL.md`  |
-| `yutori-browse/SKILL.md`    | `skills/03-browse/SKILL.md`   |
 | `yutori-computer-use/SKILL.md` | `skills/06-computer-use/SKILL.md` |
+| `yutori-browse/SKILL.md`    | `skills/03-browse/SKILL.md`   |
+| `yutori-research/SKILL.md`  | `skills/02-research/SKILL.md`  |
+| `yutori-scout/SKILL.md`     | `skills/01-scout/SKILL.md`     |
 | `yutori-competitor-watch/SKILL.md` | `skills/04-competitor-watch/SKILL.md` |
 | `yutori-api-monitor/SKILL.md` | `skills/05-api-monitor/SKILL.md`   |
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "yutori",
       "source": "./",
-      "description": "Web monitoring (Scouts), deep research, and browser automation"
+      "description": "macOS computer use, browser automation, deep research, and web monitoring (Scouts)"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "yutori",
   "version": "1.0.0",
-  "description": "Web monitoring (Scouts), deep research, and browser automation",
+  "description": "macOS computer use, browser automation, deep research, and web monitoring (Scouts)",
   "author": {
     "name": "Yutori",
     "email": "support@yutori.com",
@@ -10,5 +10,5 @@
   "homepage": "https://docs.yutori.com",
   "repository": "https://github.com/yutori-ai/yutori-mcp",
   "license": "Apache-2.0",
-  "keywords": ["web-monitoring", "scouts", "research", "browser-automation", "mcp"]
+  "keywords": ["computer-use", "browser-automation", "research", "web-monitoring", "scouts", "mcp"]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "yutori",
       "source": "./",
-      "description": "Web monitoring (Scouts), deep research, and browser automation"
+      "description": "macOS computer use, browser automation, deep research, and web monitoring (Scouts)"
     }
   ]
 }

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "yutori",
   "version": "1.0.0",
-  "description": "Web monitoring (Scouts), deep research, and browser automation",
+  "description": "macOS computer use, browser automation, deep research, and web monitoring (Scouts)",
   "author": {
     "name": "Yutori",
     "email": "support@yutori.com",
@@ -10,7 +10,7 @@
   "homepage": "https://docs.yutori.com",
   "repository": "https://github.com/yutori-ai/yutori-mcp",
   "license": "Apache-2.0",
-  "keywords": ["web-monitoring", "scouts", "research", "browser-automation", "mcp"],
+  "keywords": ["computer-use", "browser-automation", "research", "web-monitoring", "scouts", "mcp"],
   "skills": "skills",
   "mcpServers": ".mcp.json"
 }

--- a/README.md
+++ b/README.md
@@ -337,7 +337,7 @@ pip install yutori-mcp
 
 ### macOS computer use
 
-Optional, macOS 15+ only. Computer use drives the visible desktop, so it needs a local driver
+Optional, macOS 15+ only. Computer use operates the visible desktop, so it needs a local driver
 and system permissions on top of the install above:
 
 ```bash
@@ -355,12 +355,15 @@ uvx yutori-mcp computer-use smoke
 uvx yutori-mcp computer-use run "In Calculator, compute 17 * 23 and report the result." --app Calculator
 ```
 
-`smoke` runs a fixed Calculator check. `run` takes any task, prints each action as the agent
-takes it, and is the same run the `run_computer_use_task` tool performs.
+`smoke` is the end-to-end check: it types into Calculator to confirm the permissions took
+effect, then has the agent compute 9 * 9 in Calculator. `run` does whatever task you
+give it, printing each action as the agent takes it.
 </details>
 
-A task uses your real cursor and keyboard, so leave the Mac alone until it finishes. Only one
-task runs at a time.
+A task moves your real cursor and types on your real keyboard, so leave the Mac alone until it
+finishes. This version of the harness drives the foreground desktop and holds a machine-wide
+lock while it does: one task at a time, no background runs, no multiplexing. For parallel runs,
+see [n2 on Daytona](https://docs.yutori.com/reference/n2-daytona).
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -355,7 +355,8 @@ uvx yutori-mcp computer-use smoke
 uvx yutori-mcp computer-use run "In Calculator, compute 17 * 23 and report the result." --app Calculator
 ```
 
-Same run as the `run_computer_use_task` MCP tool, with per-action progress printed as it happens.
+`smoke` runs a fixed Calculator check. `run` takes any task, prints each action as the agent
+takes it, and is the same run the `run_computer_use_task` tool performs.
 </details>
 
 A task uses your real cursor and keyboard, so leave the Mac alone until it finishes. Only one

--- a/README.md
+++ b/README.md
@@ -1,90 +1,22 @@
 # Yutori MCP
 
-MCP tools and workflow skills for building agents that monitor, research, browse, and operate computers with [Yutori](https://yutori.com/api).
+MCP tools and workflow skills for building agents that operate computers, browse, research, and monitor the web with [Yutori](https://yutori.com/api).
 
 You can use it with Claude Code, Codex, Cursor, VS Code, ChatGPT, OpenClaw, and other MCP hosts.
 
 ## Features
 
 **Capabilities:**
-- **Scouting** — Monitor the web continuously for anything you care about at a desired frequency
-- **Research** — Run one-time deep web research tasks
+- **Computer use** — Operate apps on your Mac (macOS 15+)
 - **Browsing** — Automate websites with an AI navigator
-- **Computer use** — On macOS 15+, run tasks on the visible foreground desktop
-
-### macOS Computer Use
-
-On macOS, Yutori MCP exposes `run_computer_use_task` for foreground desktop automation.
-The tool controls the visible desktop, so do not touch the Mac while a task is running.
-
-The runtime is the Python CUA harness from the `yutori` SDK: `yutori-mcp` pins `yutori==0.9.2`
-and calls the SDK's `N2ComputerAgent` with `yutori.navigator.macos.MacOSComputer`. There is no
-TypeScript bundle, Node executable, or alternate harness. The pinned contract is:
-
-| Component | Value |
-|-----------|-------|
-| MCP package | `yutori-mcp==0.5.1` |
-| Model | Navigator n2 |
-| Tool set | `computer_use_tools-20260815` |
-| Desktop driver | `cua-driver==0.19.3` |
-| SDK runtime | `yutori[macos]==0.9.2` |
-
-Computer-use dependencies:
-
-| Dependency | Required for | Installed by |
-|------------|--------------|--------------|
-| macOS 15+ | Local desktop capture, input, and native overlay/recording path | You |
-| Python 3.10+ | `yutori-mcp` and the SDK-owned CUA harness | `uvx` can manage this |
-| `uv` / `uvx` | Running `yutori-mcp` without a manual virtualenv | You |
-| Yutori API key with computer-use access | Model calls from the local harness | `uvx yutori-mcp login` stores it |
-| `yutori==0.9.2` | `N2ComputerAgent` and `MacOSComputer` runtime | `yutori-mcp` dependency |
-| `cua-driver==0.19.3` and `CuaDriver.app` | Native screenshot capture and desktop actions | `uvx yutori-mcp computer-use setup` |
-| Screen Recording + Accessibility permissions | Letting CuaDriver see and operate the desktop | Requested by `computer-use setup` |
-| Xcode Command Line Tools | Optional reasoning overlay build | You; `doctor` reports if missing |
-
-Authenticate, install the local Mac runtime, and verify it:
-
-```bash
-uvx yutori-mcp login
-uvx yutori-mcp computer-use setup
-uvx yutori-mcp computer-use doctor
-uvx yutori-mcp computer-use smoke
-```
-
-`setup` downloads the pinned CuaDriver installer, checks its SHA-256, installs and starts
-`CuaDriver.app`, requests Screen Recording and Accessibility permissions, and prepares the
-optional native reasoning overlay. `doctor` verifies the pinned SDK wheel/provenance, the
-driver install, permissions, overlay cache, and Yutori API access before a task can run.
-
-`computer-use run` executes one custom task from the terminal — the same run the MCP tool
-performs, with per-action progress printed as it happens:
-
-```bash
-uvx yutori-mcp computer-use run "In Calculator, compute 17 * 23 and report the result." --app Calculator
-```
-
-To run through an MCP client, use the `run_computer_use_task` tool with a task, optional
-target app, optional start URL, time limit, and step limit. Only one task can control a Mac
-at a time.
-
-To expose the MCP tool to a client, run the default server:
-
-```json
-{
-  "mcpServers": {
-    "yutori": {
-      "command": "uvx",
-      "args": ["yutori-mcp"]
-    }
-  }
-}
-```
+- **Research** — Run one-time deep web research tasks
+- **Scouting** — Monitor the web continuously for anything you care about at a desired frequency
 
 **Workflow skills** (for clients that support slash commands):
-- [`/yutori-scout`](skills/01-scout/SKILL.md) — Set up continuous web monitoring
-- [`/yutori-research`](skills/02-research/SKILL.md) — Deep web research (async, 5–10 min)
-- [`/yutori-browse`](skills/03-browse/SKILL.md) — Browser automation
 - [`/yutori-computer-use`](skills/06-computer-use/SKILL.md) — Local Mac desktop automation
+- [`/yutori-browse`](skills/03-browse/SKILL.md) — Browser automation
+- [`/yutori-research`](skills/02-research/SKILL.md) — Deep web research (async, 5–10 min)
+- [`/yutori-scout`](skills/01-scout/SKILL.md) — Set up continuous web monitoring
 - [`/yutori-competitor-watch`](skills/04-competitor-watch/SKILL.md) — Competitor monitoring template
 - [`/yutori-api-monitor`](skills/05-api-monitor/SKILL.md) — API/changelog monitoring template
 
@@ -189,10 +121,10 @@ Use https://yutori.com/api/llms.txt and set up Yutori for me.
 
    | Skill | Description |
    |-------|-------------|
-   | `/yutori-scout` | Set up continuous web monitoring with comprehensive queries |
-   | `/yutori-research` | Deep web research workflow (async, 5-10 min) |
-   | `/yutori-browse` | Browser automation tasks |
    | `/yutori-computer-use` | Local Mac desktop automation |
+   | `/yutori-browse` | Browser automation tasks |
+   | `/yutori-research` | Deep web research workflow (async, 5-10 min) |
+   | `/yutori-scout` | Set up continuous web monitoring with comprehensive queries |
    | `/yutori-competitor-watch` | Quick competitor monitoring template |
    | `/yutori-api-monitor` | API/changelog monitoring template |
 
@@ -325,10 +257,10 @@ For setup details, see the [OpenAI MCP guide](https://platform.openai.com/docs/m
    Install skills using `$skill-installer` inside Codex:
 
    ```
-   $skill-installer install https://github.com/yutori-ai/yutori-mcp/tree/main/.agents/skills/yutori-scout
-   $skill-installer install https://github.com/yutori-ai/yutori-mcp/tree/main/.agents/skills/yutori-research
-   $skill-installer install https://github.com/yutori-ai/yutori-mcp/tree/main/.agents/skills/yutori-browse
    $skill-installer install https://github.com/yutori-ai/yutori-mcp/tree/main/.agents/skills/yutori-computer-use
+   $skill-installer install https://github.com/yutori-ai/yutori-mcp/tree/main/.agents/skills/yutori-browse
+   $skill-installer install https://github.com/yutori-ai/yutori-mcp/tree/main/.agents/skills/yutori-research
+   $skill-installer install https://github.com/yutori-ai/yutori-mcp/tree/main/.agents/skills/yutori-scout
    $skill-installer install https://github.com/yutori-ai/yutori-mcp/tree/main/.agents/skills/yutori-competitor-watch
    $skill-installer install https://github.com/yutori-ai/yutori-mcp/tree/main/.agents/skills/yutori-api-monitor
    ```
@@ -346,10 +278,10 @@ For setup details, see the [OpenAI MCP guide](https://platform.openai.com/docs/m
 
    | Skill | Command | Description |
    |-------|---------|-------------|
-   | Scout | `$yutori-scout` | Set up continuous web monitoring |
-   | Research | `$yutori-research` | Deep web research (async, 5-10 min) |
-   | Browse | `$yutori-browse` | Browser automation with AI navigator |
    | Computer Use | `$yutori-computer-use` | Local Mac desktop automation |
+   | Browse | `$yutori-browse` | Browser automation with AI navigator |
+   | Research | `$yutori-research` | Deep web research (async, 5-10 min) |
+   | Scout | `$yutori-scout` | Set up continuous web monitoring |
    | Competitor Watch | `$yutori-competitor-watch` | Quick competitor monitoring template |
    | API Monitor | `$yutori-api-monitor` | API/changelog monitoring template |
 
@@ -403,9 +335,33 @@ pip install yutori-mcp
 ```
 </details>
 
+### macOS computer use
+
+Optional, macOS 15+ only. Computer use drives the visible desktop, so it needs a local driver
+and system permissions on top of the install above:
+
+```bash
+uvx yutori-mcp computer-use setup    # installs CuaDriver.app, requests Screen Recording + Accessibility
+uvx yutori-mcp computer-use doctor   # verifies the driver, permissions, and API access
+```
+
+One task controls the Mac at a time, using the real cursor and keyboard — don't touch the
+machine while a task runs.
+
+<details>
+<summary>Run a task from the terminal</summary>
+
+```bash
+uvx yutori-mcp computer-use smoke
+uvx yutori-mcp computer-use run "In Calculator, compute 17 * 23 and report the result." --app Calculator
+```
+
+Same run as the `run_computer_use_task` MCP tool, with per-action progress printed as it happens.
+</details>
+
 ## Tools
 
-See [TOOLS.md](TOOLS.md) for the full tool reference — Scout, Research, and Browsing tools with parameters, examples, and response formats.
+See [TOOLS.md](TOOLS.md) for the full tool reference — computer use, Browsing, Research, and Scout tools with parameters, examples, and response formats.
 
 ## Development
 
@@ -430,6 +386,12 @@ yutori-mcp login    # authenticate (one-time)
 yutori-mcp          # run the server (or: python -m yutori_mcp.server)
 ```
 
+### Computer-use runtime
+
+`computer-use doctor` verifies the pinned `yutori` SDK install against the published wheel.
+SDK contributors testing an editable checkout can override that with
+`YUTORI_MCP_ALLOW_EDITABLE_SDK=1`.
+
 ### Debugging with MCP Inspector
 
 ```bash
@@ -443,14 +405,3 @@ For full API documentation, visit [docs.yutori.com](https://docs.yutori.com).
 ## License
 
 Apache 2.0
-
-## Computer-use SDK harness and runtime dependency
-
-The SDK-owned `yutori.navigator.N2ComputerAgent` and `MacOSComputer` provide the complete
-runtime. The MCP package pins SDK 0.9.2 and verifies the installed files against the immutable
-published wheel plus its packaged provenance during `computer-use doctor`. There is no
-TypeScript bundle, Node executable, alternate harness, or private dependency access.
-
-SDK contributors may deliberately test an editable 0.9.2 checkout by setting
-`YUTORI_MCP_ALLOW_EDITABLE_SDK=1`; without that explicit override, doctor rejects editable or
-modified SDK installations.

--- a/README.md
+++ b/README.md
@@ -347,9 +347,6 @@ uvx yutori-mcp computer-use setup    # installs CuaDriver.app, requests Screen R
 `setup` finishes by running the readiness checks and reports anything still missing. Re-run
 those checks any time with `uvx yutori-mcp computer-use doctor`.
 
-One task controls the Mac at a time, using the real cursor and keyboard — don't touch the
-machine while a task runs.
-
 <details>
 <summary>Run a task from the terminal</summary>
 
@@ -360,6 +357,9 @@ uvx yutori-mcp computer-use run "In Calculator, compute 17 * 23 and report the r
 
 Same run as the `run_computer_use_task` MCP tool, with per-action progress printed as it happens.
 </details>
+
+A task uses your real cursor and keyboard, so leave the Mac alone until it finishes. Only one
+task runs at a time.
 
 ## Tools
 

--- a/README.md
+++ b/README.md
@@ -342,8 +342,10 @@ and system permissions on top of the install above:
 
 ```bash
 uvx yutori-mcp computer-use setup    # installs CuaDriver.app, requests Screen Recording + Accessibility
-uvx yutori-mcp computer-use doctor   # verifies the driver, permissions, and API access
 ```
+
+`setup` finishes by running the readiness checks and reports anything still missing. Re-run
+those checks any time with `uvx yutori-mcp computer-use doctor`.
 
 One task controls the Mac at a time, using the real cursor and keyboard — don't touch the
 machine while a task runs.

--- a/README.md
+++ b/README.md
@@ -355,15 +355,14 @@ uvx yutori-mcp computer-use smoke
 uvx yutori-mcp computer-use run "In Calculator, compute 17 * 23 and report the result." --app Calculator
 ```
 
-`smoke` is the end-to-end check: it types into Calculator to confirm the permissions took
+`smoke` is an end-to-end check: it types into Calculator to confirm the permissions took
 effect, then has the agent compute 9 * 9 in Calculator. `run` does whatever task you
 give it, printing each action as the agent takes it.
 </details>
 
-A task moves your real cursor and types on your real keyboard, so leave the Mac alone until it
-finishes. This version of the harness drives the foreground desktop and holds a machine-wide
-lock while it does: one task at a time, no background runs, no multiplexing. For parallel runs,
-see [n2 on Daytona](https://docs.yutori.com/reference/n2-daytona).
+The harness in this repository is minimal: it drives the foreground desktop one task at a time,
+no background runs, no multiplexing. For scalable sandbox runs, see
+[n2 on Daytona](https://docs.yutori.com/reference/n2-daytona).
 
 ## Tools
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -4,74 +4,313 @@ All tool outputs are formatted as human-readable text optimized for LLM consumpt
 
 All tool inputs enforce validation: webhook URLs must use HTTPS, and `output_fields` (where supported) must contain at least one entry. Unknown/extra fields are rejected.
 
-## `run_computer_use_task` (macOS computer use)
+## Computer Use Tools
 
-Runs a foreground task on the visible Mac desktop. This tool is listed only on macOS. Do not
-touch the Mac during a run. Visible desktop content is sent to Yutori.
+### run_computer_use_task
 
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `task` | Yes | Natural-language desktop task |
-| `app` | No | Application to target; omit for cross-app tasks |
-| `start_url` | No | Starting URL; requires `app` |
-| `minutes` | No | Absolute deadline, 1–15 minutes (default 3) |
-| `max_steps` | No | Maximum actions, 1–100 (default 60) |
+Operate the foreground Mac desktop with the computer-use agent - clicking, typing, and driving
+apps like a person. Listed only on macOS, and only once the setup in
+[README](README.md#macos-computer-use) is done. One task controls the Mac at a time. Do not
+touch the Mac during a run; visible desktop content is sent to Yutori.
 
-First-time setup: authenticate with `uvx yutori-mcp login`, then run
-`uvx yutori-mcp computer-use setup` and `uvx yutori-mcp computer-use doctor`. Use
-`uvx yutori-mcp computer-use smoke` for the Calculator smoke test. To run from a terminal, use
-`uvx yutori-mcp computer-use run "<task>" --app <AppName>`. The tool uses the SDK-owned
-Python CUA harness (`yutori==0.9.2`), Navigator n2, `computer_use_tools-20260815`, and
-`cua-driver==0.19.3`; `doctor` verifies those pinned runtime artifacts before a task runs.
-
-Dependencies: macOS 15+, Python 3.10+, `uvx`, a Yutori API key with computer-use access,
-`CuaDriver.app`/`cua-driver==0.19.3`, Screen Recording and Accessibility permissions, and
-optionally Xcode Command Line Tools for the native reasoning overlay. `computer-use setup`
-installs the pinned driver and prompts for the macOS permissions; the task runner can continue
-without the optional overlay.
-
-## Usage
-
-### list_api_usage
-
-Get API usage statistics including active scout counts, rate limits, and activity metrics.
+**Basic example:**
 
 ```json
 {
-  "period": "7d"
+  "task": "In Calculator, compute 17 * 23 and report the result.",
+  "app": "Calculator"
+}
+```
+
+**Advanced example (target app, start URL, longer budget):**
+
+```json
+{
+  "task": "Open the Yutori company page and list the founders.",
+  "app": "Safari",
+  "start_url": "https://yutori.com",
+  "minutes": 5,
+  "max_steps": 80
+}
+```
+
+Example response:
+
+```
+Outcome: completed
+Delivery mode: foreground
+Final text: 17 * 23 = 391
+Elapsed: 18452 ms
+Perf: total 18.5s over 6 steps (3.1s/step)
+Actions:
+- #1 computer_batch: executed (raw: confirmed; mode: foreground; route: pixel; refusal: None) took 412 ms
+- #2 left_click: executed (raw: confirmed; mode: foreground; route: pixel; refusal: None) took 138 ms
+```
+
+`Outcome` is `completed`, `limit` (hit `minutes` or `max_steps`), `aborted`, or `failed`.
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `task` | Yes | Natural language instruction for the desktop agent |
+| `app` | No | Application to target; omit for cross-app tasks |
+| `start_url` | No | URL to open before the task starts; requires `app` |
+| `minutes` | No | Wall-clock deadline in minutes (1-15). Default: 3 |
+| `max_steps` | No | Max desktop actions (1-100). Default: 60 |
+
+## Browsing Tools
+
+### list_browsing_tasks
+
+List one-time browsing tasks for the user with optional filtering and cursor pagination.
+
+```json
+{
+  "limit": 10,
+  "status": "succeeded"
 }
 ```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `period` | No | Activity time range: `24h` (default), `7d`, `30d`, or `90d` |
+| `limit` | No | Max tasks to return (1-100). Default: 10 |
+| `status` | No | Filter by `running`, `succeeded`, or `failed` |
+| `cursor` | No | Cursor from a previous response |
 
 Example response:
 
 ```
-Active Scouts: 5
-  - a1b2c3d4-e5f6-7890-abcd-ef1234567890
-  - b2c3d4e5-f6a7-8901-bcde-f12345678901
-  ... and 3 more
+Found 42 browsing tasks: 1 running, 39 succeeded, 2 failed.
 
-API Rate Limits (available):
-  Requests today: 1250
-  Daily limit: 10000
-  Remaining: 8750
-  Resets at: 2026-03-04T00:00:00+00:00
+Showing 10 of 39 matching tasks (42 total):
 
-Navigator API Rate Limits:
-  Requests today: 342
-  Daily limit: 50000
-  Remaining: 49658
-  Per-second limit: 20
-  Resets at: 2026-03-04T00:00:00+00:00
+1. Give me a list of all employees of Yutori. (succeeded)
+   ID: 54fb19fd-277e-4098-ab72-5a9f8a4347fc
+   URL: https://platform.yutori.com/browsing/tasks/54fb19fd-277e-4098-ab72-5a9f8a4347fc
+   Created: 2026-06-25
 
-Activity (7d):
-  Scout runs: 47
-  Browsing tasks: 12
-  Research tasks: 8
-  Navigator API calls: 1523
+More tasks available. Use list_browsing_tasks(cursor="eyJjcmVhdGVkX2F0...") to load more.
+Use list_browsing_tasks(status="succeeded") to list tasks with retrievable results.
+Use get_browsing_task_result(task_id) for full details.
+```
+
+### run_browsing_task
+
+Execute a one-time web browsing task using the navigator agent. The agent runs either a cloud browser or Yutori Local on the desktop and operates it like a person - clicking, typing, scrolling, and navigating for you.
+
+**Basic example:**
+
+```json
+{
+  "task": "Give me a list of all employees (names and titles) of Yutori.",
+  "start_url": "https://yutori.com"
+}
+```
+
+**Advanced example (webhooks, structured output):**
+
+```json
+{
+  "task": "Log in and export the latest invoice.",
+  "start_url": "https://example.com/login",
+  "max_steps": 75,
+  "require_auth": true,
+  "webhook_url": "https://example.com/webhook",
+  "output_fields": ["name", "title"]
+}
+```
+
+Example response:
+
+```
+Browsing task started.
+
+Task ID: 54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396
+Status: queued
+View progress: https://platform.yutori.com/browsing/tasks/54fb19fd-277e-4098-ab72-5a9f8a4347fc
+
+Poll with get_browsing_task_result(task_id="54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396") to check status.
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `task` | Yes | Natural language instruction for the navigator |
+| `start_url` | Yes | URL where browsing begins |
+| `max_steps` | No | Max browser actions (1-100). Default: 25 |
+| `require_auth` | No | If true, use an auth-optimized cloud browser provider for login flows. Only applies when browser is `cloud` (default) |
+| `browser` | No | `cloud` (default) or `local` to use Yutori Local with the user's logged-in desktop browser |
+| `output_fields` | No | List of field names for structured output as array of objects |
+| `webhook_url` | No | HTTPS URL for completion notification |
+| `webhook_format` | No | `scout` (default), `slack`, or `zapier` |
+
+### get_browsing_task_result
+
+Poll for the status and result of a browsing task. Call this after `run_browsing_task` until status is `succeeded` or `failed`.
+
+```json
+{
+  "task_id": "54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396"
+}
+```
+
+Example response (running):
+
+```
+Task in progress.
+
+Task ID: 54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396
+Status: running
+
+Poll again in a few seconds.
+```
+
+Example response (succeeded):
+
+```
+Task completed.
+
+Task ID: 54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396
+Status: succeeded
+
+Result:
+Summary of All Yutori Employees
+
+I have successfully located all employees of Yutori on their company page.
+Here is the complete list of 17 employees with their names and titles:
+
+Founders & Leadership:
+1. Abhishek Das - Co-founder and Co-CEO
+2. Devi Parikh - Co-founder and Co-CEO
+3. Dhruv Batra - Co-founder and Chief Scientist
+
+Executive:
+4. Kristi Edleson - Chief of Staff
+
+Technical Staff:
+5. Rui Wang - Member of Technical Staff
+... (17 employees total)
+
+Source Page: https://yutori.com/company#team
+```
+
+## Research Tools
+
+### list_research_tasks
+
+List one-time research tasks for the user with optional filtering and cursor pagination.
+
+```json
+{
+  "limit": 10,
+  "status": "succeeded"
+}
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `limit` | No | Max tasks to return (1-100). Default: 10 |
+| `status` | No | Filter by `running`, `succeeded`, or `failed` |
+| `cursor` | No | Cursor from a previous response |
+
+Example response:
+
+```
+Found 248 research tasks: 0 running, 245 succeeded, 3 failed.
+
+Showing 10 of 245 matching tasks (248 total):
+
+1. Competitive landscape for AI code assistants (succeeded)
+   ID: ae27a17c-a4ed-4c69-8b2a-4bec330fc935
+   URL: https://platform.yutori.com/research/tasks/ae27a17c-a4ed-4c69-8b2a-4bec330fc935
+   Created: 2026-06-25
+
+More tasks available. Use list_research_tasks(cursor="eyJjcmVhdGVkX2F0...") to load more.
+Use list_research_tasks(status="succeeded") to list tasks with retrievable results.
+Use get_research_task_result(task_id) for full details.
+```
+
+### run_research_task
+
+Execute a one-time deep web research task. The research agent searches, reads, and synthesizes information from across the web.
+
+**Basic example:**
+
+```json
+{
+  "query": "What are the latest developments in quantum computing from the past week? Include company announcements, research papers, and product releases."
+}
+```
+
+**Advanced example (webhooks, structured output):**
+
+```json
+{
+  "query": "What are the latest developments in quantum computing from the past week? Include company announcements, research papers, and product releases.",
+  "user_timezone": "America/Los_Angeles",
+  "webhook_url": "https://example.com/webhook",
+  "output_fields": ["title", "summary", "source_url", "category"]
+}
+```
+
+Example response:
+
+```
+Research task started.
+
+Task ID: ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395
+Status: queued
+View progress: https://platform.yutori.com/research/tasks/ae27a17c-a4ed-4c69-8b2a-4bec330fc935
+
+Poll with get_research_task_result(task_id="ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395") to check status.
+```
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `query` | Yes | Natural language description of what to research |
+| `user_timezone` | No | Timezone for context. Default: 'America/Los_Angeles' |
+| `user_location` | No | Location for context. Default: 'San Francisco, CA, US' |
+| `output_fields` | No | List of field names for structured output as array of objects |
+| `webhook_url` | No | HTTPS URL for completion notification |
+| `webhook_format` | No | `scout` (default), `slack`, or `zapier` |
+
+### get_research_task_result
+
+Poll for the status and result of a research task. Call this after `run_research_task` until status is `succeeded` or `failed`.
+
+```json
+{
+  "task_id": "ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395"
+}
+```
+
+Example response (running):
+
+```
+Task in progress.
+
+Task ID: ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395
+Status: running
+
+Poll again in a few seconds.
+```
+
+Example response (succeeded):
+
+```
+Task completed.
+
+Task ID: ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395
+Status: succeeded
+
+Result:
+Hardware strides and strategic moves this week
+
+I focused on notable hardware breakthroughs, leadership changes, applied research,
+and an industry appearance from January 12–19, 2026.
+
+• MIT demonstrated chip-based cooling for trapped-ion qubits
+• EeroQ unveiled a scalable quantum control chip
+• IonQ appointed Katie Arrington as Chief Information Officer
+• Researchers introduced QUPID, a quantum neural network
 ```
 
 ## Scout Tools
@@ -321,260 +560,48 @@ Date: 2026-01-15 05:45 UTC
 No new findings since last update.
 ```
 
-## Research Tools
+## Usage
 
-### list_research_tasks
+### list_api_usage
 
-List one-time research tasks for the user with optional filtering and cursor pagination.
+Get API usage statistics including active scout counts, rate limits, and activity metrics.
 
 ```json
 {
-  "limit": 10,
-  "status": "succeeded"
+  "period": "7d"
 }
 ```
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|
-| `limit` | No | Max tasks to return (1-100). Default: 10 |
-| `status` | No | Filter by `running`, `succeeded`, or `failed` |
-| `cursor` | No | Cursor from a previous response |
+| `period` | No | Activity time range: `24h` (default), `7d`, `30d`, or `90d` |
 
 Example response:
 
 ```
-Found 248 research tasks: 0 running, 245 succeeded, 3 failed.
-
-Showing 10 of 245 matching tasks (248 total):
-
-1. Competitive landscape for AI code assistants (succeeded)
-   ID: ae27a17c-a4ed-4c69-8b2a-4bec330fc935
-   URL: https://platform.yutori.com/research/tasks/ae27a17c-a4ed-4c69-8b2a-4bec330fc935
-   Created: 2026-06-25
-
-More tasks available. Use list_research_tasks(cursor="eyJjcmVhdGVkX2F0...") to load more.
-Use list_research_tasks(status="succeeded") to list tasks with retrievable results.
-Use get_research_task_result(task_id) for full details.
-```
-
-### run_research_task
-
-Execute a one-time deep web research task. The research agent searches, reads, and synthesizes information from across the web.
-
-**Basic example:**
-
-```json
-{
-  "query": "What are the latest developments in quantum computing from the past week? Include company announcements, research papers, and product releases."
-}
-```
-
-**Advanced example (webhooks, structured output):**
-
-```json
-{
-  "query": "What are the latest developments in quantum computing from the past week? Include company announcements, research papers, and product releases.",
-  "user_timezone": "America/Los_Angeles",
-  "webhook_url": "https://example.com/webhook",
-  "output_fields": ["title", "summary", "source_url", "category"]
-}
-```
-
-Example response:
-
-```
-Research task started.
-
-Task ID: ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395
-Status: queued
-View progress: https://platform.yutori.com/research/tasks/ae27a17c-a4ed-4c69-8b2a-4bec330fc935
-
-Poll with get_research_task_result(task_id="ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395") to check status.
-```
-
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `query` | Yes | Natural language description of what to research |
-| `user_timezone` | No | Timezone for context. Default: 'America/Los_Angeles' |
-| `user_location` | No | Location for context. Default: 'San Francisco, CA, US' |
-| `output_fields` | No | List of field names for structured output as array of objects |
-| `webhook_url` | No | HTTPS URL for completion notification |
-| `webhook_format` | No | `scout` (default), `slack`, or `zapier` |
-
-### get_research_task_result
-
-Poll for the status and result of a research task. Call this after `run_research_task` until status is `succeeded` or `failed`.
-
-```json
-{
-  "task_id": "ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395"
-}
-```
-
-Example response (running):
-
-```
-Task in progress.
-
-Task ID: ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395
-Status: running
-
-Poll again in a few seconds.
-```
-
-Example response (succeeded):
-
-```
-Task completed.
-
-Task ID: ae27a17c-a4ed-4c69-8b2a-4bec330fc935-1768848395
-Status: succeeded
-
-Result:
-Hardware strides and strategic moves this week
-
-I focused on notable hardware breakthroughs, leadership changes, applied research,
-and an industry appearance from January 12–19, 2026.
-
-• MIT demonstrated chip-based cooling for trapped-ion qubits
-• EeroQ unveiled a scalable quantum control chip
-• IonQ appointed Katie Arrington as Chief Information Officer
-• Researchers introduced QUPID, a quantum neural network
-```
-
-## Browsing Tools
-
-### list_browsing_tasks
-
-List one-time browsing tasks for the user with optional filtering and cursor pagination.
-
-```json
-{
-  "limit": 10,
-  "status": "succeeded"
-}
-```
-
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `limit` | No | Max tasks to return (1-100). Default: 10 |
-| `status` | No | Filter by `running`, `succeeded`, or `failed` |
-| `cursor` | No | Cursor from a previous response |
-
-Example response:
-
-```
-Found 42 browsing tasks: 1 running, 39 succeeded, 2 failed.
-
-Showing 10 of 39 matching tasks (42 total):
-
-1. Give me a list of all employees of Yutori. (succeeded)
-   ID: 54fb19fd-277e-4098-ab72-5a9f8a4347fc
-   URL: https://platform.yutori.com/browsing/tasks/54fb19fd-277e-4098-ab72-5a9f8a4347fc
-   Created: 2026-06-25
-
-More tasks available. Use list_browsing_tasks(cursor="eyJjcmVhdGVkX2F0...") to load more.
-Use list_browsing_tasks(status="succeeded") to list tasks with retrievable results.
-Use get_browsing_task_result(task_id) for full details.
-```
-
-### run_browsing_task
-
-Execute a one-time web browsing task using the navigator agent. The agent runs either a cloud browser or Yutori Local on the desktop and operates it like a person - clicking, typing, scrolling, and navigating for you.
-
-**Basic example:**
-
-```json
-{
-  "task": "Give me a list of all employees (names and titles) of Yutori.",
-  "start_url": "https://yutori.com"
-}
-```
-
-**Advanced example (webhooks, structured output):**
-
-```json
-{
-  "task": "Log in and export the latest invoice.",
-  "start_url": "https://example.com/login",
-  "max_steps": 75,
-  "require_auth": true,
-  "webhook_url": "https://example.com/webhook",
-  "output_fields": ["name", "title"]
-}
-```
-
-Example response:
-
-```
-Browsing task started.
-
-Task ID: 54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396
-Status: queued
-View progress: https://platform.yutori.com/browsing/tasks/54fb19fd-277e-4098-ab72-5a9f8a4347fc
-
-Poll with get_browsing_task_result(task_id="54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396") to check status.
-```
-
-| Parameter | Required | Description |
-|-----------|----------|-------------|
-| `task` | Yes | Natural language instruction for the navigator |
-| `start_url` | Yes | URL where browsing begins |
-| `max_steps` | No | Max browser actions (1-100). Default: 25 |
-| `require_auth` | No | If true, use an auth-optimized cloud browser provider for login flows. Only applies when browser is `cloud` (default) |
-| `browser` | No | `cloud` (default) or `local` to use Yutori Local with the user's logged-in desktop browser |
-| `output_fields` | No | List of field names for structured output as array of objects |
-| `webhook_url` | No | HTTPS URL for completion notification |
-| `webhook_format` | No | `scout` (default), `slack`, or `zapier` |
-
-### get_browsing_task_result
-
-Poll for the status and result of a browsing task. Call this after `run_browsing_task` until status is `succeeded` or `failed`.
-
-```json
-{
-  "task_id": "54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396"
-}
-```
-
-Example response (running):
-
-```
-Task in progress.
-
-Task ID: 54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396
-Status: running
-
-Poll again in a few seconds.
-```
-
-Example response (succeeded):
-
-```
-Task completed.
-
-Task ID: 54fb19fd-277e-4098-ab72-5a9f8a4347fc-1768848396
-Status: succeeded
-
-Result:
-Summary of All Yutori Employees
-
-I have successfully located all employees of Yutori on their company page.
-Here is the complete list of 17 employees with their names and titles:
-
-Founders & Leadership:
-1. Abhishek Das - Co-founder and Co-CEO
-2. Devi Parikh - Co-founder and Co-CEO
-3. Dhruv Batra - Co-founder and Chief Scientist
-
-Executive:
-4. Kristi Edleson - Chief of Staff
-
-Technical Staff:
-5. Rui Wang - Member of Technical Staff
-... (17 employees total)
-
-Source Page: https://yutori.com/company#team
+Active Scouts: 5
+  - a1b2c3d4-e5f6-7890-abcd-ef1234567890
+  - b2c3d4e5-f6a7-8901-bcde-f12345678901
+  ... and 3 more
+
+API Rate Limits (available):
+  Requests today: 1250
+  Daily limit: 10000
+  Remaining: 8750
+  Resets at: 2026-03-04T00:00:00+00:00
+
+Navigator API Rate Limits:
+  Requests today: 342
+  Daily limit: 50000
+  Remaining: 49658
+  Per-second limit: 20
+  Resets at: 2026-03-04T00:00:00+00:00
+
+Activity (7d):
+  Scout runs: 47
+  Browsing tasks: 12
+  Research tasks: 8
+  Navigator API calls: 1523
 ```
 
 ## Tool Annotations
@@ -583,6 +610,7 @@ Tools include hints for client behavior:
 
 | Tool | Annotation |
 |------|------------|
-| `list_api_usage`, `list_scouts`, `get_scout_detail`, `get_scout_updates`, `list_browsing_tasks`, `get_browsing_task_result`, `list_research_tasks`, `get_research_task_result` | `readOnlyHint: true` |
+| `run_computer_use_task` | `destructiveHint: true`, `openWorldHint: true` |
+| `list_browsing_tasks`, `get_browsing_task_result`, `list_research_tasks`, `get_research_task_result`, `list_scouts`, `get_scout_detail`, `get_scout_updates`, `list_api_usage` | `readOnlyHint: true` |
 | `edit_scout` | `idempotentHint: true` |
 | `delete_scout` | `destructiveHint: true` |

--- a/skills/06-computer-use/SKILL.md
+++ b/skills/06-computer-use/SKILL.md
@@ -15,8 +15,10 @@ If the user has not set up computer use yet, ask them to run these commands in a
 ```bash
 uvx yutori-mcp login
 uvx yutori-mcp computer-use setup
-uvx yutori-mcp computer-use doctor
 ```
+
+`setup` ends with the readiness checks and reports anything still missing. To re-check later,
+or when a run fails, use `uvx yutori-mcp computer-use doctor`.
 
 Use the smoke test when validating a fresh install:
 


### PR DESCRIPTION
The macOS computer-use docs landed as a block dropped into the middle of README's Features section: dependencies, install steps, and tool reference all in one place, plus internals (SDK pins, harness class names, "there is no TypeScript bundle") at a detail level no other section uses. This puts each piece where the README already keeps that kind of information.

## README

- **Features** — deleted the `### macOS Computer Use` subsection (pinned-contract table, dependency table, setup narration, MCP tool description, server JSON block). Features is two tight bullet lists again, and the `Features → Installation` flow is restored.
- **Installation** — new `### macOS computer use` subsection at the end, after both install paths, so it applies whichever one you took. Two commands with inline comments instead of a dependency table; the terminal runner sits behind a `<details>` like the rest of the section.
- **Tools** — the TOOLS.md pointer now covers computer use; the tool's parameters live there, not here.
- **Development** — the trailing `## Computer-use SDK harness and runtime dependency` section (which sat *after* License) is gone. Its one actionable fact — `YUTORI_MCP_ALLOW_EDITABLE_SDK=1` for SDK contributors — is now two lines under Development.

## TOOLS.md

- `run_computer_use_task` was a bare `##` heading wedged above `## Usage`. It's now `## Computer Use Tools` → `### run_computer_use_task`, matching the Browsing/Research grouping and following their layout: basic example → advanced example → example response → parameter table.
- Added the example response (real `format_result` output) and the four `Outcome` values, neither of which was documented.
- Setup commands and the dependency paragraph now link to `README.md#macos-computer-use` instead of duplicating it.
- `## Tool Annotations` was missing `run_computer_use_task` entirely; it now has its own row (`destructiveHint`, `openWorldHint`).

## Ordering

Capability lists ran scouting → research → browsing → computer use, leaving the newest capability last everywhere. They now read computer use → browsing → research → scouting:

- README tagline, Features bullets, workflow-skills list, Claude Code plugin table, Codex `$skill-installer` commands and table, TOOLS.md pointer
- TOOLS.md section order (`## Usage` moved from the top to after Scout so the capability sections stay contiguous)
- `.agents/skills/README.md` symlink mapping table
- Plugin manifests for Claude and Cursor — their blurb read "Web monitoring (Scouts), deep research, and browser automation": old order *and* no computer use. Now "macOS computer use, browser automation, deep research, and web monitoring (Scouts)", with `computer-use` added to keywords.

## Deliberately unchanged

- **`skills/` directory numbering** (`01-scout` … `06-computer-use`) now runs opposite to the rendered lists. Renumbering would churn README links, `.agents` symlink targets, and any external references, so it's left for a separate call.
- **Tool registration order in `server.py`** — `run_computer_use_task` registers at runtime after the static `@mcp.tool` block, so it lands last in a client's tool list regardless of file order. Moving it first means changing when it registers, not just moving code.

## Testing

Docs only — no code changes. `pytest` does not run in this checkout (collection fails on `ModuleNotFoundError: No module named 'yutori.navigator'`, pre-existing and unrelated to this branch). The one test that reads these files, `test_repository_contains_no_node_runtime_surface`, asserts six strings stay absent from `README.md`/`TOOLS.md` and friends; all six were verified absent by hand, and this branch only removes such prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and plugin metadata only; no changes to MCP tool behavior or server registration.
> 
> **Overview**
> Reorganizes **macOS computer use** documentation so it matches how the rest of the repo presents capabilities and tools, without changing runtime code.
> 
> **README** trims Features back to short capability and skill lists (removing the mid-section install tables, SDK pin tables, and harness internals). Computer-use setup moves to a new **`### macOS computer use`** block at the end of Installation (`setup` / `doctor`, optional terminal `smoke` / `run` in a collapsible). Development keeps a short note on `YUTORI_MCP_ALLOW_EDITABLE_SDK` instead of a post-License SDK section.
> 
> **TOOLS.md** groups **`run_computer_use_task`** under `## Computer Use Tools` with the same example → response → parameters pattern as browsing/research; adds sample output, **`Outcome`** values, **`max_steps`** semantics, setup links to the README anchor, and **`run_computer_use_task`** in Tool Annotations. Section order is now Computer Use → Browsing → Research → Scout, with **`list_api_usage`** after Scout.
> 
> **Ordering** is aligned everywhere to **computer use → browsing → research → scouting** (tagline, skill tables, Codex install URLs, `.agents/skills/README.md` table, Claude/Cursor plugin descriptions and keywords).
> 
> **`skills/06-computer-use/SKILL.md`** drops `doctor` from the default setup trio and documents that **`setup`** runs readiness checks inline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef67afe418fe9ad5e6307852451cd58ae11f83b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->