### PR TITLE
fix: remove computer-use max step cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ To run through an MCP client, use the `run_computer_use_task` tool with a task, 
 target app, optional start URL, time limit, and step limit. Only one task can control a Mac
 at a time.
 
+For longer runs, prefer compacting or summarizing older screenshots and tool results so the
+conversation stays within `max_context_len`; do not rely on an artificial 100-step cap.
+
 To expose the MCP tool to a client, run the default server:
 
 ```json

--- a/skills/06-computer-use/SKILL.md
+++ b/skills/06-computer-use/SKILL.md
@@ -69,5 +69,6 @@ uvx yutori-mcp computer-use run "$ARGUMENTS" --app Safari --start-url https://ex
 - Tell the user not to touch the Mac while the task runs.
 - Use `app` for single-app tasks so the runner starts from the intended context.
 - Use `start_url` only with `app`.
-- Keep `minutes` between 1 and 15 and `max_steps` between 1 and 100.
+- Keep `minutes` between 1 and 15 and `max_steps` positive.
+- For longer runs, compact or summarize older screenshots and tool results so the conversation stays within `max_context_len`.
 - Report the final result and any setup blocker from the tool or CLI output.

--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -189,7 +189,7 @@ async def _run_custom(args: argparse.Namespace) -> int:
     from ..credentials import resolve_api_key_for_environment
 
     # Reuses the MCP tool's input schema so the CLI enforces the same bounds
-    # (minutes 1-15, steps 1-100, start_url requires app) with the same
+    # (minutes 1-15, positive steps, start_url requires app) with the same
     # messages; the resulting ValidationError is a ValueError, so dispatch's
     # handler prints it as a message rather than a traceback.
     params = ComputerUseTaskInput(
@@ -227,7 +227,7 @@ def register_parser(
     run_parser.add_argument("--app", default=None, help="Application to target")
     run_parser.add_argument("--start-url", dest="start_url", default=None, help="URL to open in the app")
     run_parser.add_argument("--minutes", type=float, default=3, help="Absolute deadline in minutes (1-15)")
-    run_parser.add_argument("--max-steps", dest="max_steps", type=int, default=60, help="Maximum actions (1-100)")
+    run_parser.add_argument("--max-steps", dest="max_steps", type=int, default=60, help="Maximum actions")
 
 
 def dispatch(command: str, args: argparse.Namespace | None = None) -> int:

--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -399,7 +399,7 @@ class ComputerUseTaskInput(ToolInput):
         default=3, ge=1, le=15, description="Absolute run deadline in minutes (1-15)"
     )
     max_steps: int = Field(
-        default=60, ge=1, le=100, description="Maximum actions (1-100)"
+        default=60, ge=1, description="Maximum actions before stopping the run"
     )
     @model_validator(mode="after")
     def require_app_for_start_url(self) -> ComputerUseTaskInput:

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -59,10 +59,14 @@ def test_schema_rejects_minutes(minutes):
         ComputerUseTaskInput(task="x", minutes=minutes)
 
 
-@pytest.mark.parametrize("max_steps", [0, 101])
-def test_schema_rejects_max_steps(max_steps):
+@pytest.mark.parametrize("max_steps", [0, -1])
+def test_schema_rejects_nonpositive_max_steps(max_steps):
     with pytest.raises(ValidationError):
         ComputerUseTaskInput(task="x", max_steps=max_steps)
+
+
+def test_schema_allows_large_max_steps():
+    assert ComputerUseTaskInput(task="x", max_steps=250).max_steps == 250
 
 
 def test_schema_requires_app_for_url_and_has_no_harness_override():


### PR DESCRIPTION
Removes the artificial 100-step upper bound from local computer-use runs while keeping the positive-step validation. Also updates CLI help and schema tests so values above 100 are accepted.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema and docs-only relaxation of a step limit; desktop automation behavior is unchanged except that callers may request longer action budgets.
> 
> **Overview**
> Removes the **100-action ceiling** on `max_steps` for `run_computer_use_task` and the `computer-use run` CLI. Validation now only requires **`max_steps` ≥ 1** (default stays 60); values like 250 are accepted.
> 
> **README** and the **computer-use skill** add guidance for longer runs: compact or summarize older screenshots and tool results so the agent stays within `max_context_len`, instead of treating the old step cap as the limit.
> 
> CLI help and inline comments are aligned with the schema change. Tests now reject non-positive steps and assert large `max_steps` values pass validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9583b581dfd1afdb3144789c0096ff26ebe01e0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->