### PR TITLE
refactor(server): route computer-use api-key resolution through current_environment()

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -22,6 +22,7 @@ from .adapter import (
     ENVIRONMENT_BASE_URLS,
     MCPClientAdapter,
     YutoriAPIError,
+    current_environment,
     resolve_base_url,
 )
 from .formatters import (
@@ -630,9 +631,7 @@ async def _handle_computer_use(
             return (
                 await run_task(
                     **params.model_dump(),
-                    api_key=resolve_api_key_for_environment(
-                        os.environ.get(ENV_VAR_ENVIRONMENT) or DEFAULT_ENVIRONMENT
-                    ),
+                    api_key=resolve_api_key_for_environment(current_environment()),
                     api_base_url=resolve_base_url(),
                     lock=lock,
                     on_event=_progress_reporter(ctx, params.max_steps) if ctx else None,


### PR DESCRIPTION
## The issue

`server.py::_handle_computer_use` resolved the active environment name for the computer-use API key with a hand-inlined expression:

```python
api_key=resolve_api_key_for_environment(
    os.environ.get(ENV_VAR_ENVIRONMENT) or DEFAULT_ENVIRONMENT
),
```

This is byte-for-byte the same logic as `adapter.current_environment()`:

```python
def current_environment() -> str:
    """The environment name this process is targeting."""
    return os.environ.get(ENV_VAR_ENVIRONMENT) or DEFAULT_ENVIRONMENT
```

Every other call site that needs the active environment already imports and calls `current_environment()` — `MCPClientAdapter.__init__`, `computer_use/cli.py` (`_smoke_live`, `_run_custom`), and `computer_use/preflight.py` (`check_api_key`, `check_api_access`). `_handle_computer_use` was the one holdout re-deriving the same value inline instead of calling the shared helper.

## Why this is worth fixing

A hand-rolled duplicate of a helper's exact expression is exactly the kind of thing that silently drifts: if `current_environment()`'s resolution order is ever extended (e.g. an additional override source), this call site would keep computing the old, now-incorrect value with no test or type error surfacing it, since nothing ties the two expressions together.

## The change

Import `current_environment` from `.adapter` (already the source module for `DEFAULT_ENVIRONMENT`/`ENV_VAR_ENVIRONMENT`, which stay imported for their other uses in this file) and call it in place of the inlined expression. Purely internal — no behavior change, since `current_environment()` computes exactly the expression it replaces.

## Why it's safe

- Behavior-preserving by construction (identical expression, single source of truth now).
- `_handle_computer_use` is exercised by `tests/test_computer_use.py::test_server_holds_desktop_lock_across_preflight_and_runner`, which patches `yutori_mcp.credentials.resolve_api_key_for_environment` and `server.resolve_base_url` — unaffected by this change, since `current_environment()` is a plain top-level import like the other names already imported from `.adapter` in this file.
- Full test suite: 334 passed, 1 skipped (unchanged from baseline).
- `ruff check` clean.
- Single file changed, 2 insertions / 3 deletions.

Co-authored-by: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_016B9w6ujZ6sUtNz5RkURGju)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with identical runtime behavior; only how the active environment name is obtained for API key lookup changes.
> 
> **Overview**
> **`_handle_computer_use`** no longer inlines `os.environ.get(ENV_VAR_ENVIRONMENT) or DEFAULT_ENVIRONMENT` when resolving the API key for computer-use tasks. It now calls **`current_environment()`** from `.adapter`, matching other call sites.
> 
> This is a behavior-preserving deduplication so environment resolution stays a single source of truth if that helper ever gains extra override logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9adf5d2da3ece9b4b049f4c032c8476d57d32445. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->