### PR TITLE
Harden macOS computer-use smoke

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.1"
+version = "0.5.2"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/yutori_mcp/computer_use/app.py
+++ b/src/yutori_mcp/computer_use/app.py
@@ -14,6 +14,7 @@ from yutori.navigator.macos.transport import (
 )
 
 _BUNDLE_ID_PATTERN = re.compile(r"^[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)+$")
+_APP_BUNDLE_IDS = {"finder": "com.apple.finder"}
 _FRONTING_SETTLE_MS = 800
 
 
@@ -73,11 +74,12 @@ async def _running_app(computer: MacOSComputer, requested: str) -> dict[str, Any
 async def prepare_app(computer: MacOSComputer, app: str, start_url: str | None) -> dict[str, Any]:
     """Launch and best-effort front one allowed target application."""
     urls = [start_url] if start_url else None
+    bundle_id = app if _BUNDLE_ID_PATTERN.match(app) else _APP_BUNDLE_IDS.get(app.casefold())
     launch_error: CuaDriverToolError | None = None
     try:
-        if _BUNDLE_ID_PATTERN.match(app):
+        if bundle_id is not None:
             try:
-                payload = await computer.launch_app(bundle_id=app, urls=urls)
+                payload = await computer.launch_app(bundle_id=bundle_id, urls=urls)
             except CuaDriverToolError as error:
                 if not _is_missing_app(error):
                     raise

--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -7,10 +7,12 @@ import subprocess
 import tempfile
 import uuid
 from pathlib import Path
+from typing import Any
 from urllib.request import urlopen
 
 from ..schemas import ComputerUseTaskInput
 from .constants import DRIVER_INSTALLER_SHA256, DRIVER_VERSION
+from .lock import ComputerUseBusyError, DesktopLock
 from .preflight import (
     check_driver_binary,
     check_runtime,
@@ -80,90 +82,85 @@ def _setup() -> int:
     return _doctor()
 
 
-class _ScriptResult:
-    def __init__(self, returncode: int, stdout: str, stderr: str):
-        self.returncode = returncode
-        self.stdout = stdout
-        self.stderr = stderr
+def _structured(result: dict[str, Any]) -> dict[str, Any]:
+    value = result.get("structuredContent") or result.get("structured_content") or {}
+    return value if isinstance(value, dict) else {}
 
 
-async def _osascript(*lines: str) -> _ScriptResult:
-    argv: list[str] = ["osascript"]
-    for line in lines:
-        argv.extend(["-e", line])
-    process = await asyncio.create_subprocess_exec(
-        *argv,
-        stdout=asyncio.subprocess.PIPE,
-        stderr=asyncio.subprocess.PIPE,
-    )
-    stdout, stderr = await process.communicate()
-    return _ScriptResult(
-        process.returncode or 0,
-        stdout.decode(errors="replace"),
-        stderr.decode(errors="replace"),
-    )
+async def _mechanical_calculator_check() -> str:
+    from yutori.navigator.macos import MacOSComputer
+    from yutori.navigator.macos.transport import CuaDriverTransport
+
+    from .app import prepare_app
+
+    driver = find_cua_driver()
+    if driver is None:
+        raise RuntimeError(check_driver_binary().remediation)
+    transport = CuaDriverTransport(binary=driver)
+    sentinel = f"yutori-smoke-{uuid.uuid4().hex[:12]}"
+    async with MacOSComputer(
+        transport=transport,
+        owns_transport=True,
+        presentation=False,
+        show_stop_button=False,
+    ) as computer:
+        await prepare_app(computer, "Calculator", None)
+        await computer._call_tool(
+            "clipboard_write",
+            {"session": computer.session, "text": sentinel},
+        )
+        await computer.keypress("ESC")
+        await computer.type("6*7=")
+        await computer.wait(500)
+        # Exact clipboard equality rejects a stale result; retries avoid racing Calculator's display update.
+        copied = ""
+        for _attempt in range(3):
+            await computer.keypress(["CMD", "C"])
+            await computer.wait(700)
+            result = await computer._call_tool(
+                "clipboard_read",
+                {"session": computer.session, "include_text": True},
+                read_only=True,
+            )
+            copied = str(_structured(result).get("text") or "").strip()
+            if copied == "42":
+                break
+            await computer.wait(500)
+    return copied
 
 
 async def _smoke_live() -> int:
     from ..adapter import current_environment, resolve_base_url
     from ..credentials import resolve_api_key_for_environment
 
-    blocker = first_blocker()
-    if blocker is not None:
-        print(blocker.remediation)
-        return 1
-    # The result is read back through Calculator's own copy-result (cmd+c) and
-    # the clipboard, not the accessibility tree: macOS 26 rewrote Calculator and
-    # "static text 1 of window 1" no longer exists there, so the AX read failed
-    # on a machine whose Accessibility grant was fine. Keystrokes still need the
-    # *terminal's* Accessibility permission, which is what this check verifies.
-    #
-    # Two measured failure modes shape this sequence. The clipboard is seeded
-    # with a unique sentinel and the read must equal exactly "42", because a
-    # previous smoke leaves "42" behind — without the seed, a cmd+c that
-    # silently did nothing still passed. And the copy is retried as its own
-    # polled step, because cmd+c can race the "=" keypress and copy the prior
-    # display value (state restoration reopens Calculator mid-calculation).
-    # Escape first clears that restored state.
-    sentinel = f"yutori-smoke-{uuid.uuid4().hex[:12]}"
-    setup = await _osascript(
-        f'set the clipboard to "{sentinel}"',
-        'tell application "Calculator" to activate',
-        "delay 2",
-        'tell application "System Events" to key code 53',
-        "delay 0.3",
-        'tell application "System Events" to keystroke "6*7="',
-        "delay 1",
-    )
-    copied = ""
-    if setup.returncode == 0:
-        for _attempt in range(3):
-            copy = await _osascript(
-                'tell application "System Events" to keystroke "c" using command down',
-                "delay 0.7",
-                "the clipboard",
+    try:
+        with DesktopLock() as lock:
+            blocker = first_blocker()
+            if blocker is not None:
+                print(blocker.remediation)
+                return 1
+
+            try:
+                copied = await _mechanical_calculator_check()
+            except Exception as error:
+                print(f"Mechanical Calculator check failed through CuaDriver. Detail: {error}")
+                return 1
+            if copied != "42":
+                print("Mechanical Calculator check failed through CuaDriver: clipboard result did not match '42'.")
+                return 1
+            result = await run_task(
+                task="In Calculator, clear the display, compute 9 * 9, and report the result.",
+                app="Calculator",
+                start_url=None,
+                minutes=2,
+                max_steps=10,
+                api_key=resolve_api_key_for_environment(current_environment()),
+                api_base_url=resolve_base_url(),
+                lock=lock,
             )
-            copied = copy.stdout.strip() if copy.returncode == 0 else ""
-            if copied == "42":
-                break
-            await asyncio.sleep(0.5)
-    if copied != "42":
-        detail = setup.stderr.strip() or f"clipboard read {copied!r}"
-        print(
-            "Mechanical Calculator check failed; verify the terminal's Accessibility "
-            "permission (System Settings > Privacy & Security > Accessibility)."
-            + (f" Detail: {detail}" if detail else "")
-        )
+    except ComputerUseBusyError as error:
+        print(error)
         return 1
-    result = await run_task(
-        task="In Calculator, clear the display, compute 9 * 9, and report the result.",
-        app="Calculator",
-        start_url=None,
-        minutes=1,
-        max_steps=10,
-        api_key=resolve_api_key_for_environment(current_environment()),
-        api_base_url=resolve_base_url(),
-    )
     print(format_result(result))
     return 0 if result.get("outcome") == "completed" else 1
 

--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -110,6 +110,7 @@ async def _mechanical_calculator_check() -> str:
             {"session": computer.session, "text": sentinel},
         )
         await computer.keypress("ESC")
+        await computer.wait(300)
         await computer.type("6*7=")
         await computer.wait(500)
         # Exact clipboard equality rejects a stale result; retries avoid racing Calculator's display update.

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -920,6 +920,7 @@ async def test_mechanical_calculator_check_uses_cua_driver(monkeypatch, tmp_path
         "show_stop_button": False,
     }
     prepare.assert_awaited_once_with(computers[0], "Calculator", None)
+    assert ("wait", 300) in computers[0].calls
     assert ("type", "6*7=") in computers[0].calls
     assert computers[0].calls.count(("keypress", ["CMD", "C"])) == 2
 

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -14,7 +14,7 @@ from urllib.error import HTTPError
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from pydantic import ValidationError
@@ -348,6 +348,7 @@ async def test_supervisor_rejects_runner_provenance_drift():
         _stream(json.dumps(_ready_event(sdk_version="0.8.1"))),
         _stream(""),
     )
+
     async def stop(_process):
         process.returncode = -signal.SIGTERM
 
@@ -398,9 +399,7 @@ async def test_supervisor_rejects_malformed_events(event):
 async def test_supervisor_rejects_invalid_utf8_in_an_otherwise_valid_event():
     stream = asyncio.StreamReader()
     stream.feed_data(json.dumps(_ready_event()).encode() + b"\n")
-    stream.feed_data(
-        b'{"type":"result","outcome":"completed","delivery_mode":"foreground","final_text":"\xff"}\n'
-    )
+    stream.feed_data(b'{"type":"result","outcome":"completed","delivery_mode":"foreground","final_text":"\xff"}\n')
     stream.feed_eof()
     process = _Process(stream, _stream(""))
     process.returncode = 0
@@ -655,10 +654,7 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 def test_runtime_constants_select_latest_python_surface():
     assert TOOL_SET == "computer_use_tools-20260815"
     assert SDK_VERSION == "0.9.2"
-    assert all(
-        len(digest) == 64
-        for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256)
-    )
+    assert all(len(digest) == 64 for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256))
     assert '"yutori==0.9.2"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
 
 
@@ -867,6 +863,118 @@ def test_setup_treats_overlay_file_errors_as_warnings(monkeypatch, tmp_path, cap
     assert "WARNING reasoning overlay unavailable" in capsys.readouterr().out
 
 
+async def test_mechanical_calculator_check_uses_cua_driver(monkeypatch, tmp_path):
+    from yutori_mcp.computer_use import app, cli
+
+    driver = tmp_path / "cua-driver"
+    driver.write_text("")
+    transports = []
+    computers = []
+
+    class FakeTransport:
+        def __init__(self, binary):
+            self.binary = binary
+            transports.append(self)
+
+    class FakeComputer:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.session = "smoke-session"
+            self.calls = []
+            self.copied = iter(("41", "42"))
+            computers.append(self)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_args):
+            return None
+
+        async def _call_tool(self, name, arguments, *, read_only=False):
+            self.calls.append((name, arguments, read_only))
+            if name == "clipboard_read":
+                return {"structuredContent": {"text": next(self.copied)}}
+            return {"structuredContent": {}}
+
+        async def keypress(self, keys):
+            self.calls.append(("keypress", keys))
+
+        async def type(self, text):
+            self.calls.append(("type", text))
+
+        async def wait(self, milliseconds):
+            self.calls.append(("wait", milliseconds))
+
+    prepare = AsyncMock()
+    monkeypatch.setattr(cli, "find_cua_driver", lambda: driver)
+    monkeypatch.setattr("yutori.navigator.macos.MacOSComputer", FakeComputer)
+    monkeypatch.setattr("yutori.navigator.macos.transport.CuaDriverTransport", FakeTransport)
+    monkeypatch.setattr(app, "prepare_app", prepare)
+
+    assert await cli._mechanical_calculator_check() == "42"
+    assert transports[0].binary == driver
+    assert computers[0].kwargs == {
+        "transport": transports[0],
+        "owns_transport": True,
+        "presentation": False,
+        "show_stop_button": False,
+    }
+    prepare.assert_awaited_once_with(computers[0], "Calculator", None)
+    assert ("type", "6*7=") in computers[0].calls
+    assert computers[0].calls.count(("keypress", ["CMD", "C"])) == 2
+
+
+async def test_smoke_reserves_desktop_before_mechanical_check(monkeypatch, tmp_path, capsys):
+    from yutori_mcp.computer_use import cli
+
+    lock_path = tmp_path / "desktop.lock"
+    mechanical_check = AsyncMock()
+    preflight = Mock()
+    monkeypatch.setattr(cli, "DesktopLock", lambda: DesktopLock(lock_path))
+    monkeypatch.setattr(cli, "first_blocker", preflight)
+    monkeypatch.setattr(cli, "_mechanical_calculator_check", mechanical_check)
+
+    with DesktopLock(lock_path):
+        assert await cli._smoke_live() == 1
+
+    preflight.assert_not_called()
+    mechanical_check.assert_not_awaited()
+    assert "Another computer-use task controls this Mac" in capsys.readouterr().out
+
+
+async def test_smoke_does_not_print_mismatched_clipboard_contents(monkeypatch, tmp_path, capsys):
+    from yutori_mcp.computer_use import cli
+
+    secret = "clipboard-secret-value"
+    monkeypatch.setattr(cli, "DesktopLock", lambda: DesktopLock(tmp_path / "desktop.lock"))
+    monkeypatch.setattr(cli, "first_blocker", lambda: None)
+    monkeypatch.setattr(cli, "_mechanical_calculator_check", AsyncMock(return_value=secret))
+
+    assert await cli._smoke_live() == 1
+
+    output = capsys.readouterr().out
+    assert "did not match '42'" in output
+    assert secret not in output
+
+
+async def test_smoke_allows_two_minutes_for_live_check(monkeypatch, tmp_path):
+    from yutori_mcp import credentials
+    from yutori_mcp.computer_use import cli
+
+    run = AsyncMock(return_value={"outcome": "completed"})
+    monkeypatch.setattr(cli, "DesktopLock", lambda: DesktopLock(tmp_path / "desktop.lock"))
+    monkeypatch.setattr(cli, "first_blocker", lambda: None)
+    monkeypatch.setattr(cli, "_mechanical_calculator_check", AsyncMock(return_value="42"))
+    monkeypatch.setattr(cli, "run_task", run)
+    monkeypatch.setattr(cli, "format_result", lambda _result: "complete")
+    monkeypatch.setattr(credentials, "resolve_api_key_for_environment", lambda _environment: "dev-key")
+
+    assert await cli._smoke_live() == 0
+
+    assert run.await_args.kwargs["minutes"] == 2
+    assert run.await_args.kwargs["lock"]._depth == 0
+
+
 def test_pick_best_window_excludes_helper_strips():
     strips = [{"window_id": index, "bounds": {"width": 600, "height": 20}, "z_index": 9} for index in range(4)]
     main = {"window_id": 99, "bounds": {"width": 400, "height": 500}, "z_index": 1}
@@ -899,6 +1007,19 @@ async def test_prepare_app_retries_bundle_as_name_and_fronts_best_window():
     computer.wait.assert_awaited_once_with(800)
 
 
+async def test_prepare_app_launches_finder_by_bundle_id():
+    computer = SimpleNamespace(
+        launch_app=AsyncMock(return_value={"pid": 42, "name": "Finder"}),
+        bring_to_front=AsyncMock(),
+        wait=AsyncMock(),
+    )
+
+    target = await prepare_app(computer, "Finder", None)
+
+    assert target == {"name": "Finder", "pid": 42}
+    computer.launch_app.assert_awaited_once_with(bundle_id="com.apple.finder", urls=None)
+
+
 async def test_prepare_app_preserves_explicit_launch_refusal():
     computer = SimpleNamespace(launch_app=AsyncMock(side_effect=CuaDriverToolError("POLICY_DENIED")))
     with pytest.raises(CuaDriverToolError, match="POLICY_DENIED"):
@@ -907,9 +1028,7 @@ async def test_prepare_app_preserves_explicit_launch_refusal():
 
 
 async def test_prepare_app_never_retries_uncertain_launch():
-    computer = SimpleNamespace(
-        launch_app=AsyncMock(side_effect=CuaDriverUncertainActionError("acknowledgement lost"))
-    )
+    computer = SimpleNamespace(launch_app=AsyncMock(side_effect=CuaDriverUncertainActionError("acknowledgement lost")))
     with pytest.raises(CuaDriverUncertainActionError, match="acknowledgement lost"):
         await prepare_app(computer, "com.apple.calculator", None)
     computer.launch_app.assert_awaited_once()
@@ -920,9 +1039,7 @@ async def test_prepare_app_fronts_running_persistent_app_after_launch_failure():
         launch_app=AsyncMock(side_effect=CuaDriverToolError("APP_NOT_INSTALLED")),
         _call_tool=AsyncMock(
             return_value={
-                "structuredContent": {
-                    "apps": [{"pid": 42, "name": "Finder", "bundle_id": "com.apple.finder"}]
-                }
+                "structuredContent": {"apps": [{"pid": 42, "name": "Finder", "bundle_id": "com.apple.finder"}]}
             }
         ),
         bring_to_front=AsyncMock(),


### PR DESCRIPTION
## Summary

- replace the AppleScript smoke probe with an end-to-end CuaDriver Calculator check
- reserve the desktop across preflight, the mechanical probe, and the live N2 task without exposing clipboard contents
- launch Finder through its canonical bundle ID and allow two minutes for the live smoke canary
- bump the package to 0.5.2 while preserving environment-aware API routing

## Verification

- `pytest -q` — 339 passed, 1 skipped
- `ruff check` and `ruff format --check` on touched Python files
- fresh macOS setup with CuaDriver 0.19.3 and SDK 0.9.2
- dedicated-Mac smoke: 9 × 9 = 81, completed in 35.1s with the Swift reasoning overlay active
- MacAgentBench pseudo-verifiers: Reminders exact-title task, Finder size/tag task, and Finder nested zero-byte/tag task all passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS computer-use smoke and desktop locking behavior; failures could mask or block legitimate smoke runs but does not alter auth or API security paths.
> 
> **Overview**
> **Replaces the AppleScript-based mechanical smoke probe** with a CuaDriver/`MacOSComputer` path that launches Calculator, seeds the clipboard, types `6*7=`, and validates copy-to-clipboard equals `42` (with retries), aligning the check with the same driver stack used for real tasks.
> 
> **`computer-use smoke` now holds a `DesktopLock`** for preflight, the mechanical check, and the live N2 canary, passes that lock into `run_task`, extends the live run to **2 minutes** (was 1), and **stops echoing mismatched clipboard text** in failure messages. **`prepare_app`** resolves friendly app names (e.g. **Finder** → `com.apple.finder`) via a small bundle-ID map.
> 
> Package version **0.5.2**; tests cover the new probe, lock ordering, clipboard redaction, and Finder launch behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 523b2438d0bb192e318634c6ae982a9bf3826927. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->