### PR TITLE
Honor --env in protected computer-use CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.2"
+version = "0.5.3"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/yutori_mcp/entrypoint.py
+++ b/src/yutori_mcp/entrypoint.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import sys
 
 from . import __version__
@@ -15,6 +16,10 @@ def _computer_use_main() -> None:
     subparsers = parser.add_subparsers(dest="command", required=True)
     register_parser(subparsers)
     args = parser.parse_args()
+    if args.env:
+        os.environ["YUTORI_ENV"] = args.env
+    else:
+        os.environ.pop("YUTORI_ENV", None)
     raise SystemExit(dispatch(args.computer_use_command, args))
 
 

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -160,6 +160,30 @@ def test_main_clears_ambient_environment_for_computer_use_without_explicit_env(m
     assert observed == {"environment": None}
 
 
+@pytest.mark.parametrize(
+    ("arguments", "ambient", "expected"),
+    [(["--env", "dev"], "prod", "dev"), ([], "dev", None)],
+)
+def test_protected_entrypoint_applies_computer_use_environment(monkeypatch, arguments, ambient, expected):
+    import yutori_mcp.computer_use.cli as computer_use_cli
+    from yutori_mcp import entrypoint
+
+    observed: dict[str, str | None] = {}
+
+    def record_dispatch(_command: str, _args: object) -> int:
+        observed["environment"] = os.environ.get("YUTORI_ENV")
+        return 0
+
+    monkeypatch.setenv("YUTORI_ENV", ambient)
+    monkeypatch.setattr(sys, "argv", ["yutori-mcp", *arguments, "computer-use", "doctor"])
+    monkeypatch.setattr(computer_use_cli, "dispatch", record_dispatch)
+
+    with pytest.raises(SystemExit) as exc_info:
+        entrypoint._computer_use_main()
+    assert exc_info.value.code == 0
+    assert observed == {"environment": expected}
+
+
 def test_lock_rejects_second_owner_and_releases(tmp_path):
     path = tmp_path / "desktop.lock"
     with DesktopLock(path), pytest.raises(ComputerUseBusyError), DesktopLock(path):


### PR DESCRIPTION
## Summary

- forward the protected computer-use entrypoint's explicit `--env` selection through `YUTORI_ENV` before preflight and dispatch
- clear ambient environment state when no explicit flag is supplied, matching the public server path
- bump the hotfix package version to 0.5.3

## Why

A fresh public 0.5.2 install with `--env dev computer-use setup` installed CuaDriver and the overlay correctly, but the final access check silently targeted production and rejected the stored dev credential.

## Verification

- `pytest -q` — 341 passed, 1 skipped
- Ruff lint/format and `git diff --check`
- regression covers both explicit dev selection and ambient-dev clearing

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CLI/env wiring change with targeted tests; no auth or API logic changes beyond correct environment selection before dispatch.
> 
> **Overview**
> Fixes a bug where **`yutori-mcp … computer-use`** could run through the protected **`entrypoint._computer_use_main`** path without updating **`YUTORI_ENV`**, so setup/access checks could target **production** even when **`--env dev`** was passed (e.g. dev credentials rejected after a successful dev setup).
> 
> **`_computer_use_main`** now sets **`YUTORI_ENV`** from **`--env`** before **`dispatch`**, and **clears** ambient **`YUTORI_ENV`** when the flag is omitted—matching the public **`server.main`** computer-use behavior. Package version is bumped to **0.5.3**, with a parametrized regression test on the protected entrypoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e9f977532f19663c7d5185e88c557de8f4b76e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->