### PR TITLE
Complete computer-use readiness diagnostics

### DIFF
--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -72,7 +72,10 @@ def _setup() -> int:
         print(check_driver_binary().remediation)
         return 1
     subprocess.run([str(driver), "permissions", "grant"], check=True)
-    from yutori.navigator.macos import MacOSOverlayPreparationError, prepare_macos_overlay
+    from yutori.navigator.macos import (
+        MacOSOverlayPreparationError,
+        prepare_macos_overlay,
+    )
 
     try:
         prepared = prepare_macos_overlay()
@@ -138,12 +141,12 @@ async def _smoke_live() -> int:
         with DesktopLock() as lock:
             blocker = first_blocker()
             if blocker is not None:
-                print(blocker.remediation)
+                print(f"{blocker.detail} Fix: {blocker.remediation}")
                 return 1
 
             try:
                 copied = await _mechanical_calculator_check()
-            except Exception as error:
+            except (OSError, RuntimeError, TypeError, ValueError) as error:
                 print(f"Mechanical Calculator check failed through CuaDriver. Detail: {error}")
                 return 1
             if copied != "42":

--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -146,6 +146,10 @@ async def _smoke_live() -> int:
 
             try:
                 copied = await _mechanical_calculator_check()
+            # Every driver and computer failure lands here: CuaDriverError and
+            # MacOSComputerError, and so every subclass prepare_app and the transport raise,
+            # derive from RuntimeError. What is left outside this tuple is a bug in this file,
+            # which should surface as a traceback rather than a setup-blocker message.
             except (OSError, RuntimeError, TypeError, ValueError) as error:
                 print(f"Mechanical Calculator check failed through CuaDriver. Detail: {error}")
                 return 1

--- a/src/yutori_mcp/computer_use/preflight.py
+++ b/src/yutori_mcp/computer_use/preflight.py
@@ -17,9 +17,9 @@ from urllib.parse import urlparse
 from urllib.request import Request, url2pathname, urlopen
 
 from .constants import (
-    MODEL,
     DRIVER_VERSION,
     MCP_VERSION,
+    MODEL,
     SDK_ARTIFACT_SHA256,
     SDK_INSTALLATION_SHA256,
     SDK_PROVENANCE_SHA256,
@@ -357,13 +357,30 @@ def check_permissions() -> CheckResult:
     )
 
 
+def _console_lock_state() -> bool | None:
+    """Read the machine's lock state without depending on this process's GUI session."""
+    try:
+        result = subprocess.run(
+            ["/usr/sbin/ioreg", "-n", "Root", "-d", "1"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    match = re.search(r'"IOConsoleLocked"\s*=\s*(Yes|No)', result.stdout)
+    return match.group(1) == "Yes" if match else None
+
+
 def check_gui_session() -> CheckResult:
-    """Ask the machine who owns the console, not this process about itself.
+    """Ask the machine who owns the console and whether that console is unlocked.
 
     The previous probe ran Quartz in-process and read CGSessionCopyCurrentDictionary. Over SSH
     that process has no window session, so it reported "inactive or locked" on a Mac that was
     logged in and driving apps fine — blocking every remote and headless setup. The console
-    owner is a property of the machine and answers the question that actually matters.
+    owner and IORegistry lock state are properties of the machine, so they remain truthful over
+    SSH without asking the caller's process whether it has a GUI session.
     """
     try:
         owner = subprocess.run(
@@ -376,12 +393,26 @@ def check_gui_session() -> CheckResult:
     except (OSError, subprocess.SubprocessError):
         owner = ""
     # root or _windowserver owns the console at the login window, i.e. nobody is logged in.
-    ok = bool(owner) and owner not in {"root", "_windowserver"}
+    logged_in = bool(owner) and owner not in {"root", "_windowserver"}
+    locked = _console_lock_state() if logged_in else None
+    ok = logged_in and locked is False
+    if not logged_in:
+        detail = "no user logged in at the console"
+        remediation = "Log in to the Mac and unlock the desktop."
+    elif locked is True:
+        detail = f"console user {owner}; screen locked"
+        remediation = "Unlock the Mac desktop."
+    elif locked is None:
+        detail = f"console user {owner}; lock state unavailable"
+        remediation = "Verify /usr/sbin/ioreg can report IOConsoleLocked, then retry."
+    else:
+        detail = f"console user {owner}"
+        remediation = ""
     return _result(
         "GUI session",
         ok,
-        f"console user {owner}" if ok else "no user logged in at the console",
-        "Log in to the Mac and unlock the desktop.",
+        detail,
+        remediation,
     )
 
 
@@ -484,6 +515,20 @@ def check_api_access() -> CheckResult:
     except HTTPError as error:
         if error.code in {401, 403}:
             return _result("Yutori API", False, "credential rejected", remediation)
+        try:
+            body = error.read()
+            error_payload = json.loads(body.decode()) if isinstance(body, bytes) else {}
+        except (AttributeError, OSError, ValueError):
+            error_payload = {}
+        api_error = error_payload.get("error") if isinstance(error_payload, dict) else None
+        if isinstance(api_error, dict):
+            message = str(api_error.get("message") or f"probe failed (HTTP {error.code})")
+            if api_error.get("code") == "invalid_model":
+                remediation = (
+                    f"This build requests {MODEL!r}; use an environment where that model is enabled "
+                    "or select a build configured for an available computer-use model."
+                )
+            return _result("Yutori API", False, message, remediation)
         return _result("Yutori API", False, f"probe failed (HTTP {error.code})", remediation)
     except (URLError, OSError, ValueError):
         return _result("Yutori API", False, "unreachable", remediation)

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import importlib.metadata
+import io
 import json
 import os
 import signal
@@ -754,6 +755,30 @@ def test_api_access_rejects_non_auth_http_failures(monkeypatch, status):
     assert result.detail == f"probe failed (HTTP {status})"
 
 
+def test_api_access_reports_invalid_model_instead_of_login(monkeypatch):
+    body = json.dumps(
+        {
+            "error": {
+                "message": "Invalid model. Available models: n1.5-latest",
+                "code": "invalid_model",
+            }
+        }
+    ).encode()
+
+    def fail_probe(*_args: Any, **_kwargs: Any) -> None:
+        raise HTTPError("https://api.yutori.com", 400, "failed", {}, io.BytesIO(body))
+
+    monkeypatch.setattr(
+        "yutori_mcp.credentials.resolve_api_key_for_environment", lambda _: "api-key"
+    )
+    monkeypatch.setattr(preflight, "urlopen", fail_probe)
+    result = preflight.check_api_access()
+    assert not result.ok
+    assert result.detail == "Invalid model. Available models: n1.5-latest"
+    assert "requests 'n2'" in result.remediation
+    assert "login" not in result.remediation
+
+
 def test_runtime_check_verifies_version_installation_and_provenance(monkeypatch, tmp_path):
     payload = b"provenance"
     package_file = Path("yutori/runtime.py")
@@ -822,6 +847,34 @@ def test_overlay_compiler_and_capture_failures_are_warnings(monkeypatch):
     with patch("yutori.navigator.macos.check_macos_overlay", side_effect=RuntimeError("missing")):
         overlay = preflight.check_overlay()
     assert not overlay.ok and not overlay.blocking
+
+
+@pytest.mark.parametrize(
+    "lock_value,ok,detail",
+    [
+        ("No", True, "console user testuser"),
+        ("Yes", False, "console user testuser; screen locked"),
+        (None, False, "console user testuser; lock state unavailable"),
+    ],
+)
+def test_gui_session_checks_machine_lock_state(monkeypatch, lock_value, ok, detail):
+    def run(argv, **_kwargs):
+        if argv[0] == "/usr/bin/stat":
+            return subprocess.CompletedProcess(argv, 0, stdout="testuser\n")
+        return subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout=(
+                f'"IOConsoleLocked" = {lock_value}\n'
+                if lock_value is not None
+                else '"OtherProperty" = Yes\n'
+            ),
+        )
+
+    monkeypatch.setattr(preflight.subprocess, "run", run)
+    result = preflight.check_gui_session()
+    assert result.ok is ok
+    assert result.detail == detail
 
 
 def test_first_blocker_skips_warnings(monkeypatch):
@@ -1090,6 +1143,25 @@ async def test_prepare_app_does_not_retry_uncertain_fronting():
     assert target == {"name": "Calculator", "pid": 42}
     computer.bring_to_front.assert_awaited_once_with(42, None)
     computer.wait.assert_awaited_once_with(800)
+
+
+async def test_smoke_reports_preflight_detail_and_fix(monkeypatch, tmp_path, capsys):
+    from yutori_mcp.computer_use import cli
+
+    blocker = preflight.CheckResult(
+        "Yutori API",
+        False,
+        "Invalid model",
+        "Use a supported model.",
+    )
+    monkeypatch.setattr(cli, "DesktopLock", lambda: DesktopLock(tmp_path / "desktop.lock"))
+    monkeypatch.setattr(cli, "first_blocker", lambda: blocker)
+    mechanical = AsyncMock()
+    monkeypatch.setattr(cli, "_mechanical_calculator_check", mechanical)
+
+    assert await cli._smoke_live() == 1
+    assert capsys.readouterr().out == "Invalid model Fix: Use a supported model.\n"
+    mechanical.assert_not_awaited()
 
 
 def _valid_request(**overrides):


### PR DESCRIPTION
## Motivation

While testing the README flow on a fresh macOS setup, setup and doctor reported every check as passing, but smoke failed because the mechanical Calculator probe ran through terminal-owned AppleScript instead of the CuaDriver app-bundle identity whose permissions doctor had verified. PR #196 moved that probe onto CuaDriver.

Continuing the live test exposed two remaining diagnostic gaps: doctor still passed when the console was logged in but locked, and an authenticated n2 rollout response was reduced to generic login remediation. That made doctor and smoke disagree or sent an already-authenticated user toward the wrong fix.

## What changed

- read IOConsoleLocked from IORegistry so doctor blocks on locked desktops and on an indeterminate lock state
- preserve structured non-auth API errors, with model-specific remediation for invalid_model
- include the failing preflight detail in smoke output instead of printing remediation alone
- keep the configured model as n2; there is no n2-preview fallback

## Verification

- pytest -q — 347 passed, 1 skipped
- Ruff source lint and git diff --check
- live IORegistry probe — an unlocked console user reported ready
- live doctor — all local readiness checks and API-key resolution passed; the currently expected n2 invalid_model rollout blocker was surfaced with model-specific remediation
- live CuaDriver mechanical Calculator check — 6 × 7 produced 42

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to diagnostic messaging and subprocess-based lock probing; no auth, payment, or task-execution logic changes.
> 
> **Overview**
> **Doctor and smoke** now align better with real macOS and API rollout conditions.
> 
> **GUI session** no longer treats “console user logged in” as sufficient: it reads **`IOConsoleLocked`** via `ioreg` and **blocks** when the desktop is locked or lock state cannot be determined, with **specific detail and remediation** for each case (fixes false passes over SSH where the probe process had no GUI session).
> 
> **Yutori API preflight** on HTTP errors **parses the response body** and surfaces the API **`message`** instead of only generic auth/login text; **`invalid_model`** gets remediation that names the build’s configured **`n2`** model.
> 
> **Smoke / run** print **`{detail} Fix: {remediation}`** when a preflight blocker fires. The mechanical Calculator path **catches** `OSError`, `RuntimeError`, `TypeError`, and `ValueError` so driver/computer failures read as setup failures while unexpected bugs still traceback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcb4bf54ca699d62e064609cf7d6da922c751972. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->