### PR TITLE
refactor(computer-use): extract shared blocker-message formatting

### DIFF
--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -14,6 +14,7 @@ from ..schemas import ComputerUseTaskInput
 from .constants import DRIVER_INSTALLER_SHA256, DRIVER_VERSION
 from .lock import ComputerUseBusyError, DesktopLock
 from .preflight import (
+    blocker_message,
     check_driver_binary,
     check_runtime,
     child_search_path,
@@ -141,7 +142,7 @@ async def _smoke_live() -> int:
         with DesktopLock() as lock:
             blocker = first_blocker()
             if blocker is not None:
-                print(f"{blocker.detail} Fix: {blocker.remediation}")
+                print(blocker_message(blocker))
                 return 1
 
             try:
@@ -206,7 +207,7 @@ async def _run_custom(args: argparse.Namespace) -> int:
     )
     blocker = first_blocker()
     if blocker is not None:
-        print(f"{blocker.detail} Fix: {blocker.remediation}")
+        print(blocker_message(blocker))
         return 1
     print("The model takes over this Mac's desktop now; do not touch it during the run.")
     result = await run_task(

--- a/src/yutori_mcp/computer_use/preflight.py
+++ b/src/yutori_mcp/computer_use/preflight.py
@@ -589,3 +589,8 @@ def first_blocker() -> CheckResult | None:
         if not result.ok and result.blocking:
             return result
     return None
+
+
+def blocker_message(blocker: CheckResult) -> str:
+    """Render a blocking check's detail and remediation as the one-line message callers print."""
+    return f"{blocker.detail} Fix: {blocker.remediation}"

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -615,7 +615,7 @@ async def _handle_computer_use(
     from .credentials import resolve_api_key_for_environment
 
     from .computer_use.lock import ComputerUseBusyError, DesktopLock
-    from .computer_use.preflight import first_blocker
+    from .computer_use.preflight import blocker_message, first_blocker
     from .computer_use.result import failure
     from .computer_use.supervisor import run_task
 
@@ -627,7 +627,7 @@ async def _handle_computer_use(
         with lock:
             blocker = first_blocker()
             if blocker is not None:
-                return failure(f"{blocker.detail} Fix: {blocker.remediation}"), {}
+                return failure(blocker_message(blocker)), {}
             return (
                 await run_task(
                     **params.model_dump(),


### PR DESCRIPTION
## Issue

`first_blocker()` returns a `CheckResult`, and three separate call sites built the same
`"<detail> Fix: <remediation>"` line with an independently hand-written f-string:

- `computer_use/cli.py`'s `_smoke_live()`
- `computer_use/cli.py`'s `_run_custom()`
- `server.py`'s `_handle_computer_use()` (the MCP tool handler)

Three copies of the same formatting logic means a future change to the message shape (or a fix
to it) has to be applied in three places by hand, with nothing enforcing that they stay in sync.

## Improvement

Adds `blocker_message(blocker: CheckResult) -> str` next to `first_blocker()` in
`computer_use/preflight.py`, and points all three call sites at it instead of the inline
f-string.

## Safety / behavior

- Pure extraction — the returned string is byte-for-byte identical to before
  (`f"{blocker.detail} Fix: {blocker.remediation}"`), so no output any caller sees changes.
- Covered by the existing `test_smoke_reports_preflight_detail_and_fix` test, which asserts the
  exact printed string; it passes unchanged.
- Full suite: `347 passed, 1 skipped` (same as `main`).
- Touches 3 files, ~10 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GxHpJZtEnUV7YK8KiYPdSx)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure string-formatting extraction with no logic or output changes; only affects preflight error messaging at existing early-exit paths.
> 
> **Overview**
> **Centralizes** how blocking preflight failures are turned into user-facing text by adding `blocker_message()` in `computer_use/preflight.py` next to `first_blocker()`.
> 
> The CLI smoke/run paths and the MCP `run_computer_use_task` handler previously each inlined `f"{blocker.detail} Fix: {blocker.remediation}"`; they now call the shared helper so any future change to that one-line shape happens in one place.
> 
> **Behavior is unchanged** — the helper returns the same string as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e9a5a8da258037401f90df0de4cd4f0ae7c943b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->