### PR TITLE
refactor: dedupe computer-use env apply/clear logic

### DIFF
--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import hashlib
+import os
 import subprocess
 import tempfile
 import uuid
@@ -218,6 +219,21 @@ async def _run_custom(args: argparse.Namespace) -> int:
     )
     print(format_result(result))
     return 0 if result.get("outcome") == "completed" else 1
+
+
+def apply_computer_use_environment(env: str | None) -> None:
+    """Set or clear YUTORI_ENV so resolve_base_url() sees --env exactly as passed.
+
+    Public computer-use commands default to production even if a shell has stale
+    YUTORI_ENV state, so the absence of an explicit --env clears any ambient value
+    rather than leaving it in place.
+    """
+    from ..adapter import ENV_VAR_ENVIRONMENT
+
+    if env:
+        os.environ[ENV_VAR_ENVIRONMENT] = env
+    else:
+        os.environ.pop(ENV_VAR_ENVIRONMENT, None)
 
 
 def register_parser(

--- a/src/yutori_mcp/entrypoint.py
+++ b/src/yutori_mcp/entrypoint.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
 import argparse
-import os
 import sys
 
 from . import __version__
 
 
 def _computer_use_main() -> None:
-    from .computer_use.cli import dispatch, register_parser
+    from .computer_use.cli import apply_computer_use_environment, dispatch, register_parser
 
     parser = argparse.ArgumentParser(prog="yutori-mcp")
     parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
@@ -16,10 +15,7 @@ def _computer_use_main() -> None:
     subparsers = parser.add_subparsers(dest="command", required=True)
     register_parser(subparsers)
     args = parser.parse_args()
-    if args.env:
-        os.environ["YUTORI_ENV"] = args.env
-    else:
-        os.environ.pop("YUTORI_ENV", None)
+    apply_computer_use_environment(args.env)
     raise SystemExit(dispatch(args.computer_use_command, args))
 
 

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -850,10 +850,9 @@ def main() -> None:
     if args.command == "computer-use":
         # Public computer-use commands default to production even if a shell has
         # stale YUTORI_ENV state. Internal testing can still pass --env explicitly.
-        if not args.env:
-            os.environ.pop(ENV_VAR_ENVIRONMENT, None)
-        from .computer_use.cli import dispatch
+        from .computer_use.cli import apply_computer_use_environment, dispatch
 
+        apply_computer_use_environment(args.env)
         raise SystemExit(dispatch(args.computer_use_command, args))
 
     # Dispatched after --env is applied, not before: `login --env <name>` has to know which


### PR DESCRIPTION
## Day-over-day pattern

Two commits landed today (2026-08-26) from @ksk002, hours apart, each independently implementing the same "apply an explicit `--env`, or clear ambient `YUTORI_ENV`" logic before computer-use dispatch:

- `1722d7c` ("fix: apply env before computer-use dispatch") added the logic to `server.py::main()`, using the shared `ENV_VAR_ENVIRONMENT` constant from `adapter.py`.
- `0e9f977` ("Honor environment in protected computer-use CLI") independently added the same logic to `entrypoint.py::_computer_use_main()`, but with a hardcoded `"YUTORI_ENV"` string literal instead of the shared constant.

Both are live, separately-tested code paths — the packaged `yutori-mcp` CLI entry point routes `computer-use` through `entrypoint.py`, while `server.main()`'s own `computer-use` branch is exercised directly in tests (`test_main_applies_explicit_environment_before_computer_use_dispatch`, `test_main_clears_ambient_environment_for_computer_use_without_explicit_env`) — so this wasn't dead code, just two copies of one contract that could silently diverge.

## What this PR does

Purely structural, no behavior change:

- Extracts `apply_computer_use_environment(env: str | None) -> None` into `computer_use/cli.py`, next to `dispatch`/`register_parser`, which both `server.py` and `entrypoint.py` already import from there.
- Updates both `server.py::main()` and `entrypoint.py::_computer_use_main()` to call the shared helper instead of their own inline set/clear logic.
- `entrypoint.py` now goes through the shared `ENV_VAR_ENVIRONMENT` constant instead of a hardcoded `"YUTORI_ENV"` literal, consistent with every other call site.

`ruff check` passes clean, and the full test suite (`pytest tests/`) passes: 347 passed, 1 skipped — including all 3 tests that directly cover this env-apply/clear behavior across both call sites.

cc @ksk002 as the author of both originating commits, for review.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNvFHCHkBM1PjU9n1Y5VHj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural deduplication with existing tests on both call sites; no new env or auth semantics beyond unifying the constant name in the entrypoint path.
> 
> **Overview**
> Consolidates duplicated **computer-use `--env` handling** that had lived separately in `entrypoint.py` and `server.py` into a single **`apply_computer_use_environment()`** in `computer_use/cli.py`.
> 
> Both entry paths now call that helper before `dispatch()`: an explicit `--env` sets `YUTORI_ENV` via the shared **`ENV_VAR_ENVIRONMENT`** constant; omitting `--env` **clears** any ambient value so public computer-use commands still default to production. The protected entrypoint no longer hardcodes `"YUTORI_ENV"`.
> 
> **No intended behavior change**—only one implementation of the contract shared by the packaged CLI and `server.main()`’s computer-use branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42042e7954caa5f981ce0bb3105705f8e212301e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->