### PR TITLE
refactor(computer-use): extract shared action-line formatting

### DIFF
--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -22,7 +22,7 @@ from .preflight import (
     first_blocker,
     run_checks,
 )
-from .result import format_result
+from .result import format_action_line, format_result
 from .supervisor import run_task
 
 
@@ -178,11 +178,7 @@ async def _print_event(event: dict) -> None:
     if event.get("type") == "ready":
         print("runner ready; driving the desktop")
         return
-    line = f"action #{event.get('index')}: {event.get('tool')} -> {event.get('status')}"
-    if event.get("refusal_code"):
-        line += f" ({event['refusal_code']})"
-    if event.get("duration_ms") is not None:
-        line += f" took {event['duration_ms']} ms"
+    line = format_action_line(event)
     if event.get("elapsed_ms") is not None:
         line += f" [at {event['elapsed_ms']} ms]"
     if event.get("command"):

--- a/src/yutori_mcp/computer_use/result.py
+++ b/src/yutori_mcp/computer_use/result.py
@@ -60,6 +60,22 @@ def format_perf(result: dict[str, Any]) -> list[str]:
     return lines
 
 
+def format_action_line(event: dict[str, Any], *, index_default: Any = None) -> str:
+    """The "action #N: tool -> status" prefix shared by the CLI and MCP progress renderers.
+
+    Only the part that is byte-identical between the two callers lives here; each caller
+    appends its own elapsed-time and command formatting, which intentionally differ (a
+    multi-line indented command preview for a terminal vs. a single-line MCP log message).
+    """
+    index = event.get("index", index_default)
+    line = f"action #{index}: {event.get('tool')} -> {event.get('status')}"
+    if event.get("refusal_code"):
+        line += f" ({event['refusal_code']})"
+    if event.get("duration_ms") is not None:
+        line += f" took {event['duration_ms']} ms"
+    return line
+
+
 def format_result(result: dict[str, Any]) -> str:
     lines = [
         f"Outcome: {result.get('outcome', 'failed')}",

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -586,6 +586,7 @@ def _progress_reporter(
     not an upper bound for it — a fabricated total would render a bar that
     overshoots. The human-readable message carries the step budget instead.
     """
+    from .computer_use.result import format_action_line
 
     async def on_event(event: dict[str, Any]) -> None:
         if event.get("type") == "ready":
@@ -594,11 +595,7 @@ def _progress_reporter(
             await ctx.info(message)
             return
         index = event.get("index", 0)
-        message = f"action #{index}: {event.get('tool')} -> {event.get('status')}"
-        if event.get("refusal_code"):
-            message += f" ({event['refusal_code']})"
-        if event.get("duration_ms") is not None:
-            message += f" took {event['duration_ms']} ms"
+        message = format_action_line(event, index_default=0)
         if event.get("elapsed_ms") is not None:
             message += f" [{event['elapsed_ms']} ms]"
         if event.get("command"):


### PR DESCRIPTION
## Issue

`computer_use/cli.py`'s `_print_event` and `server.py`'s `_progress_reporter` each hand-built the same `"action #N: tool -> status"` line — including identical conditional suffixes for `refusal_code` and `duration_ms` — independently. Both are recent additions from the computer-use feature work (#187–#198) and had not previously been audited for duplication (`preflight.blocker_message()` was the one extraction #200 found in that surface; this is a second, adjacent instance the same pattern applies to).

## Improvement

Extracted the byte-identical prefix into `computer_use/result.py::format_action_line()`, which already houses the other computer-use output formatters (`format_result`, `format_perf`, `failure`). Each caller still appends its own `elapsed_ms`/`command` suffix formatting as-is — those genuinely differ (a multi-line indented command preview for a terminal print vs. a single-line MCP progress/log message) and are left untouched.

## Safety

- Pure extraction, no behavior change: verified with a manual side-by-side render of sample events before/after — output is byte-identical for both call sites.
- No public MCP tool schema touched (this only affects human-readable progress/log text, not `structuredContent`).
- 3 files changed, ~20/-11 lines.
- `ruff check` clean; full suite `pytest -q`: **347 passed, 1 skipped**, matching the pre-change baseline exactly (no new or missing tests).


---
_Generated by [Claude Code](https://claude.ai/code/session_01KCbaVfB4N7TLXDPHYmhgio)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with intended byte-identical user-facing strings; no API schema or runner logic changes.
> 
> **Overview**
> Pulls the duplicated **action #N: tool → status** progress text out of the computer-use CLI and MCP server into **`format_action_line`** in `computer_use/result.py`, alongside the other output helpers.
> 
> **`_print_event`** (CLI) and **`_progress_reporter`** (MCP) now call that helper for the shared prefix, including optional **`refusal_code`** and **`duration_ms`** suffixes. Each path still adds its own **`elapsed_ms`** and **`command`** formatting (terminal multi-line vs single-line MCP log). The server passes **`index_default=0`** so missing **`index`** behaves like before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa3a37f5b1bb39f83d4959d0d4576de2b29b5ae6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->