### PR TITLE
Allow one-hour computer-use runs

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -54,7 +54,7 @@ Actions:
 | `task` | Yes | Natural language instruction for the desktop agent |
 | `app` | No | Application to target; omit for cross-app tasks |
 | `start_url` | No | URL to open before the task starts; requires `app` |
-| `minutes` | No | Wall-clock deadline in minutes (1-15). Default: 3 |
+| `minutes` | No | Wall-clock deadline in minutes (1-60). Default: 3 |
 | `max_steps` | No | Max desktop actions, 1 or more. Default: 60 |
 
 `max_steps` has no upper bound. On long runs, compact or summarize older screenshots and tool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.4"
+version = "0.5.5"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"

--- a/skills/06-computer-use/SKILL.md
+++ b/skills/06-computer-use/SKILL.md
@@ -71,6 +71,6 @@ uvx yutori-mcp computer-use run "$ARGUMENTS" --app Safari --start-url https://ex
 - Tell the user not to touch the Mac while the task runs.
 - Use `app` for single-app tasks so the runner starts from the intended context.
 - Use `start_url` only with `app`.
-- Keep `minutes` between 1 and 15 and `max_steps` positive.
+- Keep `minutes` between 1 and 60 and `max_steps` positive.
 - For longer runs, compact or summarize older screenshots and tool results so the conversation stays within `max_context_len`.
 - Report the final result and any setup blocker from the tool or CLI output.

--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 from urllib.request import urlopen
 
-from ..schemas import ComputerUseTaskInput
+from ..schemas import COMPUTER_USE_MAX_MINUTES, ComputerUseTaskInput
 from .constants import DRIVER_INSTALLER_SHA256, DRIVER_VERSION
 from .lock import ComputerUseBusyError, DesktopLock
 from .preflight import (
@@ -191,7 +191,7 @@ async def _run_custom(args: argparse.Namespace) -> int:
     from ..credentials import resolve_api_key_for_environment
 
     # Reuses the MCP tool's input schema so the CLI enforces the same bounds
-    # (minutes 1-15, positive steps, start_url requires app) with the same
+    # (minutes 1-60, positive steps, start_url requires app) with the same
     # messages; the resulting ValidationError is a ValueError, so dispatch's
     # handler prints it as a message rather than a traceback.
     params = ComputerUseTaskInput(
@@ -228,7 +228,12 @@ def register_parser(
     run_parser.add_argument("task", help="Task for the model to perform")
     run_parser.add_argument("--app", default=None, help="Application to target")
     run_parser.add_argument("--start-url", dest="start_url", default=None, help="URL to open in the app")
-    run_parser.add_argument("--minutes", type=float, default=3, help="Absolute deadline in minutes (1-15)")
+    run_parser.add_argument(
+        "--minutes",
+        type=float,
+        default=3,
+        help=f"Absolute deadline in minutes (1-{COMPUTER_USE_MAX_MINUTES})",
+    )
     run_parser.add_argument("--max-steps", dest="max_steps", type=int, default=60, help="Maximum actions")
 
 

--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -389,6 +389,9 @@ class BrowsingTaskInput(ToolInput):
     )
     webhook_format: WebhookFormat = _webhook_format_field()
 
+COMPUTER_USE_MAX_MINUTES = 60
+
+
 class ComputerUseTaskInput(ToolInput):
     task: str = Field(..., description="Task to perform on the visible Mac desktop")
     app: str | None = Field(default=None, description="Optional application to target")
@@ -396,7 +399,10 @@ class ComputerUseTaskInput(ToolInput):
         default=None, description="Optional URL to open in the target app"
     )
     minutes: float = Field(
-        default=3, ge=1, le=15, description="Absolute run deadline in minutes (1-15)"
+        default=3,
+        ge=1,
+        le=COMPUTER_USE_MAX_MINUTES,
+        description=f"Absolute run deadline in minutes (1-{COMPUTER_USE_MAX_MINUTES})",
     )
     max_steps: int = Field(
         default=60, ge=1, description="Maximum actions before stopping the run"

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -54,10 +54,14 @@ from yutori_mcp.computer_use.supervisor import (
 from yutori_mcp.schemas import ComputerUseTaskInput
 
 
-@pytest.mark.parametrize("minutes", [0.9, 15.1])
+@pytest.mark.parametrize("minutes", [0.9, 60.1])
 def test_schema_rejects_minutes(minutes):
     with pytest.raises(ValidationError):
         ComputerUseTaskInput(task="x", minutes=minutes)
+
+
+def test_schema_allows_one_hour_deadline():
+    assert ComputerUseTaskInput(task="x", minutes=60).minutes == 60
 
 
 @pytest.mark.parametrize("max_steps", [0, -1])


### PR DESCRIPTION
## Summary

- raise the computer-use wall-clock limit from 15 to 60 minutes
- keep the default at 3 minutes and centralize the upper bound across schema and CLI help
- update public tool/skill guidance and cover both the inclusive 60-minute boundary and rejection above it

## Verification

- `348 passed, 1 skipped`
- Ruff clean
- wheel build succeeds (`yutori_mcp-0.5.5-py3-none-any.whl`)
- `git diff --check` clean
- independent final review clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Validation and documentation only; default deadline unchanged, though callers may now hold the desktop lock for up to an hour.
> 
> **Overview**
> Raises the **computer-use** `minutes` ceiling from **15 to 60** while keeping the default at **3 minutes**.
> 
> The upper bound is centralized as `COMPUTER_USE_MAX_MINUTES` in `schemas.py`, so MCP validation, CLI `--minutes` help, and docs (`TOOLS.md`, computer-use skill) stay aligned. Package version bumps to **0.5.5**. Tests now reject values above 60 and accept exactly 60.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2e2f54ca17c5e372a20e3416f2c62b064c0bdc5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->