### PR TITLE
Default computer-use runs to fifteen minutes

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -54,7 +54,7 @@ Actions:
 | `task` | Yes | Natural language instruction for the desktop agent |
 | `app` | No | Application to target; omit for cross-app tasks |
 | `start_url` | No | URL to open before the task starts; requires `app` |
-| `minutes` | No | Wall-clock deadline in minutes (1-60). Default: 3 |
+| `minutes` | No | Wall-clock deadline in minutes (1-60). Default: 15 |
 | `max_steps` | No | Max desktop actions, 1 or more. Default: 60 |
 
 `max_steps` has no upper bound. On long runs, compact or summarize older screenshots and tool

--- a/skills/06-computer-use/SKILL.md
+++ b/skills/06-computer-use/SKILL.md
@@ -37,7 +37,7 @@ Prefer the MCP tool when it is available:
 ```json
 {
   "task": "$ARGUMENTS",
-  "minutes": 3,
+  "minutes": 15,
   "max_steps": 60
 }
 ```
@@ -57,7 +57,7 @@ Use optional fields when helpful:
 If the MCP tool is unavailable, ask the user to run the CLI task runner:
 
 ```bash
-uvx yutori-mcp computer-use run "$ARGUMENTS" --minutes 3 --max-steps 60
+uvx yutori-mcp computer-use run "$ARGUMENTS" --minutes 15 --max-steps 60
 ```
 
 For an app-specific task:

--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -10,7 +10,11 @@ from pathlib import Path
 from typing import Any
 from urllib.request import urlopen
 
-from ..schemas import COMPUTER_USE_MAX_MINUTES, ComputerUseTaskInput
+from ..schemas import (
+    COMPUTER_USE_DEFAULT_MINUTES,
+    COMPUTER_USE_MAX_MINUTES,
+    ComputerUseTaskInput,
+)
 from .constants import DRIVER_INSTALLER_SHA256, DRIVER_VERSION
 from .lock import ComputerUseBusyError, DesktopLock
 from .preflight import (
@@ -231,7 +235,7 @@ def register_parser(
     run_parser.add_argument(
         "--minutes",
         type=float,
-        default=3,
+        default=COMPUTER_USE_DEFAULT_MINUTES,
         help=f"Absolute deadline in minutes (1-{COMPUTER_USE_MAX_MINUTES})",
     )
     run_parser.add_argument("--max-steps", dest="max_steps", type=int, default=60, help="Maximum actions")

--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -389,6 +389,7 @@ class BrowsingTaskInput(ToolInput):
     )
     webhook_format: WebhookFormat = _webhook_format_field()
 
+COMPUTER_USE_DEFAULT_MINUTES = 15
 COMPUTER_USE_MAX_MINUTES = 60
 
 
@@ -399,7 +400,7 @@ class ComputerUseTaskInput(ToolInput):
         default=None, description="Optional URL to open in the target app"
     )
     minutes: float = Field(
-        default=3,
+        default=COMPUTER_USE_DEFAULT_MINUTES,
         ge=1,
         le=COMPUTER_USE_MAX_MINUTES,
         description=f"Absolute run deadline in minutes (1-{COMPUTER_USE_MAX_MINUTES})",

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -33,6 +33,7 @@ from .formatters import (
 )
 from .schema_utils import output_fields_to_output_schema
 from .schemas import (
+    COMPUTER_USE_DEFAULT_MINUTES,
     DEFAULT_LIST_LIMIT,
     BrowserChoice,
     BrowsingTaskInput,
@@ -403,7 +404,7 @@ async def run_computer_use_task(
     task: str,
     app: str | None = None,
     start_url: str | None = None,
-    minutes: float = 3,
+    minutes: float = COMPUTER_USE_DEFAULT_MINUTES,
     max_steps: int = 60,
     ctx: Context | None = None,
 ) -> str:

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -51,7 +51,7 @@ from yutori_mcp.computer_use.supervisor import (
     python_runner_command,
     run_task,
 )
-from yutori_mcp.schemas import ComputerUseTaskInput
+from yutori_mcp.schemas import COMPUTER_USE_DEFAULT_MINUTES, ComputerUseTaskInput
 
 
 @pytest.mark.parametrize("minutes", [0.9, 60.1])
@@ -62,6 +62,11 @@ def test_schema_rejects_minutes(minutes):
 
 def test_schema_allows_one_hour_deadline():
     assert ComputerUseTaskInput(task="x", minutes=60).minutes == 60
+
+
+def test_schema_defaults_to_fifteen_minutes():
+    assert COMPUTER_USE_DEFAULT_MINUTES == 15
+    assert ComputerUseTaskInput(task="x").minutes == 15
 
 
 @pytest.mark.parametrize("max_steps", [0, -1])


### PR DESCRIPTION
## Summary

- make 15 minutes the default wall-clock budget for MCP and CLI computer-use runs
- retain the explicit 60-minute ceiling introduced in #205
- centralize the default across the schema, MCP signature, and CLI, and update the bundled guidance

## Verification

- `349 passed, 1 skipped`
- Ruff clean
- direct runtime inspection: schema, MCP signature, and CLI default all report 15; max remains 60
- 0.5.5 wheel build succeeds
- independent final review clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and default-timeout tuning only; bounds and validation logic are unchanged, with slightly longer unattended desktop runs when `minutes` is omitted.
> 
> **Overview**
> Raises the **default** `minutes` wall-clock deadline for computer-use from **3 to 15** when callers omit the parameter. The **1–60 minute validation ceiling is unchanged**.
> 
> A new shared constant `COMPUTER_USE_DEFAULT_MINUTES` in `schemas.py` wires the default through **`ComputerUseTaskInput`**, the MCP `run_computer_use_task` signature, and the CLI `computer-use run --minutes` flag so those surfaces stay aligned. **TOOLS.md** and the computer-use **SKILL** examples are updated to match.
> 
> A test asserts the schema default is 15.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b95e3d1756bb34b6b7adef8796b8ebcb9d7120d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->