### PR TITLE
Default computer-use runs to thirty minutes

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -54,7 +54,7 @@ Actions:
 | `task` | Yes | Natural language instruction for the desktop agent |
 | `app` | No | Application to target; omit for cross-app tasks |
 | `start_url` | No | URL to open before the task starts; requires `app` |
-| `minutes` | No | Wall-clock deadline in minutes (1-60). Default: 15 |
+| `minutes` | No | Wall-clock deadline in minutes (1-60). Default: 30 |
 | `max_steps` | No | Max desktop actions, 1 or more. Default: 60 |
 
 `max_steps` has no upper bound. On long runs, compact or summarize older screenshots and tool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.5"
+version = "0.5.6"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"

--- a/skills/06-computer-use/SKILL.md
+++ b/skills/06-computer-use/SKILL.md
@@ -37,7 +37,7 @@ Prefer the MCP tool when it is available:
 ```json
 {
   "task": "$ARGUMENTS",
-  "minutes": 15,
+  "minutes": 30,
   "max_steps": 60
 }
 ```
@@ -57,7 +57,7 @@ Use optional fields when helpful:
 If the MCP tool is unavailable, ask the user to run the CLI task runner:
 
 ```bash
-uvx yutori-mcp computer-use run "$ARGUMENTS" --minutes 15 --max-steps 60
+uvx yutori-mcp computer-use run "$ARGUMENTS" --minutes 30 --max-steps 60
 ```
 
 For an app-specific task:

--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -389,7 +389,7 @@ class BrowsingTaskInput(ToolInput):
     )
     webhook_format: WebhookFormat = _webhook_format_field()
 
-COMPUTER_USE_DEFAULT_MINUTES = 15
+COMPUTER_USE_DEFAULT_MINUTES = 30
 COMPUTER_USE_MAX_MINUTES = 60
 
 

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -64,9 +64,9 @@ def test_schema_allows_one_hour_deadline():
     assert ComputerUseTaskInput(task="x", minutes=60).minutes == 60
 
 
-def test_schema_defaults_to_fifteen_minutes():
-    assert COMPUTER_USE_DEFAULT_MINUTES == 15
-    assert ComputerUseTaskInput(task="x").minutes == 15
+def test_schema_defaults_to_thirty_minutes():
+    assert COMPUTER_USE_DEFAULT_MINUTES == 30
+    assert ComputerUseTaskInput(task="x").minutes == 30
 
 
 @pytest.mark.parametrize("max_steps", [0, -1])


### PR DESCRIPTION
## Summary
- raise the default computer-use wall-clock deadline from 15 to 30 minutes
- keep the explicit deadline range and 60-minute ceiling unchanged
- update the public tool docs, bundled skill examples, regression test, and package version to 0.5.6

## Why
A representative MacAgentBench Reminders trajectory completed naturally in 13m57s, leaving too little margin under a 15-minute default. Thirty minutes provides practical headroom without making the one-hour ceiling implicit.

## Verification
- `351 passed, 1 skipped`
- `ruff check src tests`
- built `yutori_mcp-0.5.6-py3-none-any.whl`
- independent review confirmed the 30-minute default propagates through Pydantic, CLI parsing, the MCP function signature, and MCP-advertised schema; 60 remains accepted and 60.1 rejected
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Default-only configuration change with no validation or ceiling changes; longer unattended desktop runs when users do not set `minutes`.
> 
> **Overview**
> Raises the default **computer-use** wall-clock deadline from **15 to 30 minutes** when callers omit `minutes`, so longer Mac desktop trajectories can finish without hitting the limit prematurely.
> 
> The change is centralized in `COMPUTER_USE_DEFAULT_MINUTES` in `schemas.py`, which feeds the Pydantic `ComputerUseTaskInput` default, the MCP tool signature, and CLI parsing. The allowed range (1–60) and maximum ceiling stay the same.
> 
> **TOOLS.md**, the bundled `06-computer-use` skill examples, and the regression test are updated to match. Package version bumps to **0.5.6**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a773304a94d0c52247f992a0c3e354580dc63b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->