### PR TITLE
refactor(computer-use): extract redacted-error-text helper in runner.py

### DIFF
--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -304,6 +304,15 @@ def _strip_final_markers(text: str | None) -> str | None:
     return stripped or None
 
 
+def _redacted_error_text(error: BaseException, secret: str) -> str:
+    """Render an exception as protocol-safe text with the API key scrubbed out.
+
+    Falls back to the exception's type name when str(error) is empty (e.g. a bare
+    `RuntimeError()`), so the caller always reports something readable.
+    """
+    return str(error).replace(secret, "[REDACTED]") or type(error).__name__
+
+
 async def _collect_run(agent: Any, messages: Any) -> list[dict[str, Any]]:
     items: list[dict[str, Any]] = []
     async for response in agent.run(messages):
@@ -502,7 +511,7 @@ async def run_request(
         outcome, final_text = _cancelled_outcome("target_crash")
     except Exception as error:  # noqa: BLE001 - the protocol carries a redacted failure
         outcome = "failed"
-        final_text = str(error).replace(api_key, "[REDACTED]") or type(error).__name__
+        final_text = _redacted_error_text(error, api_key)
     finally:
         status = computer.presentation_status
         try:
@@ -510,7 +519,7 @@ async def run_request(
         except Exception as error:  # noqa: BLE001 - preserve the primary outcome
             if outcome == "completed":
                 outcome = "failed"
-                final_text = str(error).replace(api_key, "[REDACTED]") or type(error).__name__
+                final_text = _redacted_error_text(error, api_key)
 
     reporter.flush_interrupted()
     elapsed_ms = max(0, round((time.monotonic() - run_start) * 1000))
@@ -609,7 +618,7 @@ def main() -> int:
     try:
         outcome = asyncio.run(_run_until_terminated(request, emitter, api_key))
     except Exception as error:  # noqa: BLE001 - last-resort protocol boundary
-        message = str(error).replace(api_key, "[REDACTED]") or type(error).__name__
+        message = _redacted_error_text(error, api_key)
         emitter.emit(
             {
                 "type": "result",

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -1232,6 +1232,15 @@ def test_classify_result_maps_outputs_to_statuses(output, raw_status, status):
     assert runner_module._status_for(raw_status) == status
 
 
+def test_redacted_error_text_scrubs_the_secret():
+    error = RuntimeError("driver rejected key yt-secret-123")
+    assert runner_module._redacted_error_text(error, "yt-secret-123") == "driver rejected key [REDACTED]"
+
+
+def test_redacted_error_text_falls_back_to_type_name_when_message_is_empty():
+    assert runner_module._redacted_error_text(RuntimeError(), "yt-secret-123") == "RuntimeError"
+
+
 class _CollectStream:
     def __init__(self):
         self.lines: list[str] = []


### PR DESCRIPTION
## What

`src/yutori_mcp/computer_use/runner.py` built the same protocol-safe error message by hand in three separate places: `run_request()`'s primary exception handler, `run_request()`'s `aclose()`-failure handler, and `main()`'s last-resort catch-all. All three independently wrote the identical expression:

```python
str(error).replace(api_key, "[REDACTED]") or type(error).__name__
```

— scrub the API key out of the exception text, and fall back to the exception's type name when that renders empty (e.g. a bare `RuntimeError()`).

Extracted this into a single helper, `_redacted_error_text(error, secret) -> str`, with a docstring explaining the fallback, and pointed all three call sites at it.

## Why this is safe

- **No behavior change.** Same expression, same inputs, same output at every call site — this is a pure Extract Function refactor.
- **Reduces real drift risk.** This logic scrubs a secret (the API key) out of user/log-facing text. Three independent copies is exactly the shape where one gets updated (e.g. to redact an additional secret, or fix an edge case) and the other two are missed — a security-relevant inconsistency, not just a style nit.
- **Small, contained diff.** One production file, one test file, 21 insertions / 3 deletions.
- **New direct test coverage** for the extracted helper (secret scrubbed; empty-message fallback to type name) — these two behaviors weren't previously exercised by any test, since none of the three call sites' exception paths (an unexpected error mid-run, a failing `aclose()`, or `main()`'s catch-all) had existing tests.

## Verification

- `pytest -q`: **353 passed, 1 skipped** (up from the pre-change baseline of 351 passed / 1 skipped — exactly the 2 new tests added, no regressions).
- Manual review of the diff: all three call sites now delegate identically to the shared helper; no other file references the old inline expression.
- No public tool contract, CLI surface, or MCP-visible behavior touched — this is entirely inside a private helper module.

---
Part of the recurring automated structural-refactor sweep for this repo (see `.claude/REFACTOR.md` in `yutori-ai/yutori`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PG4Uq5Mt8DCEeBQKaubKAF)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure extract-function refactor with identical logic; centralizing API-key scrubbing slightly reduces drift risk in security-sensitive error reporting.
> 
> **Overview**
> Centralizes how the computer-use runner turns exceptions into protocol-safe `final_text` by adding **`_redacted_error_text(error, secret)`**, which scrubs the API key and falls back to the exception type name when the message is empty.
> 
> **`run_request()`** (primary failure and **`aclose()`** failure paths) and **`main()`**’s last-resort handler now call this helper instead of repeating the same inline expression.
> 
> Adds two unit tests that cover secret scrubbing and the empty-message fallback—behaviors that were not directly tested before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9dea457e4d62062fdf51856f596dd1c1213ffe1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->