### PR TITLE
refactor(computer-use): route check_daemon_identity through _run_safely

### DIFF
--- a/src/yutori_mcp/computer_use/preflight.py
+++ b/src/yutori_mcp/computer_use/preflight.py
@@ -330,17 +330,10 @@ def check_driver_contract() -> CheckResult:
 
 
 def check_daemon_identity() -> CheckResult:
-    try:
-        result = subprocess.run(
-            ["pgrep", "-f", "/Applications/CuaDriver.app/Contents/MacOS/"],
-            capture_output=True,
-            check=False,
-        )
-    except OSError:
-        result = subprocess.CompletedProcess([], 1)
+    result = _run_safely(["pgrep", "-f", "/Applications/CuaDriver.app/Contents/MacOS/"], timeout=10)
     return _result(
         "daemon identity",
-        result.returncode == 0,
+        result is not None and result.returncode == 0,
         "app-bundle daemon",
         "Start it with: open -n -g -a CuaDriver --args serve",
     )


### PR DESCRIPTION
## Issue

`preflight.py#_run_safely()` was extracted in #209 to consolidate the repeated "run a subprocess, treat a launch failure or timeout as 'this probe is unavailable'" pattern used by `check_compiler`, `driver_version`, `_console_lock_state`, and `check_capture`. `check_daemon_identity` had the exact same shape (`subprocess.run` wrapped in `try/except OSError`, falling back to a synthetic failed result) but was missed by that extraction, so the pattern still existed in two independently-maintained places.

## Change

Point `check_daemon_identity` at `_run_safely` instead of hand-rolling its own try/except:

```python
def check_daemon_identity() -> CheckResult:
    result = _run_safely(["pgrep", "-f", "/Applications/CuaDriver.app/Contents/MacOS/"], timeout=10)
    return _result(
        "daemon identity",
        result is not None and result.returncode == 0,
        "app-bundle daemon",
        "Start it with: open -n -g -a CuaDriver --args serve",
    )
```

`timeout=10` matches the other quick local-command checks (`check_compiler`, `driver_version`) that already use `_run_safely`.

## Why this is safe

- Behavior-preserving: the only inputs this check reads from the subprocess result are `returncode` (and nothing from `stdout`/`stderr`), so switching the default `text=True` and adding `subprocess.SubprocessError` to the caught exceptions (on top of the existing `OSError`) has no observable effect for this call site — `pgrep` never hits a timeout in practice.
- No call sites outside this function; `_result` is only ever passed a bool for the `ok` field, so `result is not None and result.returncode == 0` reduces to the same fallback-to-not-ok behavior as the old synthetic `CompletedProcess([], 1)`.
- Pure extraction, 1 file, ~10 lines changed.
- Full suite: 353 passed, 1 skipped (fresh venv install, matches the baseline documented after #198 landed).
- `ruff check` passes on the modified file. `ruff format` reports pre-existing drift across the whole file (no `[tool.ruff]` config in `pyproject.toml`; CI does not run ruff — only `pytest` per `.github/workflows/test.yml`), unrelated to this change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01GEicazXQN1XrRTyMmyTdFA)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-function refactor in preflight probing with behavior-preserving error handling; no auth, data, or API surface changes.
> 
> **Overview**
> **`check_daemon_identity`** now uses the shared **`_run_safely`** helper instead of its own `subprocess.run` + `try/except OSError` block and synthetic failed `CompletedProcess`.
> 
> The success condition becomes **`result is not None and result.returncode == 0`**, so launch failures, timeouts, and **`SubprocessError`** (also handled by `_run_safely`) still count as “daemon not running,” matching the old fallback. A **10s timeout** aligns this probe with other quick local checks like **`check_compiler`** and **`driver_version`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80870204574dbe889974da8bb952007ebed8954f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->