### PR TITLE
refactor(computer-use): extend resolve_run_credentials() to preflight checks

### DIFF
--- a/src/yutori_mcp/computer_use/preflight.py
+++ b/src/yutori_mcp/computer_use/preflight.py
@@ -441,11 +441,10 @@ def check_capture() -> CheckResult:
 
 
 def check_api_key() -> CheckResult:
-    from ..adapter import current_environment
-    from ..credentials import resolve_api_key_for_environment
+    from ..adapter import current_environment, resolve_run_credentials
 
     environment = current_environment()
-    key = resolve_api_key_for_environment(environment)
+    key, _ = resolve_run_credentials(environment)
     return _result(
         "API key",
         bool(key),
@@ -462,15 +461,14 @@ def check_api_access() -> CheckResult:
     {"error": {"type": "billing_error"}} — a key with no prepaid balance looked healthy here while
     every task failed at zero steps with an empty stderr. Status codes alone cannot see that.
     """
-    from ..adapter import current_environment, resolve_base_url
-    from ..credentials import resolve_api_key_for_environment
+    from ..adapter import current_environment, resolve_run_credentials
 
     environment = current_environment()
     remediation = _api_access_remediation(environment)
     try:
-        key = resolve_api_key_for_environment(environment)
+        key, base_url = resolve_run_credentials(environment)
         request = Request(
-            f"{resolve_base_url(environment).rstrip('/')}/chat/completions",
+            f"{base_url.rstrip('/')}/chat/completions",
             data=json.dumps(
                 {
                     "model": MODEL,

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -744,8 +744,8 @@ def test_api_access_probes_the_runtime_toolset(monkeypatch):
             return b'{"choices":[{}]}'
 
     monkeypatch.setattr(
-        "yutori_mcp.credentials.resolve_api_key_for_environment",
-        lambda _environment: "api-key",
+        "yutori_mcp.adapter.resolve_run_credentials",
+        lambda _environment: ("api-key", "https://api.yutori.com/v1"),
     )
     monkeypatch.setattr(preflight, "urlopen", lambda request, timeout: requests.append(request) or Response())
 
@@ -759,7 +759,9 @@ def test_api_access_rejects_non_auth_http_failures(monkeypatch, status):
     def fail_probe(*_args: Any, **_kwargs: Any) -> None:
         raise HTTPError("https://api.yutori.com", status, "failed", {}, None)
 
-    monkeypatch.setattr("yutori_mcp.credentials.resolve_api_key_for_environment", lambda _: "api-key")
+    monkeypatch.setattr(
+        "yutori_mcp.adapter.resolve_run_credentials", lambda _: ("api-key", "https://api.yutori.com/v1")
+    )
     monkeypatch.setattr(preflight, "urlopen", fail_probe)
     result = preflight.check_api_access()
     assert not result.ok
@@ -780,7 +782,7 @@ def test_api_access_reports_invalid_model_instead_of_login(monkeypatch):
         raise HTTPError("https://api.yutori.com", 400, "failed", {}, io.BytesIO(body))
 
     monkeypatch.setattr(
-        "yutori_mcp.credentials.resolve_api_key_for_environment", lambda _: "api-key"
+        "yutori_mcp.adapter.resolve_run_credentials", lambda _: ("api-key", "https://api.yutori.com/v1")
     )
     monkeypatch.setattr(preflight, "urlopen", fail_probe)
     result = preflight.check_api_access()

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -170,7 +170,10 @@ def test_the_missing_key_remediation_points_at_default_login(monkeypatch):
     from yutori_mcp.computer_use import preflight
 
     monkeypatch.delenv("YUTORI_ENV", raising=False)
-    with patch("yutori_mcp.credentials.resolve_api_key_for_environment", return_value=None):
+    with patch(
+        "yutori_mcp.adapter.resolve_run_credentials",
+        return_value=(None, "https://api.yutori.com/v1"),
+    ):
         result = preflight.check_api_key()
     assert not result.ok
     assert result.remediation == "Run: uvx yutori-mcp login"


### PR DESCRIPTION
## What

`preflight.check_api_key()` and `preflight.check_api_access()` each independently resolved a run's credentials via `current_environment()` + `resolve_api_key_for_environment()` (and, for `check_api_access`, also `resolve_base_url()`) — the same two-call pairing that PR #204 already consolidated into `adapter.resolve_run_credentials(environment) -> tuple[str | None, str]` for `server.py::_handle_computer_use` and `cli.py`'s `_smoke_live`/`_run_custom`. These two preflight checks were the remaining call sites still doing it by hand.

Both now delegate to `resolve_run_credentials()`, matching the rest of the computer-use surface.

## Why safe

- No behavior change: `resolve_run_credentials(environment)` resolves the same key and base URL, from the same environment, at the same point in each function's control flow. `check_api_key` only needed the key, so it discards the unused `base_url` half of the pair (a pure dict lookup, no I/O).
- Scoped to 1 source file (2 functions) + 2 test files.

## How verified

- `uv run pytest -q`: 353 passed / 1 skipped — identical to the pre-change baseline.
- Updated the 4 existing tests that patched the two former halves (`yutori_mcp.credentials.resolve_api_key_for_environment`) to instead patch the single consolidated entry point (`yutori_mcp.adapter.resolve_run_credentials`), the same test-update shape PR #204 used for its own call sites.
- `ruff check` clean on changed files. (`ruff format` would reformat unrelated pre-existing lines in these files to an 88-column width; this repo has no `[tool.ruff]` config and CI doesn't run a format check, so left untouched — consistent with prior PRs in this repo.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01NFVzfJMGTP7ArKuKEhLPcw)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor only: preflight still resolves the same key and base URL for the active environment via the existing adapter helper.
> 
> **Overview**
> **Preflight API checks** now resolve credentials through `adapter.resolve_run_credentials(environment)` instead of calling `resolve_api_key_for_environment` and (for access probes) `resolve_base_url` separately.
> 
> `check_api_key()` only uses the key from the returned pair; `check_api_access()` uses both key and base URL for the `chat/completions` probe URL. This aligns the last hand-rolled credential paths with server/CLI computer-use entry points from PR #204.
> 
> Tests that stubbed `credentials.resolve_api_key_for_environment` now patch `adapter.resolve_run_credentials` and return `(key, base_url)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a412080a8160caddb53cc23bd26366a2e6f172f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->