### PR TITLE
refactor(computer-use): extract _blocked() for the preflight-check-and-print pattern in cli.py

### DIFF
--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -91,6 +91,15 @@ def _setup() -> int:
     return _doctor()
 
 
+def _blocked() -> bool:
+    """Print and return True if a blocking preflight check fails; False if ready to run."""
+    blocker = first_blocker()
+    if blocker is None:
+        return False
+    print(blocker_message(blocker))
+    return True
+
+
 def _structured(result: dict[str, Any]) -> dict[str, Any]:
     value = result.get("structuredContent") or result.get("structured_content") or {}
     return value if isinstance(value, dict) else {}
@@ -144,9 +153,7 @@ async def _smoke_live() -> int:
 
     try:
         with DesktopLock() as lock:
-            blocker = first_blocker()
-            if blocker is not None:
-                print(blocker_message(blocker))
+            if _blocked():
                 return 1
 
             try:
@@ -205,9 +212,7 @@ async def _run_custom(args: argparse.Namespace) -> int:
         minutes=args.minutes,
         max_steps=args.max_steps,
     )
-    blocker = first_blocker()
-    if blocker is not None:
-        print(blocker_message(blocker))
+    if _blocked():
         return 1
     print("The model takes over this Mac's desktop now; do not touch it during the run.")
     api_key, api_base_url = resolve_run_credentials()


### PR DESCRIPTION
`_smoke_live()` and `_run_custom()` in `src/yutori_mcp/computer_use/cli.py` each independently called `first_blocker()`, printed `blocker_message(blocker)` when it returned a check, and returned `1` — the identical four-line block duplicated in both places.

Extracted `_blocked() -> bool`, which does the check-and-print and reports whether the caller should bail; both call sites now read `if _blocked(): return 1`.

No behavior change: same `first_blocker()`/`blocker_message()` calls, same printed output, same early return. Tests patch `cli.first_blocker` directly (a module-global lookup resolved at call time), so monkeypatching continues to work through the new indirection unchanged.

**Verified:**
- Full suite: 353 passed / 1 skipped (matches baseline exactly)
- `ruff check` clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01U6K5sPkyK9AV1aizuduVCt)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor in the computer-use CLI with no logic or I/O changes beyond consolidating duplicate code.
> 
> **Overview**
> Deduplicates the shared preflight gate in **`_smoke_live()`** and **`_run_custom()`** by introducing **`_blocked()`**, which runs **`first_blocker()`**, prints **`blocker_message()`** when a blocker exists, and returns whether the caller should exit early.
> 
> Both paths now use **`if _blocked(): return 1`** instead of repeating the same four-line check. **No intended behavior change**—same messages, same exit codes; tests that patch **`cli.first_blocker`** still hit the helper unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 29335212d4d51cb16f8548f447446c146216dbb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->