### PR TITLE
refactor(computer-use): extract structured_content() for the _call_tool payload-shape pattern

### DIFF
--- a/src/yutori_mcp/computer_use/app.py
+++ b/src/yutori_mcp/computer_use/app.py
@@ -18,6 +18,17 @@ _APP_BUNDLE_IDS = {"finder": "com.apple.finder"}
 _FRONTING_SETTLE_MS = 800
 
 
+def structured_content(result: dict[str, Any]) -> dict[str, Any]:
+    """The structured payload of a ``_call_tool`` result, tolerating either key casing.
+
+    The driver protocol has used both ``structuredContent`` (MCP-style) and
+    ``structured_content`` across releases; every caller wants "whichever one is present,
+    or an empty dict" rather than caring which.
+    """
+    value = result.get("structuredContent") or result.get("structured_content") or {}
+    return value if isinstance(value, dict) else {}
+
+
 def _windows(payload: dict[str, Any]) -> list[dict[str, Any]]:
     windows: list[dict[str, Any]] = []
     for window in payload.get("windows") or []:
@@ -67,8 +78,7 @@ async def _running_app(computer: MacOSComputer, requested: str) -> dict[str, Any
     # The pinned SDK has no public list_apps convenience method. Its generic hook
     # retains deadline/Stop cancellation while keeping the transport SDK-owned.
     result = await computer._call_tool("list_apps", {}, read_only=True)
-    payload = result.get("structuredContent") or result.get("structured_content") or {}
-    return _find_running_app(payload if isinstance(payload, dict) else {}, requested)
+    return _find_running_app(structured_content(result), requested)
 
 
 async def prepare_app(computer: MacOSComputer, app: str, start_url: str | None) -> dict[str, Any]:

--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -8,7 +8,6 @@ import subprocess
 import tempfile
 import uuid
 from pathlib import Path
-from typing import Any
 from urllib.request import urlopen
 
 from ..schemas import (
@@ -100,16 +99,11 @@ def _blocked() -> bool:
     return True
 
 
-def _structured(result: dict[str, Any]) -> dict[str, Any]:
-    value = result.get("structuredContent") or result.get("structured_content") or {}
-    return value if isinstance(value, dict) else {}
-
-
 async def _mechanical_calculator_check() -> str:
     from yutori.navigator.macos import MacOSComputer
     from yutori.navigator.macos.transport import CuaDriverTransport
 
-    from .app import prepare_app
+    from .app import prepare_app, structured_content
 
     driver = find_cua_driver()
     if driver is None:
@@ -141,7 +135,7 @@ async def _mechanical_calculator_check() -> str:
                 {"session": computer.session, "include_text": True},
                 read_only=True,
             )
-            copied = str(_structured(result).get("text") or "").strip()
+            copied = str(structured_content(result).get("text") or "").strip()
             if copied == "42":
                 break
             await computer.wait(500)


### PR DESCRIPTION
## Structural issue

`computer_use/app.py::_running_app()` and `computer_use/cli.py`'s private `_structured()` each independently reimplemented the exact same pattern for pulling the structured payload out of a `_call_tool(...)` result:

```python
value = result.get("structuredContent") or result.get("structured_content") or {}
return value if isinstance(value, dict) else {}
```

(cli.py's version was a one-line-shorter but behaviorally identical inline expression.) Both key spellings exist because the driver protocol has used `structuredContent` (MCP-style) and `structured_content` across releases, and both call sites need "whichever is present, or empty dict."

## Why this is an improvement

Two independent copies of a key-casing/type-guard rule are one drift risk away from silently diverging (e.g. if a future driver release adds a third key spelling, only one copy would get updated). This is the same "extract shared helper for X pattern" shape as several recently-merged PRs in this repo (#208, #209, #210, #211, #213).

## What changed

- Added `structured_content(result: dict[str, Any]) -> dict[str, Any]` to `app.py` (already the module both call sites import from/are adjacent to).
- `app.py::_running_app()` now calls it instead of the inline expression.
- `cli.py::_mechanical_calculator_check()` now imports and calls it instead of the file's private `_structured()`, which is removed. Also dropped the now-unused `from typing import Any` import in `cli.py`.

## Why this is safe

- Pure extraction — the returned value and fallback behavior are byte-identical to both prior implementations (same key precedence, same `isinstance` guard, same `{}` fallback).
- No public MCP tool surface, CLI flag, or schema touched.
- Full test suite passes unchanged: `353 passed, 1 skipped` (fresh venv, matching the baseline before this change) — including `tests/test_computer_use.py::test_mechanical_calculator_check_uses_cua_driver` and the `prepare_app`/`_running_app` tests that exercise both former code paths through their `structuredContent` result shapes.
- Only 2 files touched, ~15 line diff.


---
_Generated by [Claude Code](https://claude.ai/code/session_011dFa44gP2jb5dznYuZPxHf)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with identical key precedence and type guards; no API or schema changes.
> 
> **Overview**
> Consolidates duplicated logic for reading structured payloads from **`_call_tool`** results into a single **`structured_content()`** helper in **`app.py`**, which accepts either **`structuredContent`** or **`structured_content`** and returns a dict (or **`{}`**).
> 
> **`_running_app()`** and the CLI mechanical Calculator smoke check now call that helper instead of inline expressions; **`cli.py`** drops its private **`_structured()`** and the unused **`typing.Any`** import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca64b2b5e1dcb7fa6e7f6da431a5beb3908b7756. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->