### PR TITLE
refactor(entrypoint): guard hardcoded --env choices against adapter drift

### DIFF
--- a/src/yutori_mcp/entrypoint.py
+++ b/src/yutori_mcp/entrypoint.py
@@ -5,13 +5,20 @@ import sys
 
 from . import __version__
 
+# Duplicates the key set of adapter.ENVIRONMENT_BASE_URLS rather than importing it: this module
+# (and computer_use.cli, which it dispatches to) must stay importable without pulling in the
+# yutori SDK, and adapter.py needs the SDK's DEFAULT_BASE_URL to build that dict.
+# tests/test_computer_use.py::test_entrypoint_env_choices_match_adapter_environments guards the
+# two from drifting apart.
+_ENV_CHOICES = ("prod", "dev")
+
 
 def _computer_use_main() -> None:
     from .computer_use.cli import apply_computer_use_environment, dispatch, register_parser
 
     parser = argparse.ArgumentParser(prog="yutori-mcp")
     parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
-    parser.add_argument("--env", choices=("prod", "dev"))
+    parser.add_argument("--env", choices=_ENV_CHOICES)
     subparsers = parser.add_subparsers(dest="command", required=True)
     register_parser(subparsers)
     args = parser.parse_args()

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -198,6 +198,16 @@ def test_protected_entrypoint_applies_computer_use_environment(monkeypatch, argu
     assert observed == {"environment": expected}
 
 
+def test_entrypoint_env_choices_match_adapter_environments():
+    """entrypoint._ENV_CHOICES is a hardcoded duplicate of adapter.ENVIRONMENT_BASE_URLS's keys
+    (see the comment on _ENV_CHOICES for why it can't just import that dict). This pins the two
+    together so a new environment added to one is caught if it is not added to the other."""
+    from yutori_mcp import entrypoint
+    from yutori_mcp.adapter import ENVIRONMENT_BASE_URLS
+
+    assert set(entrypoint._ENV_CHOICES) == set(ENVIRONMENT_BASE_URLS)
+
+
 def test_lock_rejects_second_owner_and_releases(tmp_path):
     path = tmp_path / "desktop.lock"
     with DesktopLock(path), pytest.raises(ComputerUseBusyError), DesktopLock(path):


### PR DESCRIPTION
## What

`src/yutori_mcp/entrypoint.py` hardcoded the computer-use CLI's `--env` choices as an inline `("prod", "dev")` literal, duplicating the key set of `adapter.ENVIRONMENT_BASE_URLS` — the actual source of truth for valid environment names, used identically by `server.py`'s own `--env` parser (`choices=tuple(ENVIRONMENT_BASE_URLS)`).

## Why this is an improvement

Unlike every other cross-module invariant in this codebase (task-tool tables, scout-edit fields, tool descriptions, limit defaults — all guarded by an explicit drift-guard test per the established idiom), this one had no guard: adding a third environment to `ENVIRONMENT_BASE_URLS` would silently leave the `computer-use` CLI's argparse rejecting that environment name.

The duplication itself is intentional and can't be collapsed into a single import: `entrypoint.py`/`computer_use/cli.py` must stay importable without pulling in the `yutori` SDK (enforced by `test_computer_use_cli_imports_without_executing_the_sdk`), while `adapter.py` needs the SDK's `DEFAULT_BASE_URL` to build `ENVIRONMENT_BASE_URLS`. So instead of collapsing it, this extracts the tuple to a documented `_ENV_CHOICES` constant and adds a test pinning it to `adapter.ENVIRONMENT_BASE_URLS`, mirroring this repo's existing drift-guard pattern.

## Why this is safe — no behavioral change

Identical argparse `choices=` value at runtime, just named and guarded.

## Verification

- `ruff check` clean on both touched files.
- `pytest tests/test_computer_use.py`: 87 passed / 1 skipped / 8 failed, vs. 86 passed / 1 skipped / 8 failed on `main` — the 8 failures are pre-existing and identical before/after (confirmed via `git stash`), caused by this sandbox not having the package `pip install -e`'d (`PackageNotFoundError: No package metadata was found for yutori-mcp`), unrelated to this change. The one new test (`test_entrypoint_env_choices_match_adapter_environments`) passes.


---
_Generated by [Claude Code](https://claude.ai/code/session_012f9gsVSajRRPs1q17Dxze1)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor plus a drift-guard test only; no change to argparse behavior or environment resolution logic.
> 
> **Overview**
> The computer-use CLI path in `entrypoint.py` still cannot import `adapter.ENVIRONMENT_BASE_URLS` (entrypoint and `computer_use.cli` must load without the Yutori SDK), so this PR **names** the duplicated `--env` values as `_ENV_CHOICES` and documents why the duplication stays.
> 
> It adds **`test_entrypoint_env_choices_match_adapter_environments`**, which asserts `_ENV_CHOICES` matches the keys of `ENVIRONMENT_BASE_URLS`, so a new environment in the adapter is not silently rejected by the protected `computer-use` entrypoint. **Runtime behavior is unchanged** (`prod` / `dev` only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f1eb19017a4aa4cddfae94eb9aa12c032294247. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->