### PR TITLE
refactor(computer-use): centralize the "foreground" delivery_mode literal

### DIFF
--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -8,6 +8,11 @@ PROTOCOL_VERSION = 1
 MCP_VERSION = __version__
 MODEL = "n2"
 TOOL_SET = "computer_use_tools-20260815"
+# The only delivery mode this runtime implements today. Repeated verbatim across every
+# `action`/`result` protocol event (runner.py, supervisor.py's timeout/cancellation
+# fallbacks, and result.py's failure() shape); centralized so a future second mode can't
+# be introduced with one of those spots left on the old literal by accident.
+DELIVERY_MODE_FOREGROUND = "foreground"
 SDK_VERSION = "0.9.2"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.

--- a/src/yutori_mcp/computer_use/result.py
+++ b/src/yutori_mcp/computer_use/result.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from .constants import DELIVERY_MODE_FOREGROUND
+
 
 def _seconds(ms: Any) -> str:
     return f"{ms / 1000:.1f}s" if isinstance(ms, (int, float)) else "?"
@@ -108,7 +110,7 @@ def format_result(result: dict[str, Any]) -> str:
 def failure(message: str, *, actions: list[dict[str, Any]] | None = None) -> dict[str, Any]:
     return {
         "outcome": "failed",
-        "delivery_mode": "foreground",
+        "delivery_mode": DELIVERY_MODE_FOREGROUND,
         "final_text": message,
         "actions": actions or [],
     }

--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -26,6 +26,7 @@ from yutori.navigator.macos import (
 
 from .app import prepare_app
 from .constants import (
+    DELIVERY_MODE_FOREGROUND,
     DRIVER_VERSION,
     PROTOCOL_VERSION,
     SDK_ARTIFACT_SHA256,
@@ -245,7 +246,7 @@ class ActionReporter:
                 "tool": str(item.get("name") or "unknown").lower(),
                 "status": _status_for(raw_status),
                 "raw_status": raw_status,
-                "delivery_mode": "foreground",
+                "delivery_mode": DELIVERY_MODE_FOREGROUND,
                 "route": "pixel",
                 "refusal_code": "driver_refused" if raw_status == "refused" else None,
                 "elapsed_ms": max(0, round((self._clock() - self._run_start) * 1000)),
@@ -448,7 +449,7 @@ async def run_request(
             {
                 "type": "result",
                 "outcome": "limit",
-                "delivery_mode": "foreground",
+                "delivery_mode": DELIVERY_MODE_FOREGROUND,
                 "final_text": "The deadline expired before the run started.",
                 "elapsed_ms": 0,
                 "steps": 0,
@@ -533,7 +534,7 @@ async def run_request(
         {
             "type": "result",
             "outcome": outcome,
-            "delivery_mode": "foreground",
+            "delivery_mode": DELIVERY_MODE_FOREGROUND,
             "final_text": final_text,
             "elapsed_ms": elapsed_ms,
             "steps": guard.steps,
@@ -629,7 +630,7 @@ def main() -> int:
             {
                 "type": "result",
                 "outcome": "failed",
-                "delivery_mode": "foreground",
+                "delivery_mode": DELIVERY_MODE_FOREGROUND,
                 "final_text": message,
                 "steps": 0,
             }

--- a/src/yutori_mcp/computer_use/supervisor.py
+++ b/src/yutori_mcp/computer_use/supervisor.py
@@ -11,6 +11,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any
 
 from .constants import (
+    DELIVERY_MODE_FOREGROUND,
     DRIVER_VERSION,
     MCP_VERSION,
     MODEL,
@@ -235,7 +236,7 @@ async def _supervise(
         await _stop_process_group(process)
         return {
             "outcome": "limit",
-            "delivery_mode": "foreground",
+            "delivery_mode": DELIVERY_MODE_FOREGROUND,
             "final_text": "The absolute deadline expired.",
             "actions": actions,
         }
@@ -243,7 +244,7 @@ async def _supervise(
         await _stop_process_group(process)
         return {
             "outcome": "aborted",
-            "delivery_mode": "foreground",
+            "delivery_mode": DELIVERY_MODE_FOREGROUND,
             "final_text": "Computer-use task was cancelled; the runner process group was terminated.",
             "actions": actions,
         }


### PR DESCRIPTION
## What

The computer-use protocol's `delivery_mode` field was the literal string `"foreground"`, hand-typed at 7 call sites spread across three files:

- `runner.py` — 4 sites (the `action` event emitted per tool call, the early-deadline `result` event, the terminal `result` event, and the top-level exception-boundary `result` event)
- `supervisor.py` — 2 sites (the timeout and cancellation fallback results)
- `result.py` — 1 site (`failure()`'s synthesized result shape)

Nothing enforced that these stayed in sync besides careful copy-pasting; a future edit to one site (e.g. adding a mode) could easily miss another.

## Why this is safe

Pure constant extraction — introduces `DELIVERY_MODE_FOREGROUND = "foreground"` in `computer_use/constants.py` (alongside the other protocol-identity constants like `SDK_VERSION`/`DRIVER_VERSION` already centralized there) and points every call site at it. The emitted JSON value is byte-identical before and after; this is internal to the computer-use protocol implementation and does not touch any MCP tool name, parameter schema, or response shape.

Verified:
- Full test suite: `354 passed, 1 skipped` (unchanged from before the change)
- Direct import/smoke check confirming `result.failure(...)` still emits `"delivery_mode": "foreground"`
- `ruff check` on the touched files shows no newly introduced issues (the two pre-existing findings on `runner.py`/`supervisor.py` are present identically on `main`, unrelated to this diff)

Touches 4 files, ~16 lines.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hou93UHhgcJEgFkHyDFs46)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Constant extraction only; wire protocol values and event shapes are byte-identical with no behavior change.
> 
> **Overview**
> Introduces **`DELIVERY_MODE_FOREGROUND`** in `computer_use/constants.py` (with a short comment that this runtime only supports foreground today) and replaces seven inline `"foreground"` strings on protocol **`action`** and **`result`** payloads.
> 
> **`runner.py`** uses the constant for per-tool action events and every terminal result path (pre-run deadline, normal completion, and top-level exception boundary). **`supervisor.py`** uses it for timeout and cancellation synthesized results. **`result.failure()`** uses it for failed outcomes.
> 
> Emitted JSON is unchanged (`"foreground"`); this is a maintainability pass so future delivery modes cannot be added at one call site while others still hard-code the old literal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22541d597dc584b570f92fede8cdd419e2d4dbaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->