### PR TITLE
refactor(computer-use): extract shared redact() helper for secret scrubbing

### DIFF
--- a/src/yutori_mcp/computer_use/result.py
+++ b/src/yutori_mcp/computer_use/result.py
@@ -4,6 +4,17 @@ from typing import Any
 
 from .constants import DELIVERY_MODE_FOREGROUND
 
+REDACTED = "[REDACTED]"
+
+
+def redact(text: str, secret: str) -> str:
+    """Scrub ``secret`` out of ``text`` before it can reach the protocol stream or logs.
+
+    Shared by the runner (exception text) and the supervisor (stderr diagnostics and
+    protocol stdout lines) so the child's API key never survives past this one point.
+    """
+    return text.replace(secret, REDACTED)
+
 
 def _seconds(ms: Any) -> str:
     return f"{ms / 1000:.1f}s" if isinstance(ms, (int, float)) else "?"

--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -34,6 +34,7 @@ from .constants import (
     SDK_VERSION,
     TOOL_SET,
 )
+from .result import redact
 
 SYSTEM_CONTEXT = (
     "You control the entire macOS screen. This is macOS, not Linux: do not use "
@@ -317,7 +318,7 @@ def _redacted_error_text(error: BaseException, secret: str) -> str:
     Falls back to the exception's type name when str(error) is empty (e.g. a bare
     `RuntimeError()`), so the caller always reports something readable.
     """
-    return str(error).replace(secret, "[REDACTED]") or type(error).__name__
+    return redact(str(error), secret) or type(error).__name__
 
 
 async def _collect_run(agent: Any, messages: Any) -> list[dict[str, Any]]:

--- a/src/yutori_mcp/computer_use/supervisor.py
+++ b/src/yutori_mcp/computer_use/supervisor.py
@@ -22,7 +22,7 @@ from .constants import (
 )
 from .lock import ComputerUseBusyError, DesktopLock
 from .preflight import child_search_path, find_cua_driver
-from .result import failure
+from .result import failure, redact
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +90,7 @@ async def _stop_process_group(process: asyncio.subprocess.Process) -> None:
 async def _drain_stderr(stream: asyncio.StreamReader, secret: str) -> list[str]:
     diagnostics: list[str] = []
     while line := await stream.readline():
-        diagnostics.append(line.decode(errors="replace").replace(secret, "[REDACTED]").rstrip())
+        diagnostics.append(redact(line.decode(errors="replace"), secret).rstrip())
     return diagnostics[-20:]
 
 
@@ -185,7 +185,7 @@ async def _supervise(
             if not line:
                 break
             try:
-                event = json.loads(line.decode().replace(api_key, "[REDACTED]"))
+                event = json.loads(redact(line.decode(), api_key))
             except (json.JSONDecodeError, UnicodeDecodeError):
                 return failure("Computer-use runner emitted invalid JSON.", actions=actions)
             if not isinstance(event, dict):

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -35,7 +35,7 @@ from yutori_mcp.computer_use.constants import (
     TOOL_SET,
 )
 from yutori_mcp.computer_use.lock import ComputerUseBusyError, DesktopLock
-from yutori_mcp.computer_use.result import format_result
+from yutori_mcp.computer_use.result import format_result, redact
 from yutori_mcp.computer_use.runner import (
     ActionReporter,
     Emitter,
@@ -1251,6 +1251,14 @@ def test_redacted_error_text_scrubs_the_secret():
 
 def test_redacted_error_text_falls_back_to_type_name_when_message_is_empty():
     assert runner_module._redacted_error_text(RuntimeError(), "yt-secret-123") == "RuntimeError"
+
+
+def test_redact_scrubs_every_occurrence_of_the_secret():
+    assert redact("key=yt-secret then yt-secret again", "yt-secret") == "key=[REDACTED] then [REDACTED] again"
+
+
+def test_redact_is_a_noop_when_the_secret_is_absent():
+    assert redact("nothing sensitive here", "yt-secret") == "nothing sensitive here"
 
 
 class _CollectStream:


### PR DESCRIPTION
## Summary

- `_redacted_error_text()` in `runner.py` and both call sites in `_drain_stderr()`/`_supervise()` in `supervisor.py` each independently duplicated the same `text.replace(secret, "[REDACTED]")` mechanism.
- Extracts a single `redact()` helper into `result.py` — already the shared home for cross-module protocol formatting (e.g. `format_action_line()`) — and routes all three call sites through it.
- No behavior change: identical scrubbing semantics, still applied before the API key can reach the protocol stream or logs.

## Validation

- `uv run pytest -q`: 356 passed, 1 skipped
- `uv run ruff check`: all checks passed
- Added direct unit tests for `redact()` alongside the existing `_redacted_error_text` tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_014CS2jDaRuGYUHqo4Sh11cV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only with tests; secret scrubbing semantics are preserved at the same call sites.
> 
> **Overview**
> Centralizes API-key scrubbing in a shared **`redact()`** helper (and **`REDACTED`** constant) in `result.py`, replacing duplicated `text.replace(secret, "[REDACTED]")` logic.
> 
> The **runner** routes exception text through `redact` via `_redacted_error_text`; the **supervisor** uses it when draining child stderr and before parsing protocol stdout JSON. Behavior is unchanged: secrets are still stripped before logs or the protocol stream.
> 
> Adds direct unit tests for `redact()` (multiple occurrences and absent secret).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 771e1e9bfe0f168177589a991efec5b66329758b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->