### PR TITLE
refactor(computer-use): fix missed foreground literal in format_result

### DIFF
--- a/src/yutori_mcp/computer_use/result.py
+++ b/src/yutori_mcp/computer_use/result.py
@@ -92,7 +92,7 @@ def format_action_line(event: dict[str, Any], *, index_default: Any = None) -> s
 def format_result(result: dict[str, Any]) -> str:
     lines = [
         f"Outcome: {result.get('outcome', 'failed')}",
-        f"Delivery mode: {result.get('delivery_mode', 'foreground')}",
+        f"Delivery mode: {result.get('delivery_mode', DELIVERY_MODE_FOREGROUND)}",
     ]
     if result.get("final_text"):
         lines.append(f"Final text: {result['final_text']}")


### PR DESCRIPTION
## What

PR #216 (merged earlier today) centralized the repeated `"foreground"` `delivery_mode` protocol literal into `DELIVERY_MODE_FOREGROUND` in `constants.py` and pointed every call site at it — including `result.py::failure()`, one function below the one this PR fixes. It missed `result.py::format_result()`'s own default value:

```python
f"Delivery mode: {result.get('delivery_mode', 'foreground')}",
```

This PR points that default at the same `DELIVERY_MODE_FOREGROUND` constant `failure()` already uses in the same file, closing the one remaining spot where the string could drift from the constant if it's ever changed.

## Why it's safe

- Pure constant substitution — `DELIVERY_MODE_FOREGROUND == "foreground"` today, so rendered output is byte-identical.
- Confirmed via `grep -rn foreground src/ tests/` that this was the only production-code call site left on the raw literal after #216; the remaining hits are docs (`README.md`/`TOOLS.md`) and test fixtures constructing protocol payload dicts (correctly literal, since they're simulating wire data, not asserting against the constant).
- Verified: `pytest -q` → 356 passed, 1 skipped (matches the current `main` baseline exactly). `ruff check .` clean.
- 1 file, 1 line changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017FHypGoG3o1CzdpnNYH6Gc


---
_Generated by [Claude Code](https://claude.ai/code/session_017FHypGoG3o1CzdpnNYH6Gc)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line constant substitution in display formatting with no security or protocol behavior change.
> 
> **Overview**
> Completes the **#216** constant migration by replacing the last in-file raw `'foreground'` default in `format_result()` with `DELIVERY_MODE_FOREGROUND`, matching `failure()` in the same module.
> 
> **Behavior is unchanged** today because the constant still equals `"foreground"`; the change only prevents the formatted delivery-mode line from drifting if the protocol default is updated in one place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9cf09eb68cb2bfe158903fafc01d671efd8c92c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->