### PR TITLE
refactor(credentials): extract shared environments-map guard

### DIFF
--- a/src/yutori_mcp/credentials.py
+++ b/src/yutori_mcp/credentials.py
@@ -41,12 +41,15 @@ def _load_config() -> dict[str, Any]:
     return data if isinstance(data, dict) else {}
 
 
+def _environments(config: dict[str, Any]) -> dict[str, Any]:
+    """The ``environments`` map from ``config``, or an empty dict if absent or malformed."""
+    environments = config.get(ENVIRONMENTS_FIELD)
+    return environments if isinstance(environments, dict) else {}
+
+
 def stored_environment_key(environment: str) -> str | None:
     """The key saved for ``environment``, or None if there isn't one."""
-    environments = _load_config().get(ENVIRONMENTS_FIELD)
-    if not isinstance(environments, dict):
-        return None
-    entry = environments.get(environment)
+    entry = _environments(_load_config()).get(environment)
     if not isinstance(entry, dict):
         return None
     key = entry.get(API_KEY_FIELD)
@@ -99,9 +102,7 @@ def save_environment_key(environment: str, api_key: str) -> Path:
     os.chmod(config_path.parent, stat.S_IRWXU)
 
     config = _load_config()
-    environments = config.get(ENVIRONMENTS_FIELD)
-    if not isinstance(environments, dict):
-        environments = {}
+    environments = _environments(config)
     environments[environment] = {API_KEY_FIELD: api_key.strip()}
     config[ENVIRONMENTS_FIELD] = environments
 
@@ -112,8 +113,8 @@ def save_environment_key(environment: str, api_key: str) -> Path:
 def clear_environment_key(environment: str) -> bool:
     """Forget the key stored for ``environment``. True if one was removed."""
     config = _load_config()
-    environments = config.get(ENVIRONMENTS_FIELD)
-    if not isinstance(environments, dict) or environment not in environments:
+    environments = _environments(config)
+    if environment not in environments:
         return False
     del environments[environment]
     if environments:


### PR DESCRIPTION
## Issue

`src/yutori_mcp/credentials.py` has three functions that each independently reimplement the same guard: read `config["environments"]`, and treat anything that isn't a `dict` (missing, `None`, malformed) as empty.

- `stored_environment_key()`:
  ```python
  environments = _load_config().get(ENVIRONMENTS_FIELD)
  if not isinstance(environments, dict):
      return None
  ```
- `save_environment_key()`:
  ```python
  environments = config.get(ENVIRONMENTS_FIELD)
  if not isinstance(environments, dict):
      environments = {}
  ```
- `clear_environment_key()`:
  ```python
  environments = config.get(ENVIRONMENTS_FIELD)
  if not isinstance(environments, dict) or environment not in environments:
      return False
  ```

## Fix

Factor the shape guard into one helper:

```python
def _environments(config: dict[str, Any]) -> dict[str, Any]:
    """The ``environments`` map from ``config``, or an empty dict if absent or malformed."""
    environments = config.get(ENVIRONMENTS_FIELD)
    return environments if isinstance(environments, dict) else {}
```

All three call sites now go through it, dropping the duplicated `isinstance` branch from each.

## Why it's safe

No behavior change — each call site's `isinstance` check already treated a missing/malformed `environments` key as "acts empty," which is exactly what `_environments()` returns:

- `stored_environment_key`: `_environments(...).get(environment)` on `{}` returns `None`, same as the old early return.
- `save_environment_key`: mutating the `{}` `_environments()` returns and assigning it back to `config[ENVIRONMENTS_FIELD]` is identical to the old `environments = {}` fallback.
- `clear_environment_key`: `environment not in {}` is `True`, so it still returns `False` for a missing/malformed map — same as the old combined `isinstance`-or-`not in` check.

Verified by the existing `tests/test_credentials.py` suite, which already exercises the corrupt-config, missing-`environments`, and clear-nonexistent-environment paths:

```
356 passed, 1 skipped
```

`ruff check` and `ruff format --check` also pass on the changed file.


---
_Generated by [Claude Code](https://claude.ai/code/session_018DSWS7uA3ww2AAx2gGZP1o)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor in credential config parsing with no API or precedence changes; existing credential tests cover the guarded paths.
> 
> **Overview**
> **Deduplicates** how per-environment API keys read the `environments` section of `~/.yutori/config.json` by introducing `_environments(config)`, which returns the map or `{}` when the field is missing or not a dict.
> 
> `stored_environment_key`, `save_environment_key`, and `clear_environment_key` now call that helper instead of repeating `config.get("environments")` plus `isinstance(..., dict)` checks. **Behavior is unchanged**: missing or malformed `environments` still behaves like an empty map at each call site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 753bca05af0c58bcbdea269542e8fecf866864e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->