### PR TITLE
refactor(server): extract is_scoped_environment() for the auth-subcommand guard

### DIFF
--- a/src/yutori_mcp/adapter.py
+++ b/src/yutori_mcp/adapter.py
@@ -55,6 +55,17 @@ def resolve_base_url(environment: str | None = None) -> str:
         ) from None
 
 
+def is_scoped_environment(environment: str | None) -> bool:
+    """Whether ``environment`` explicitly names a non-default environment to target.
+
+    None (unset) and the literal ``DEFAULT_ENVIRONMENT`` both mean "use the SDK's single
+    top-level credential/config", the behavior every install had before per-environment
+    support existed. Shared by server.py's auth subcommands so a future change to what counts
+    as "the default" only needs to happen here.
+    """
+    return bool(environment) and environment != DEFAULT_ENVIRONMENT
+
+
 def resolve_run_credentials(environment: str | None = None) -> tuple[str | None, str]:
     """The (api_key, base_url) pair a computer-use run should authenticate with.
 

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -22,6 +22,7 @@ from .adapter import (
     ENVIRONMENT_BASE_URLS,
     MCPClientAdapter,
     YutoriAPIError,
+    is_scoped_environment,
     resolve_base_url,
 )
 from .formatters import (
@@ -708,7 +709,7 @@ def _register_computer_use_tool() -> None:
 
 
 def _auth_login(environment: str | None) -> NoReturn:
-    if environment and environment != DEFAULT_ENVIRONMENT:
+    if is_scoped_environment(environment):
         from getpass import getpass
 
         from .credentials import mask, save_environment_key
@@ -742,7 +743,7 @@ def _auth_login(environment: str | None) -> NoReturn:
 
 
 def _auth_logout(environment: str | None) -> NoReturn:
-    if environment and environment != DEFAULT_ENVIRONMENT:
+    if is_scoped_environment(environment):
         from .credentials import clear_environment_key
 
         removed = clear_environment_key(environment)
@@ -761,7 +762,7 @@ def _auth_logout(environment: str | None) -> NoReturn:
 
 
 def _auth_status(environment: str | None) -> NoReturn:
-    if environment and environment != DEFAULT_ENVIRONMENT:
+    if is_scoped_environment(environment):
         from yutori.auth.credentials import get_config_path
 
         from .credentials import mask, stored_environment_key

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -12,6 +12,7 @@ from yutori_mcp.adapter import (
     MCPClientAdapter,
     YutoriAPIError,
     _strip_none,
+    is_scoped_environment,
     resolve_base_url,
     resolve_run_credentials,
 )
@@ -209,6 +210,31 @@ class TestResolveBaseUrl:
         monkeypatch.setenv(ENV_VAR_ENVIRONMENT, "staging")
         with pytest.raises(ValueError, match="Unknown Yutori environment 'staging'"):
             resolve_base_url()
+
+
+# ---------------------------------------------------------------------------
+# is_scoped_environment
+# ---------------------------------------------------------------------------
+
+
+class TestIsScopedEnvironment:
+    """Whether an `--env` argument names a non-default environment to target.
+
+    server.py's `_auth_login`/`_auth_logout`/`_auth_status` each branch on this to decide
+    between the per-environment paste flow and the SDK's own single-credential flow.
+    """
+
+    def test_none_is_not_scoped(self):
+        assert is_scoped_environment(None) is False
+
+    def test_empty_string_is_not_scoped(self):
+        assert is_scoped_environment("") is False
+
+    def test_default_environment_is_not_scoped(self):
+        assert is_scoped_environment(DEFAULT_ENVIRONMENT) is False
+
+    def test_a_named_non_default_environment_is_scoped(self):
+        assert is_scoped_environment("dev") is True
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Structural issue

`_auth_login()`, `_auth_logout()`, and `_auth_status()` in `server.py` each independently reimplemented the identical guard:

```python
if environment and environment != DEFAULT_ENVIRONMENT:
    ...  # per-environment paste flow
...  # SDK's own single-credential flow
```

Three copies of the same compound boolean condition means a future change to what counts as "the default" (e.g. handling a new alias, or an empty-string sentinel) would need to be applied at three call sites in sync, with no single place that fails loudly if one is missed.

## Fix

Factored the condition into `adapter.is_scoped_environment(environment: str | None) -> bool`, alongside the other environment-resolution helpers (`current_environment()`, `resolve_base_url()`, `DEFAULT_ENVIRONMENT`) that already live in `adapter.py`. All three `server.py` call sites now delegate to it.

This mirrors the same kind of consolidation already applied elsewhere in this package, e.g. `credentials.py`'s `_environments()` guard (#219) and `entrypoint.py`'s `--env` choices drift-guard (#215).

## Why it's safe

- **No behavior change**: `is_scoped_environment(environment)` is exactly the same boolean expression (`bool(environment) and environment != DEFAULT_ENVIRONMENT`), just named and shared.
- Added `TestIsScopedEnvironment` in `tests/test_adapter.py` covering `None`, empty string, the default environment, and a named non-default environment.
- Full suite: 360 passed / 1 skipped (up from 356/1, the 4 new cases), `ruff check .` clean.
- Small, contained diff: 3 files, +41/-3.


---
_Generated by [Claude Code](https://claude.ai/code/session_01P7mLnNbhaUyWDdVcSVa2or)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with unit tests; auth branching logic is unchanged, only deduplicated.
> 
> **Overview**
> Introduces **`is_scoped_environment()`** in `adapter.py` next to the other environment helpers, centralizing the rule for when an explicit `--env` value should use per-environment credentials vs the SDK’s default login/logout/status flow.
> 
> **`server.py`** auth handlers **`_auth_login`**, **`_auth_logout`**, and **`_auth_status`** now call that helper instead of repeating `environment and environment != DEFAULT_ENVIRONMENT`.
> 
> Adds **`TestIsScopedEnvironment`** in `tests/test_adapter.py` for `None`, empty string, the default environment, and a named non-default (e.g. `dev`). **No intended behavior change**—same boolean logic, single place to update if “default” semantics evolve.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e161a86411ebc5a4a76836da1e35534cd055ea6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->