### PR TITLE
refactor(adapter): route resolve_base_url through current_environment()

### DIFF
--- a/src/yutori_mcp/adapter.py
+++ b/src/yutori_mcp/adapter.py
@@ -45,7 +45,7 @@ def resolve_base_url(environment: str | None = None) -> str:
     for names not in ENVIRONMENT_BASE_URLS so a typo fails loudly instead
     of silently targeting production.
     """
-    name = environment or os.environ.get(ENV_VAR_ENVIRONMENT) or DEFAULT_ENVIRONMENT
+    name = environment or current_environment()
     try:
         return ENVIRONMENT_BASE_URLS[name]
     except KeyError:


### PR DESCRIPTION
`resolve_base_url()` independently reimplemented `current_environment()`'s exact expression (`os.environ.get(ENV_VAR_ENVIRONMENT) or DEFAULT_ENVIRONMENT`) inline instead of calling it, even though `resolve_run_credentials()` right below it already calls `current_environment()` for the same purpose. Nothing tied the two computations together besides eyeballing them.

No behavior change: `current_environment()`'s body is byte-identical to the expression it replaces, so resolution order (explicit argument, then `YUTORI_ENV`, then prod) and the empty-env-var-falls-back-to-default case are unaffected.

Verified by the existing `TestResolveBaseUrl` suite in `tests/test_adapter.py` (defaults, explicit argument, env var, override, empty env var, and unknown-environment cases), plus the full suite (360 passed, 1 skipped).

Co-authored-by: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_015z4gcJ7Tuvnwpr9JZczaaL)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-expression refactor with identical semantics; environment URL resolution is unchanged.
> 
> **Overview**
> **`resolve_base_url()`** no longer inlines `YUTORI_ENV` / default env resolution; it now uses **`current_environment()`**, matching **`resolve_run_credentials()`** and other adapter paths so env naming stays in one place.
> 
> Resolution order is unchanged: explicit `environment` argument, then env var, then prod; unknown names still raise **`ValueError`**. Existing **`TestResolveBaseUrl`** coverage applies with no intended behavior change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b7ad4c979d87b5d06eb7a2cf4d52001e2c0ff6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->