### PR TITLE
test(computer-use): extract _run_supervised() for the repeated _supervise() harness setup

### DIFF
--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -297,6 +297,22 @@ def _result_event(**overrides):
     return event
 
 
+async def _run_supervised(process, *, api_key="yt-key", deadline_seconds=1, **supervise_kwargs):
+    """Patch the child process and call `_supervise` with the shared fixed args this file's tests repeat.
+
+    Only for tests that don't need to assert on the `create_subprocess_exec` mock itself or patch anything
+    beyond it -- those keep their own inline `with patch(...)` block.
+    """
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)):
+        return await _supervise(
+            command=python_runner_command(),
+            request={"type": "run"},
+            api_key=api_key,
+            deadline=time.monotonic() + deadline_seconds,
+            **supervise_kwargs,
+        )
+
+
 async def test_supervisor_redacts_key_and_keeps_it_out_of_argv():
     secret = "yt-super-secret-value"
     process = _Process(
@@ -338,14 +354,7 @@ async def test_supervisor_forwards_ready_and_action_events():
     async def on_event(event):
         seen.append(event)
 
-    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)):
-        result = await _supervise(
-            command=python_runner_command(),
-            request={"type": "run"},
-            api_key="yt-key",
-            deadline=time.monotonic() + 1,
-            on_event=on_event,
-        )
+    result = await _run_supervised(process, on_event=on_event)
     assert [event["type"] for event in seen] == ["ready", "action"]
     assert result["actions"] == [events[1]]
 
@@ -379,13 +388,7 @@ async def test_supervisor_rejects_result_larger_than_configured_stream_limit():
     process = _Process(stream, _stream(""))
     process.returncode = 0
 
-    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)):
-        result = await _supervise(
-            command=python_runner_command(),
-            request={"type": "run"},
-            api_key="yt-key",
-            deadline=time.monotonic() + 1,
-        )
+    result = await _run_supervised(process)
 
     assert result["outcome"] == "failed"
     assert "exceeded" in result["final_text"]
@@ -433,13 +436,7 @@ async def test_supervisor_rejects_runner_provenance_drift():
 async def test_supervisor_rejects_malformed_events(event):
     process = _Process(_stream(json.dumps(_ready_event()), json.dumps(event)), _stream(""))
     process.returncode = 0
-    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)):
-        result = await _supervise(
-            command=python_runner_command(),
-            request={"type": "run"},
-            api_key="yt-key",
-            deadline=time.monotonic() + 1,
-        )
+    result = await _run_supervised(process)
     assert result["outcome"] == "failed"
     assert "malformed" in result["final_text"]
 
@@ -451,13 +448,7 @@ async def test_supervisor_rejects_invalid_utf8_in_an_otherwise_valid_event():
     stream.feed_eof()
     process = _Process(stream, _stream(""))
     process.returncode = 0
-    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)):
-        result = await _supervise(
-            command=python_runner_command(),
-            request={"type": "run"},
-            api_key="yt-key",
-            deadline=time.monotonic() + 1,
-        )
+    result = await _run_supervised(process)
     assert result["outcome"] == "failed"
     assert "invalid JSON" in result["final_text"]
 
@@ -481,13 +472,7 @@ async def test_supervisor_overwrites_child_supplied_actions():
         ),
         _stream(""),
     )
-    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)):
-        result = await _supervise(
-            command=python_runner_command(),
-            request={"type": "run"},
-            api_key="yt-key",
-            deadline=time.monotonic() + 1,
-        )
+    result = await _run_supervised(process)
     assert result["actions"] == [action]
 
 
@@ -501,13 +486,7 @@ async def test_supervisor_rejects_data_after_a_terminal_event():
         _stream(""),
     )
     process.returncode = 0
-    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)):
-        result = await _supervise(
-            command=python_runner_command(),
-            request={"type": "run"},
-            api_key="yt-key",
-            deadline=time.monotonic() + 1,
-        )
+    result = await _run_supervised(process)
     assert result["outcome"] == "failed"
     assert "after its terminal event" in result["final_text"]
 


### PR DESCRIPTION
## What

Six tests in `tests/test_computer_use.py` each independently duplicated the same 5-7 line block:

```python
with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)):
    result = await _supervise(
        command=python_runner_command(),
        request={"type": "run"},
        api_key="yt-key",
        deadline=time.monotonic() + 1,
    )
```

to patch the child process and drive `_supervise`. Extracted `_run_supervised(process, **overrides)` next to the file's other shared fixtures (`_ready_event`, `_result_event`) so it does the patch-and-call once.

Four other `_supervise(...)` call sites in the same file were deliberately left untouched — they either need the `create_subprocess_exec` mock captured for a direct assertion (e.g. `create.await_args.kwargs["limit"]`), or patch something in addition to the subprocess exec (`_stop_process_group`). Folding those into the helper too would need more parameters than it would save, and this repo's own audit history (see `.claude/REFACTOR.md`'s `yutori-mcp` section) has repeatedly and deliberately rejected over-generalizing helpers for that reason — so I matched that judgment here rather than force every call site through one shape.

## Why this is safe

- Test-only change, no production code touched.
- Pure extraction — same patch target, same `_supervise` kwargs, same call order at every touched site.
- `deadline_seconds` defaults to `1` (matching every touched call site's literal `time.monotonic() + 1`), and `on_event=...` still passes through via `**supervise_kwargs`.

## Verification

- `uv run pytest -q` → 360 passed, 1 skipped (matches `main`'s baseline exactly — no coverage change, same behavior).
- `uv run ruff check .` → clean.
- (`ruff format` reports pre-existing drift across this whole file and others, unrelated to this diff — the repo has no `[tool.ruff]` format config and CI runs `pytest` only, matching several `.claude/REFACTOR.md` audit notes on this repo.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3LJCYiVyazWk36TonjaD8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production changes; behavior is unchanged at each updated call site.
> 
> **Overview**
> Adds **`_run_supervised(process, ...)`** next to the existing `_ready_event` / `_result_event` helpers in `tests/test_computer_use.py`. It patches `asyncio.create_subprocess_exec`, calls `_supervise` with the shared `python_runner_command()`, default run request, API key, and deadline, and forwards extra kwargs (e.g. `on_event`).
> 
> **Six** supervisor tests that only needed that harness now call `_run_supervised` instead of copying the same `with patch(...)` block. Tests that assert on the subprocess mock (e.g. stream `limit`) or patch `_stop_process_group` / use a custom API key for redaction checks **stay** with inline setup, as documented in the helper docstring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6884ad8753946e95912c6520772bb59f6b0ad10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->