### PR TITLE
test(adapter): extract _create_adapter_with_resolved_key() for the repeated TestAdapterInit patch boilerplate

### DIFF
--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -121,6 +121,22 @@ class TestErrorFormattingContract:
 # ---------------------------------------------------------------------------
 
 
+def _create_adapter_with_resolved_key(**adapter_kwargs):
+    """Patch resolve_api_key_for_environment + AsyncYutoriClient and construct MCPClientAdapter(**adapter_kwargs).
+
+    Returns the AsyncYutoriClient class mock so the caller can assert on its call args, which differ per test.
+    """
+    with (
+        patch(
+            "yutori_mcp.adapter.resolve_api_key_for_environment",
+            return_value="yt-key",
+        ),
+        patch("yutori_mcp.adapter.AsyncYutoriClient") as mock_client_cls,
+    ):
+        MCPClientAdapter(**adapter_kwargs)
+    return mock_client_cls
+
+
 class TestAdapterInit:
     def test_raises_without_api_key(self):
         with patch(
@@ -131,46 +147,27 @@ class TestAdapterInit:
 
     def test_creates_client_with_resolved_key(self, monkeypatch):
         monkeypatch.delenv(ENV_VAR_ENVIRONMENT, raising=False)
-        with (
-            patch(
-                "yutori_mcp.adapter.resolve_api_key_for_environment",
-                return_value="yt-key",
-            ),
-            patch("yutori_mcp.adapter.AsyncYutoriClient") as mock_client_cls,
-        ):
-            MCPClientAdapter()
-            mock_client_cls.assert_called_once_with(
-                api_key="yt-key",
-                base_url=ENVIRONMENT_BASE_URLS[DEFAULT_ENVIRONMENT],
-            )
+        mock_client_cls = _create_adapter_with_resolved_key()
+        mock_client_cls.assert_called_once_with(
+            api_key="yt-key",
+            base_url=ENVIRONMENT_BASE_URLS[DEFAULT_ENVIRONMENT],
+        )
 
     def test_env_var_selects_dev_base_url(self, monkeypatch):
         monkeypatch.setenv(ENV_VAR_ENVIRONMENT, "dev")
-        with (
-            patch(
-                "yutori_mcp.adapter.resolve_api_key_for_environment",
-                return_value="yt-key",
-            ),
-            patch("yutori_mcp.adapter.AsyncYutoriClient") as mock_client_cls,
-        ):
-            MCPClientAdapter()
-            mock_client_cls.assert_called_once_with(
-                api_key="yt-key", base_url=ENVIRONMENT_BASE_URLS["dev"]
-            )
+        mock_client_cls = _create_adapter_with_resolved_key()
+        mock_client_cls.assert_called_once_with(
+            api_key="yt-key", base_url=ENVIRONMENT_BASE_URLS["dev"]
+        )
 
     def test_explicit_base_url_wins_over_env_var(self, monkeypatch):
         monkeypatch.setenv(ENV_VAR_ENVIRONMENT, "dev")
-        with (
-            patch(
-                "yutori_mcp.adapter.resolve_api_key_for_environment",
-                return_value="yt-key",
-            ),
-            patch("yutori_mcp.adapter.AsyncYutoriClient") as mock_client_cls,
-        ):
-            MCPClientAdapter(base_url="http://localhost:8000/v1")
-            mock_client_cls.assert_called_once_with(
-                api_key="yt-key", base_url="http://localhost:8000/v1"
-            )
+        mock_client_cls = _create_adapter_with_resolved_key(
+            base_url="http://localhost:8000/v1"
+        )
+        mock_client_cls.assert_called_once_with(
+            api_key="yt-key", base_url="http://localhost:8000/v1"
+        )
 
     async def test_close_closes_client(self, adapter):
         adapter._client.close = AsyncMock()


### PR DESCRIPTION
## Day-over-day pattern

Yesterday's PR #222 named and fixed "repeated patch-and-call boilerplate across sibling test methods" by extracting `_run_supervised()` in `tests/test_computer_use.py`. Because that PR stayed scoped to the one file it was reviewing, the identical mechanism was left unaddressed in `tests/test_adapter.py`: three `TestAdapterInit` tests each independently duplicate the same block —

```python
with (
    patch("yutori_mcp.adapter.resolve_api_key_for_environment", return_value="yt-key"),
    patch("yutori_mcp.adapter.AsyncYutoriClient") as mock_client_cls,
):
    MCPClientAdapter(...)
    mock_client_cls.assert_called_once_with(...)
```

That's only visible by looking across the day's commits together — #222's own diff wouldn't naturally surface a sibling file it didn't touch.

## Change

Extracted `_create_adapter_with_resolved_key(**adapter_kwargs)`, mirroring #222's own precedent: the helper does the patch-and-construct once and returns the `AsyncYutoriClient` class mock, since what each test asserts on it (the `base_url` in particular) differs per test.

Test-only, no behavior change:
- `python -m pytest` (full suite): **362 passed, 1 skipped**, matching baseline exactly.
- `ruff check` clean on the touched file. (`ruff format --diff` flags an unrelated, pre-existing formatting drift further down the same file in `TestResolveRunCredentials`, confirmed present on `main` before this change — left untouched as out of scope.)

## Owner

Tagging @dhruvbatra, sole recent author of both `test_adapter.py` and the sibling `test_computer_use.py` fix in #222.

---
*Opened by the automated daily cross-repo cleanup routine, which reviews the previous 24h of merged commits for structural refactor opportunities that only become visible when viewed together.*

---
_Generated by [Claude Code](https://claude.ai/code/session_01CaaxFaKJW1Xrk3C9sRLHdg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only deduplication with no changes to adapter or runtime code.
> 
> **Overview**
> **Test-only refactor** in `tests/test_adapter.py`: three `TestAdapterInit` cases that each duplicated the same `patch` + `MCPClientAdapter()` setup now call a shared **`_create_adapter_with_resolved_key(**adapter_kwargs)`** helper.
> 
> The helper applies the `resolve_api_key_for_environment` and `AsyncYutoriClient` patches, constructs the adapter with optional kwargs (e.g. explicit `base_url`), and returns the client class mock so each test can still assert on `assert_called_once_with` for environment-specific URLs. **`test_raises_without_api_key`** and **`test_close_closes_client`** are unchanged.
> 
> This mirrors the same “extract repeated patch-and-construct” pattern used in `test_computer_use.py` (#222); no production or adapter behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 945746d5971246cd09b4b8282389efa20c8f3ac9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->