### PR TITLE
refactor(computer-use): centralize the max_steps default

### DIFF
--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from urllib.request import urlopen
 
 from ..schemas import (
+    COMPUTER_USE_DEFAULT_MAX_STEPS,
     COMPUTER_USE_DEFAULT_MINUTES,
     COMPUTER_USE_MAX_MINUTES,
     ComputerUseTaskInput,
@@ -253,7 +254,13 @@ def register_parser(
         default=COMPUTER_USE_DEFAULT_MINUTES,
         help=f"Absolute deadline in minutes (1-{COMPUTER_USE_MAX_MINUTES})",
     )
-    run_parser.add_argument("--max-steps", dest="max_steps", type=int, default=60, help="Maximum actions")
+    run_parser.add_argument(
+        "--max-steps",
+        dest="max_steps",
+        type=int,
+        default=COMPUTER_USE_DEFAULT_MAX_STEPS,
+        help="Maximum actions",
+    )
 
 
 def dispatch(command: str, args: argparse.Namespace | None = None) -> int:

--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -391,6 +391,10 @@ class BrowsingTaskInput(ToolInput):
 
 COMPUTER_USE_DEFAULT_MINUTES = 30
 COMPUTER_USE_MAX_MINUTES = 60
+# Shared with computer_use/cli.py's `--max-steps` argparse default and server.py's
+# run_computer_use_task signature default, mirroring COMPUTER_USE_DEFAULT_MINUTES above so the
+# three call sites cannot drift apart if the default ever changes.
+COMPUTER_USE_DEFAULT_MAX_STEPS = 60
 
 
 class ComputerUseTaskInput(ToolInput):
@@ -406,7 +410,7 @@ class ComputerUseTaskInput(ToolInput):
         description=f"Absolute run deadline in minutes (1-{COMPUTER_USE_MAX_MINUTES})",
     )
     max_steps: int = Field(
-        default=60, ge=1, description="Maximum actions before stopping the run"
+        default=COMPUTER_USE_DEFAULT_MAX_STEPS, ge=1, description="Maximum actions before stopping the run"
     )
     @model_validator(mode="after")
     def require_app_for_start_url(self) -> ComputerUseTaskInput:

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -33,6 +33,7 @@ from .formatters import (
 )
 from .schema_utils import output_fields_to_output_schema
 from .schemas import (
+    COMPUTER_USE_DEFAULT_MAX_STEPS,
     COMPUTER_USE_DEFAULT_MINUTES,
     DEFAULT_LIST_LIMIT,
     BrowserChoice,
@@ -405,7 +406,7 @@ async def run_computer_use_task(
     app: str | None = None,
     start_url: str | None = None,
     minutes: float = COMPUTER_USE_DEFAULT_MINUTES,
-    max_steps: int = 60,
+    max_steps: int = COMPUTER_USE_DEFAULT_MAX_STEPS,
     ctx: Context | None = None,
 ) -> str:
     # `ctx` is FastMCP's injected request context (excluded from the client-facing


### PR DESCRIPTION
## What

The `#205`/`#206`/`#207` series of PRs centralized the computer-use `minutes` deadline default into `schemas.COMPUTER_USE_DEFAULT_MINUTES`, imported by both `server.py` and `computer_use/cli.py` so the three call sites can't drift apart.

The same pattern was never applied to `max_steps`: its default of `60` was a bare literal independently duplicated in three places:
- `schemas.ComputerUseTaskInput.max_steps` (`Field(default=60, ...)`)
- `server.run_computer_use_task`'s signature default (`max_steps: int = 60`)
- `computer_use/cli.py`'s `--max-steps` argparse default

This adds `COMPUTER_USE_DEFAULT_MAX_STEPS = 60` next to `COMPUTER_USE_DEFAULT_MINUTES` in `schemas.py` and routes all three through it.

## Why it's safe

- Pure constant extraction — no behavior change. The effective default stays `60` everywhere, verified by the existing schema/CLI/server tests (none of which pinned the literal `60` directly, so nothing needed updating).
- Mirrors an already-established, reviewed pattern in this repo (`COMPUTER_USE_DEFAULT_MINUTES`), so the risk profile matches a change that already shipped three times.
- Touches 3 files with a combined diff of 15 insertions / 3 deletions.

## Verification

- `uv run --extra dev pytest -q` → 362 passed, 1 skipped (matches baseline, unchanged)
- `uv run --extra dev ruff check .` → all checks pass


---
_Generated by [Claude Code](https://claude.ai/code/session_01PAuTfxfMJgwUpMeUtnkvuC)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Constant extraction with no runtime behavior change; mirrors an established pattern already used for computer-use minutes defaults.
> 
> **Overview**
> Introduces **`COMPUTER_USE_DEFAULT_MAX_STEPS`** (`60`) in `schemas.py`, following the same pattern as **`COMPUTER_USE_DEFAULT_MINUTES`**, so the computer-use step limit default stays aligned across entry points.
> 
> **`ComputerUseTaskInput.max_steps`**, **`run_computer_use_task`**’s signature default, and the CLI **`--max-steps`** argparse default now all reference that constant instead of duplicating the literal **`60`**. Behavior is unchanged; this only prevents the three defaults from drifting if the value is updated later.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b03bee30d79304b78cd6a5e10803ab3f29f6d095. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->