### PR TITLE
test(computer-use): extract _patch_smoke_preflight() for repeated _smoke_live() test setup

### DIFF
--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -1009,14 +1009,23 @@ async def test_mechanical_calculator_check_uses_cua_driver(monkeypatch, tmp_path
     assert computers[0].calls.count(("keypress", ["CMD", "C"])) == 2
 
 
+def _patch_smoke_preflight(monkeypatch, cli, lock_path, first_blocker=lambda: None):
+    """Patch the DesktopLock path and first_blocker() result every _smoke_live() test needs.
+
+    Every caller of `_smoke_live()` reserves the desktop at a test-owned lock path and stubs
+    the preflight gate before exercising it; only the blocker (or lack of one) differs per test.
+    """
+    monkeypatch.setattr(cli, "DesktopLock", lambda: DesktopLock(lock_path))
+    monkeypatch.setattr(cli, "first_blocker", first_blocker)
+
+
 async def test_smoke_reserves_desktop_before_mechanical_check(monkeypatch, tmp_path, capsys):
     from yutori_mcp.computer_use import cli
 
     lock_path = tmp_path / "desktop.lock"
     mechanical_check = AsyncMock()
     preflight = Mock()
-    monkeypatch.setattr(cli, "DesktopLock", lambda: DesktopLock(lock_path))
-    monkeypatch.setattr(cli, "first_blocker", preflight)
+    _patch_smoke_preflight(monkeypatch, cli, lock_path, preflight)
     monkeypatch.setattr(cli, "_mechanical_calculator_check", mechanical_check)
 
     with DesktopLock(lock_path):
@@ -1031,8 +1040,7 @@ async def test_smoke_does_not_print_mismatched_clipboard_contents(monkeypatch, t
     from yutori_mcp.computer_use import cli
 
     secret = "clipboard-secret-value"
-    monkeypatch.setattr(cli, "DesktopLock", lambda: DesktopLock(tmp_path / "desktop.lock"))
-    monkeypatch.setattr(cli, "first_blocker", lambda: None)
+    _patch_smoke_preflight(monkeypatch, cli, tmp_path / "desktop.lock")
     monkeypatch.setattr(cli, "_mechanical_calculator_check", AsyncMock(return_value=secret))
 
     assert await cli._smoke_live() == 1
@@ -1046,8 +1054,7 @@ async def test_smoke_allows_two_minutes_for_live_check(monkeypatch, tmp_path):
     from yutori_mcp.computer_use import cli
 
     run = AsyncMock(return_value={"outcome": "completed"})
-    monkeypatch.setattr(cli, "DesktopLock", lambda: DesktopLock(tmp_path / "desktop.lock"))
-    monkeypatch.setattr(cli, "first_blocker", lambda: None)
+    _patch_smoke_preflight(monkeypatch, cli, tmp_path / "desktop.lock")
     monkeypatch.setattr(cli, "_mechanical_calculator_check", AsyncMock(return_value="42"))
     monkeypatch.setattr(cli, "run_task", run)
     monkeypatch.setattr(cli, "format_result", lambda _result: "complete")
@@ -1159,8 +1166,7 @@ async def test_smoke_reports_preflight_detail_and_fix(monkeypatch, tmp_path, cap
         "Invalid model",
         "Use a supported model.",
     )
-    monkeypatch.setattr(cli, "DesktopLock", lambda: DesktopLock(tmp_path / "desktop.lock"))
-    monkeypatch.setattr(cli, "first_blocker", lambda: blocker)
+    _patch_smoke_preflight(monkeypatch, cli, tmp_path / "desktop.lock", lambda: blocker)
     mechanical = AsyncMock()
     monkeypatch.setattr(cli, "_mechanical_calculator_check", mechanical)
 


### PR DESCRIPTION
## What

Four tests exercising `computer_use/cli.py::_smoke_live()` each independently patched the same
pair of module attributes — `cli.DesktopLock` (to a test-owned lock path) and `cli.first_blocker`
(the preflight-gate stub) — with an identical two-line block, differing only in what
`first_blocker` returns:

- `test_smoke_reserves_desktop_before_mechanical_check`
- `test_smoke_does_not_print_mismatched_clipboard_contents`
- `test_smoke_allows_two_minutes_for_live_check`
- `test_smoke_reports_preflight_detail_and_fix`

Extracted the shared pair into a small helper, `_patch_smoke_preflight(monkeypatch, cli,
lock_path, first_blocker=lambda: None)`, and pointed all four call sites at it. This mirrors the
same-file's existing `_run_supervised()` / `_run_task_kwargs()` helper convention (small
`monkeypatch`-based setup helpers defined right before their first use).

## Why this is safe

- Test-only change — no production code touched, and nothing about the public MCP tool/CLI
  surface changes.
- Purely mechanical: each call site's exact same two `monkeypatch.setattr` calls are now made
  through the helper instead of written out inline; the values passed (lock path, blocker) are
  unchanged per test.
- Full suite passes unchanged: `362 passed, 1 skipped` before and after (no coverage change,
  since this doesn't add or remove any assertions).
- `ruff check` clean on the touched file.


---
_Generated by [Claude Code](https://claude.ai/code/session_019R1CDa2GkV8gYsvoBeAB6N)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production or assertion changes.
> 
> **Overview**
> Introduces **`_patch_smoke_preflight()`** in `tests/test_computer_use.py` to centralize the shared `monkeypatch` setup for `_smoke_live()` tests: wiring `cli.DesktopLock` to a test-owned lock path and stubbing `cli.first_blocker` (default `lambda: None`).
> 
> Four smoke tests now call the helper instead of duplicating those two `setattr` lines; behavior is unchanged—each test still passes the same lock path and blocker stub (including the mock `preflight` in the desktop-reservation test and the `CheckResult` lambda in the preflight-detail test).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a174fedaaefb20e26e4151c9cda7091093eb5792. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->