### PR TITLE
refactor(computer-use): extract _result_event() for the runner's shared result shape

### DIFF
--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -437,6 +437,23 @@ def _cancelled_outcome(cause: str | None) -> tuple[str, str]:
     return "aborted", "The computer-use run was stopped."
 
 
+def _result_event(outcome: str, final_text: str | None) -> dict[str, Any]:
+    """The four keys every runner-to-supervisor "result" event shares.
+
+    A deadline that expires before the run starts, a normal run outcome, and an unexpected
+    top-level exception in ``main()`` each terminate at a different point with different
+    additional data available (elapsed_ms/steps, timings, presentation state), but all three
+    must still agree on this core shape -- the same one `supervisor._event_shape_error()`
+    validates on the other side of the pipe.
+    """
+    return {
+        "type": "result",
+        "outcome": outcome,
+        "delivery_mode": DELIVERY_MODE_FOREGROUND,
+        "final_text": final_text,
+    }
+
+
 async def run_request(
     request: dict[str, Any],
     emitter: Emitter,
@@ -448,10 +465,7 @@ async def run_request(
     if remaining_seconds <= 0:
         emitter.emit(
             {
-                "type": "result",
-                "outcome": "limit",
-                "delivery_mode": DELIVERY_MODE_FOREGROUND,
-                "final_text": "The deadline expired before the run started.",
+                **_result_event("limit", "The deadline expired before the run started."),
                 "elapsed_ms": 0,
                 "steps": 0,
             }
@@ -533,10 +547,7 @@ async def run_request(
     elapsed_ms = max(0, round((time.monotonic() - run_start) * 1000))
     emitter.emit(
         {
-            "type": "result",
-            "outcome": outcome,
-            "delivery_mode": DELIVERY_MODE_FOREGROUND,
-            "final_text": final_text,
+            **_result_event(outcome, final_text),
             "elapsed_ms": elapsed_ms,
             "steps": guard.steps,
             "timings": _timings_payload(elapsed_ms, agent, api_counter, reporter, computer),
@@ -629,10 +640,7 @@ def main() -> int:
         message = _redacted_error_text(error, api_key)
         emitter.emit(
             {
-                "type": "result",
-                "outcome": "failed",
-                "delivery_mode": DELIVERY_MODE_FOREGROUND,
-                "final_text": message,
+                **_result_event("failed", message),
                 "steps": 0,
             }
         )

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -1261,6 +1261,15 @@ def test_failure_is_the_failed_outcome_of_the_shared_shape():
     assert failure("boom") == terminal_result("failed", "boom")
 
 
+def test_result_event_carries_the_outcome_and_shared_shape():
+    assert runner_module._result_event("limit", "deadline expired") == {
+        "type": "result",
+        "outcome": "limit",
+        "delivery_mode": DELIVERY_MODE_FOREGROUND,
+        "final_text": "deadline expired",
+    }
+
+
 class _CollectStream:
     def __init__(self):
         self.lines: list[str] = []
@@ -1463,6 +1472,23 @@ async def test_run_request_reports_an_action_interrupted_by_cancellation(monkeyp
     assert [event["type"] for event in events[-2:]] == ["action", "result"]
     assert events[-2]["raw_status"] == "interrupted"
     assert events[-2]["status"] == "uncertain"
+
+
+async def test_run_request_reports_limit_when_the_deadline_has_already_passed():
+    stream = _CollectStream()
+    request = parse_request(_valid_request(deadline_ms=int((time.time() - 1) * 1000)))
+
+    assert await runner_module.run_request(request, Emitter(stream), "yt-secret") == "limit"
+
+    (event,) = [json.loads(line) for line in stream.lines]
+    assert event == {
+        "type": "result",
+        "outcome": "limit",
+        "delivery_mode": DELIVERY_MODE_FOREGROUND,
+        "final_text": "The deadline expired before the run started.",
+        "elapsed_ms": 0,
+        "steps": 0,
+    }
 
 
 def test_format_result_handles_python_runtime_action_fields():


### PR DESCRIPTION
## Issue

`runner.py` builds the same four-key protocol "result" event (`type`, `outcome`, `delivery_mode`, `final_text`) by hand in three separate places:

1. `run_request()`'s early return when the deadline already expired before the run started
2. `run_request()`'s normal terminal emit (layers on `elapsed_ms`/`steps`/`timings`/presentation state)
3. `main()`'s top-level exception handler (the last-resort protocol boundary)

This is the runner-side counterpart to the supervisor-side `terminal_result()` shape that PR #223 already consolidated (`result.py`) — that one had the identical problem for the *supervisor*'s terminal result; this one is the same problem one layer down, in the *runner*'s own result events. All three copies must agree with what `supervisor._event_shape_error()` validates on the other end of the pipe, so a shape change previously had to be made in three places by hand.

## Improvement

Extracted `_result_event(outcome, final_text) -> dict[str, Any]` into `runner.py`, returning just the four shared keys. Each of the three call sites now does `{**_result_event(...), <its own extra fields>}` instead of repeating the four-key literal — mirroring the exact `**_result_event(...)`/extra-fields composition style `result.py`'s `terminal_result()`/`_supervise()` already use for the analogous supervisor-side shape.

## Safety rationale

- **Behaviorally identical**: each call site constructs the exact same dict it did before — same keys, same values, same insertion order for the shared prefix. Verified this isn't just visual by diffing the resulting dicts field-by-field against the pre-change literals.
- **Scoped**: 2 files touched (`src/yutori_mcp/computer_use/runner.py`, `tests/test_computer_use.py`), no call-site-wide migration, no public/MCP tool-surface change.
- **Verified**: full suite `pytest -q` → 364 passed / 1 skipped (baseline 362/1; +2 are new direct-unit coverage: one pinning `_result_event()`'s shared shape, one a new characterization test for the previously-untested already-expired-deadline path in `run_request()` — the other two call sites already had indirect coverage through existing tests). `ruff check` clean on both touched files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LqEgaHyht5JFs5QgodY9J4)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with identical emitted events; only runner internals and tests change, no protocol or MCP surface change.
> 
> **Overview**
> Introduces **`_result_event(outcome, final_text)`** in the computer-use runner so the four protocol fields every **`result`** event must share (`type`, `outcome`, `delivery_mode`, `final_text`) are built in one place instead of duplicated literals.
> 
> **`run_request()`** (deadline-already-expired short circuit and normal completion) and **`main()`**’s last-resort exception handler now emit **`{**_result_event(...), …extra fields}`**, matching the supervisor-side **`terminal_result()`** pattern without changing emitted payloads.
> 
> Tests add a direct shape assertion on **`_result_event`** and cover the previously untested “deadline passed before start” **`run_request`** path end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c0fa4fbf557a2d09ee37302d26cab39f18f12b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->