### PR TITLE
refactor(computer-use): extract _error_event() for the runner's shared error shape

### DIFF
--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -437,6 +437,16 @@ def _cancelled_outcome(cause: str | None) -> tuple[str, str]:
     return "aborted", "The computer-use run was stopped."
 
 
+def _error_event(code: str, message: str) -> dict[str, Any]:
+    """The two keys every runner-to-supervisor "error" event shares.
+
+    `main()` reports a malformed request and a missing API key at two different points before
+    the run ever starts, but both must still agree on this shape -- the same one
+    `supervisor._event_shape_error()` validates on the other side of the pipe.
+    """
+    return {"type": "error", "code": code, "message": message}
+
+
 def _result_event(outcome: str, final_text: str | None) -> dict[str, Any]:
     """The four keys every runner-to-supervisor "result" event shares.
 
@@ -623,16 +633,10 @@ def main() -> int:
             raise RequestError("INVALID_JSON", "Request was not valid JSON.") from None
         request = parse_request(payload)
     except RequestError as error:
-        emitter.emit({"type": "error", "code": error.code, "message": str(error)})
+        emitter.emit(_error_event(error.code, str(error)))
         return 1
     if not api_key:
-        emitter.emit(
-            {
-                "type": "error",
-                "code": "MISSING_API_KEY",
-                "message": "YUTORI_API_KEY is not set in the runner environment.",
-            }
-        )
+        emitter.emit(_error_event("MISSING_API_KEY", "YUTORI_API_KEY is not set in the runner environment."))
         return 1
     try:
         outcome = asyncio.run(_run_until_terminated(request, emitter, api_key))

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -1270,6 +1270,14 @@ def test_result_event_carries_the_outcome_and_shared_shape():
     }
 
 
+def test_error_event_carries_the_code_and_message():
+    assert runner_module._error_event("MISSING_API_KEY", "not set") == {
+        "type": "error",
+        "code": "MISSING_API_KEY",
+        "message": "not set",
+    }
+
+
 class _CollectStream:
     def __init__(self):
         self.lines: list[str] = []


### PR DESCRIPTION
## What

`runner.py::main()` built the same two-key protocol `"error"` event (`type`/`code`/`message`) by hand in two places:

1. the `RequestError` handler for a malformed request (`code=error.code`)
2. the missing-`YUTORI_API_KEY` check (`code="MISSING_API_KEY"`)

Both must agree with the shape `supervisor.py::_event_shape_error()` validates on the other end of the pipe (`required = {"code": str, "message": str}` for `event_type == "error"`).

This mirrors the exact reasoning that justified `_result_event()` for the runner's `"result"` event shape in #227 (merged earlier today) — same validator, same runner module, same "must not silently drift apart" risk, just for the sibling `"error"` event type instead.

## Why it's safe

- Extracted `_error_event(code, message) -> dict[str, Any]`, placed and documented in the same style as the neighboring `_result_event()`.
- Both call sites now build the identical dict via the helper instead of by hand — output is byte-identical, no field added/removed/renamed.
- No public MCP tool schema, CLI surface, or protocol wire format is touched — this is purely internal to the runner subprocess's event construction.
- Added a direct unit test (`test_error_event_carries_the_code_and_message`), matching the existing `test_result_event_carries_the_outcome_and_shared_shape` pattern.

## Verification

- `uv run pytest -q` → 365 passed, 1 skipped (baseline was 364 passed, 1 skipped; +1 is the new helper test)
- `uv run ruff check .` → clean
- `uv run ruff format --diff` on the two touched files shows only pre-existing whole-file formatting drift (this repo has no `[tool.ruff]` config and CI runs `pytest` only), confirmed via diff to not touch any of the newly added/changed lines

Diff is 2 files, +20/-8.


---
_Generated by [Claude Code](https://claude.ai/code/session_0159AMf7QymDPoJWxRza6n31)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal runner refactor with byte-identical protocol events; no MCP surface or supervisor validation changes.
> 
> **Overview**
> Introduces **`_error_event(code, message)`** in the computer-use runner so pre-run failures emit a single, documented **`type` / `code` / `message`** shape instead of duplicating dict literals.
> 
> **`main()`** now uses the helper for **`RequestError`** handling (invalid JSON / bad request) and the missing **`YUTORI_API_KEY`** path; emitted events stay the same and stay aligned with what **`supervisor._event_shape_error()`** expects, parallel to the existing **`_result_event()`** pattern.
> 
> Adds **`test_error_event_carries_the_code_and_message`** to lock the helper’s output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50af916241f4a25c08eb891d6fa07797e9b62e51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->