### PR TITLE
refactor(computer-use): extract _remaining_seconds() for the supervisor's deadline check

### DIFF
--- a/src/yutori_mcp/computer_use/supervisor.py
+++ b/src/yutori_mcp/computer_use/supervisor.py
@@ -86,6 +86,20 @@ async def _stop_process_group(process: asyncio.subprocess.Process) -> None:
         await process.wait()
 
 
+def _remaining_seconds(deadline: float) -> float:
+    """Seconds left before ``deadline``, or raise ``asyncio.TimeoutError`` if none remain.
+
+    ``_supervise`` checks this before both of its waits on the child process -- the
+    per-line read loop and the final ``process.wait()`` after EOF -- so an expired
+    absolute deadline is caught the same way in both places instead of one of them
+    risking a zero/negative timeout reaching ``asyncio.wait_for``.
+    """
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise asyncio.TimeoutError
+    return remaining
+
+
 async def _drain_stderr(stream: asyncio.StreamReader, secret: str) -> list[str]:
     diagnostics: list[str] = []
     while line := await stream.readline():
@@ -171,9 +185,7 @@ async def _supervise(
         process.stdin.close()
         await process.stdin.wait_closed()
         while True:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
-                raise asyncio.TimeoutError
+            remaining = _remaining_seconds(deadline)
             try:
                 line = await asyncio.wait_for(process.stdout.readline(), remaining)
             except ValueError:
@@ -216,9 +228,7 @@ async def _supervise(
                 # Any further stdout is a protocol violation, so consume to EOF.
             else:
                 return failure(f"Computer-use runner emitted unknown event type: {event_type!r}.", actions=actions)
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            raise asyncio.TimeoutError
+        remaining = _remaining_seconds(deadline)
         await asyncio.wait_for(process.wait(), remaining)
         if terminal is None:
             diagnostics = await stderr_task

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -492,6 +492,17 @@ async def test_supervisor_rejects_data_after_a_terminal_event():
     assert "after its terminal event" in result["final_text"]
 
 
+def test_remaining_seconds_returns_positive_time_left():
+    deadline = time.monotonic() + 5
+    remaining = supervisor._remaining_seconds(deadline)
+    assert 0 < remaining <= 5
+
+
+def test_remaining_seconds_raises_once_deadline_has_passed():
+    with pytest.raises(asyncio.TimeoutError):
+        supervisor._remaining_seconds(time.monotonic() - 1)
+
+
 async def test_stop_process_group_escalates_to_kill():
     process = SimpleNamespace(pid=123, returncode=None, wait=AsyncMock(return_value=0))
 


### PR DESCRIPTION
## What

`_supervise()` in `src/yutori_mcp/computer_use/supervisor.py` computed "time left before the absolute deadline, else raise `asyncio.TimeoutError`" twice, verbatim:

- once to bound each `process.stdout.readline()` call in the event-reading loop
- once to bound the final `process.wait()` call after the child closes stdout (EOF)

Both sites were the same three lines:

```python
remaining = deadline - time.monotonic()
if remaining <= 0:
    raise asyncio.TimeoutError
```

This extracts that into a single `_remaining_seconds(deadline)` helper that both call sites now use.

## Why this is an improvement

- Single source of truth for "how do we treat an expired absolute deadline" in this function. A future tweak (e.g. a small grace window, or logging when the deadline trips) now only needs to change one place instead of two that must be kept in sync by hand.
- No behavior change: same computation, same exception, same call sites.

## Why it's safe

- Purely mechanical extraction — the two deleted blocks and the new helper body are line-for-line identical.
- The existing test suite already exercises both call sites of the duplicated logic (`test_supervisor_stdout_deadline_returns_limit_and_stops_group` for the read loop, `test_supervisor_eof_does_not_bypass_the_deadline` for the post-EOF `process.wait()`), and both still pass.
- Added two direct unit tests for the new helper (`test_remaining_seconds_returns_positive_time_left`, `test_remaining_seconds_raises_once_deadline_has_passed`), matching this file's existing convention of testing extracted helpers directly.
- Full suite: `367 passed, 1 skipped` locally across all changed and existing tests.
- Diff is confined to one source file and its test file.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XfooK3BTwiLhxbP8M15eoZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor in computer-use supervision with existing integration tests still covering both wait sites; no auth or data-handling changes.
> 
> **Overview**
> **`_supervise`** no longer repeats the same “seconds until absolute deadline, else `asyncio.TimeoutError`” logic in two places. That check is centralized in **`_remaining_seconds(deadline)`**, which both the stdout read loop and the post-EOF **`process.wait()`** use before calling **`asyncio.wait_for`**.
> 
> The helper’s docstring calls out why: expired deadlines are handled consistently so a zero or negative timeout is not passed to **`wait_for`**.
> 
> Two direct unit tests cover positive remaining time and **`TimeoutError`** after the deadline passes. No intended runtime behavior change—same math and exception as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a01ab98c98f3a8d416bfaf5b8614bd76d9d3bb59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->