### PR TITLE
refactor(computer-use): extract report() closures for repeated preflight check name/remediation pairs

### DIFF
--- a/src/yutori_mcp/computer_use/preflight.py
+++ b/src/yutori_mcp/computer_use/preflight.py
@@ -172,44 +172,48 @@ def _stable_distribution_digest(distribution: importlib.metadata.Distribution) -
 
 def check_runtime() -> CheckResult:
     remediation = f"Reinstall the pinned runtime: uvx --refresh --from yutori-mcp=={MCP_VERSION} yutori-mcp"
+
+    def report(ok: bool, detail: str) -> CheckResult:
+        return _result("Python runtime", ok, detail, remediation)
+
     try:
         distribution = importlib.metadata.distribution("yutori")
         version = distribution.version
     except (ImportError, importlib.metadata.PackageNotFoundError, OSError, ValueError) as error:
-        return _result("Python runtime", False, str(error), remediation)
+        return report(False, str(error))
 
     editable = _editable_distribution(distribution)
     if editable:
         override = os.environ.get(_EDITABLE_SDK_OVERRIDE) == "1"
         detail = f"yutori {version}; editable installation; override {'enabled' if override else 'required'}"
         if not override or version != SDK_VERSION:
-            return _result("Python runtime", False, detail, remediation)
+            return report(False, detail)
         try:
             provenance = _provenance_path(distribution, editable=True).read_bytes()
         except (OSError, ValueError, json.JSONDecodeError) as error:
-            return _result("Python runtime", False, str(error), remediation)
+            return report(False, str(error))
         ok = hashlib.sha256(provenance).hexdigest() == SDK_PROVENANCE_SHA256
-        return _result("Python runtime", ok, detail, remediation)
+        return report(ok, detail)
 
     try:
         installation_digest = _stable_distribution_digest(distribution)
     except OSError as error:
-        return _result("Python runtime", False, f"installed file unavailable: {error}", remediation)
+        return report(False, f"installed file unavailable: {error}")
     if version != SDK_VERSION or installation_digest != SDK_INSTALLATION_SHA256:
         detail = (
             f"yutori {version}; artifact sha256 {SDK_ARTIFACT_SHA256}; installation sha256 {installation_digest}"
         )
-        return _result("Python runtime", False, detail, remediation)
+        return report(False, detail)
     try:
         provenance = _provenance_path(distribution, editable=False).read_bytes()
     except (OSError, ValueError) as error:
-        return _result("Python runtime", False, str(error), remediation)
+        return report(False, str(error))
     provenance_digest = hashlib.sha256(provenance).hexdigest()
     detail = (
         f"yutori {version}; artifact sha256 {SDK_ARTIFACT_SHA256}; installation sha256 {installation_digest}; "
         f"provenance sha256 {provenance_digest}"
     )
-    return _result("Python runtime", provenance_digest == SDK_PROVENANCE_SHA256, detail, remediation)
+    return report(provenance_digest == SDK_PROVENANCE_SHA256, detail)
 
 
 def _run_safely(
@@ -465,6 +469,13 @@ def check_api_access() -> CheckResult:
 
     environment = current_environment()
     remediation = _api_access_remediation(environment)
+
+    def report(ok: bool, detail: str) -> CheckResult:
+        # `remediation` is read here at call time, not capture time, so the
+        # invalid_model/billing overrides below (assigned to the enclosing
+        # function's `remediation` before either return) still apply.
+        return _result("Yutori API", ok, detail, remediation)
+
     try:
         key, base_url = resolve_run_credentials(environment)
         request = Request(
@@ -485,7 +496,7 @@ def check_api_access() -> CheckResult:
             payload = json.loads(response.read().decode() or "{}")
     except HTTPError as error:
         if error.code in {401, 403}:
-            return _result("Yutori API", False, "credential rejected", remediation)
+            return report(False, "credential rejected")
         try:
             body = error.read()
             error_payload = json.loads(body.decode()) if isinstance(body, bytes) else {}
@@ -499,10 +510,10 @@ def check_api_access() -> CheckResult:
                     f"This build requests {MODEL!r}; use an environment where that model is enabled "
                     "or select a build configured for an available computer-use model."
                 )
-            return _result("Yutori API", False, message, remediation)
-        return _result("Yutori API", False, f"probe failed (HTTP {error.code})", remediation)
+            return report(False, message)
+        return report(False, f"probe failed (HTTP {error.code})")
     except (URLError, OSError, ValueError):
-        return _result("Yutori API", False, "unreachable", remediation)
+        return report(False, "unreachable")
 
     error = payload.get("error")
     if isinstance(error, dict):
@@ -513,10 +524,10 @@ def check_api_access() -> CheckResult:
             if "billing" in kind or "funds" in kind
             else remediation
         )
-        return _result("Yutori API", False, message, remediation)
+        return report(False, message)
     if not payload.get("choices"):
-        return _result("Yutori API", False, "no completion returned", remediation)
-    return _result("Yutori API", True, "computer-use model returned a completion", remediation)
+        return report(False, "no completion returned")
+    return report(True, "computer-use model returned a completion")
 
 
 _PLATFORM_CHECKS: tuple[Callable[[], CheckResult], ...] = (


### PR DESCRIPTION
## Structural issue

`check_runtime()` and `check_api_access()` in `preflight.py` each independently repeated their own check name and `remediation` string across every early-return branch:

```python
return _result("Python runtime", False, str(error), remediation)
...
return _result("Python runtime", False, detail, remediation)
...
return _result("Python runtime", ok, detail, remediation)
```

`check_runtime()` had 7 such call sites and `check_api_access()` had 8. This is exactly the kind of drift risk `_result()` itself already exists to prevent for every other check in this file (see its docstring/usage elsewhere) — but here the two arguments most likely to be copy-pasted wrong (the check's name, and its remediation string) were still spelled out at every return point instead of bound once.

## Fix

Each function now builds a small local `report(ok, detail) -> CheckResult` closure right after `remediation` is computed, binding the check name and remediation once:

```python
def report(ok: bool, detail: str) -> CheckResult:
    return _result("Python runtime", ok, detail, remediation)
```

All of that function's return points now call `report(ok, detail)` instead of respelling the name/remediation pair.

`check_api_access()`'s `remediation` is reassigned mid-function in two branches (`invalid_model`, billing); the closure reads it from the enclosing scope at call time, so both overrides still apply exactly as before (documented with a short comment at the closure definition).

## Why it's safe

- **No behavior change**: `report(ok, detail)` calls `_result(name, ok, detail, remediation)` with exactly the same arguments each call site passed before — pure extraction, no branching or condition changed.
- Full suite: 367 passed / 1 skipped (same as `main`), including the existing `check_runtime`/`check_api_access` branch tests in `tests/test_computer_use.py`.
- Small, contained diff: 1 file, +26/-15.

---
_Generated by [Claude Code](https://claude.ai/code/session_014f3sVv9Vi1VQivfqRBEBFJ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with identical `_result` arguments; preflight behavior is covered by existing computer-use tests.
> 
> **Overview**
> **Refactors** `check_runtime()` and `check_api_access()` in `preflight.py` so each defines a local `report(ok, detail)` closure that binds the check label (`"Python runtime"` / `"Yutori API"`) and the shared `remediation` once, instead of repeating them on every `_result(...)` return.
> 
> All failure and success paths in those two probes now call `report(...)` with only `ok` and `detail`. For **Yutori API**, a short comment documents that `remediation` is read at call time so mid-function overrides for `invalid_model` and billing errors still apply when `report` runs.
> 
> No branching, probe logic, or remediation text changes—pure deduplication to reduce copy-paste drift on check names and fix hints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a052df558f9f73f27bb0228f888e42aa73abdb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->