### PR TITLE
test(computer-use): extract _recording_dispatch() for the repeated --env dispatch stub

### DIFF
--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -11,6 +11,7 @@ import subprocess
 import sys
 import time
 import urllib.request
+from collections.abc import Callable
 from urllib.error import HTTPError
 from pathlib import Path
 from types import SimpleNamespace
@@ -135,15 +136,26 @@ def test_main_applies_explicit_environment_before_computer_use_registration(monk
     assert observed == ["prod"]
 
 
-def test_main_applies_explicit_environment_before_computer_use_dispatch(monkeypatch):
-    import yutori_mcp.computer_use.cli as computer_use_cli
-    from yutori_mcp import server
+def _recording_dispatch() -> tuple[dict[str, str | None], Callable[[str, object], int]]:
+    """A `dispatch`-shaped stub that records the ambient YUTORI_ENV it sees when called.
 
+    Shared by the three tests below pinning how `--env`/ambient YUTORI_ENV reaches
+    `computer_use.cli.dispatch` through server.main() and entrypoint._computer_use_main().
+    """
     observed: dict[str, str | None] = {}
 
     def record_dispatch(_command: str, _args: object) -> int:
         observed["environment"] = os.environ.get("YUTORI_ENV")
         return 0
+
+    return observed, record_dispatch
+
+
+def test_main_applies_explicit_environment_before_computer_use_dispatch(monkeypatch):
+    import yutori_mcp.computer_use.cli as computer_use_cli
+    from yutori_mcp import server
+
+    observed, record_dispatch = _recording_dispatch()
 
     monkeypatch.setenv("YUTORI_ENV", "prod")
     monkeypatch.setattr(sys, "argv", ["yutori-mcp", "--env", "dev", "computer-use", "doctor"])
@@ -159,11 +171,7 @@ def test_main_clears_ambient_environment_for_computer_use_without_explicit_env(m
     import yutori_mcp.computer_use.cli as computer_use_cli
     from yutori_mcp import server
 
-    observed: dict[str, str | None] = {}
-
-    def record_dispatch(_command: str, _args: object) -> int:
-        observed["environment"] = os.environ.get("YUTORI_ENV")
-        return 0
+    observed, record_dispatch = _recording_dispatch()
 
     monkeypatch.setenv("YUTORI_ENV", "dev")
     monkeypatch.setattr(sys, "argv", ["yutori-mcp", "computer-use", "doctor"])
@@ -183,11 +191,7 @@ def test_protected_entrypoint_applies_computer_use_environment(monkeypatch, argu
     import yutori_mcp.computer_use.cli as computer_use_cli
     from yutori_mcp import entrypoint
 
-    observed: dict[str, str | None] = {}
-
-    def record_dispatch(_command: str, _args: object) -> int:
-        observed["environment"] = os.environ.get("YUTORI_ENV")
-        return 0
+    observed, record_dispatch = _recording_dispatch()
 
     monkeypatch.setenv("YUTORI_ENV", ambient)
     monkeypatch.setattr(sys, "argv", ["yutori-mcp", *arguments, "computer-use", "doctor"])


### PR DESCRIPTION
## What

`tests/test_computer_use.py` had three tests independently defining the identical
`observed`/`record_dispatch` closure pair:

```python
observed: dict[str, str | None] = {}

def record_dispatch(_command: str, _args: object) -> int:
    observed["environment"] = os.environ.get("YUTORI_ENV")
    return 0
```

- `test_main_applies_explicit_environment_before_computer_use_dispatch`
- `test_main_clears_ambient_environment_for_computer_use_without_explicit_env`
- `test_protected_entrypoint_applies_computer_use_environment` (parametrized)

All three pin how `--env`/ambient `YUTORI_ENV` reaches `computer_use.cli.dispatch`
through `server.main()` and `entrypoint._computer_use_main()`, and all three used
the exact same stub to observe it.

## Why this is safe

- Test-only change; no production code touched.
- Pure extraction: `_recording_dispatch()` returns the same `observed` dict and the
  same `record_dispatch` closure shape, so each test's `monkeypatch.setattr(...,
  "dispatch", record_dispatch)` and subsequent assertions are byte-identical to
  before.
- Matches this file's established test-helper-extraction convention
  (`_run_supervised`, `_patch_smoke_preflight`, `_create_adapter_with_resolved_key`
  from prior PRs in this repo's history).
- No coverage change: same 3 call sites, same assertions.

## Verification

- `uv run pytest -q` → 367 passed, 1 skipped (matches the pre-change baseline exactly)
- `uv run ruff check .` → clean

🤖 Generated as part of an automated structural-refactor sweep.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KrFubpGVA7KmdRx4ZKunCU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tests-only deduplication with no runtime code touched.
> 
> **Overview**
> **Test-only refactor** in `tests/test_computer_use.py`: the duplicated `observed` / `record_dispatch` stub used to assert how `YUTORI_ENV` is set when `computer_use.cli.dispatch` runs is pulled into **`_recording_dispatch()`**, with a typed return and a short docstring.
> 
> The three environment-pinning tests (`server.main()` with explicit `--env`, clearing ambient env without `--env`, and `entrypoint._computer_use_main()` parametrized cases) now call that helper instead of redefining the same closure. An import of **`Callable`** from `collections.abc` supports the helper’s type hint.
> 
> **No production or assertion behavior changes**—same monkeypatches and expected `observed` values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e8d5311c091e19aaa29cd454b526d2c6f3b69bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->