### PR TITLE
test(computer-use): extract _patch_successful_driver_setup() for the repeated _setup() gate stubs

### DIFF
--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -928,15 +928,25 @@ def test_installer_checksum_aborts_before_execution(monkeypatch):
     run.assert_not_called()
 
 
-def test_setup_prepares_overlay_after_driver_permissions(monkeypatch, tmp_path):
-    from yutori_mcp.computer_use import cli
+def _patch_successful_driver_setup(monkeypatch, cli, tmp_path) -> None:
+    """Patch every _setup() gate before the overlay step so it always reaches that step.
 
+    Both overlay-outcome tests below need `_setup()` to sail through the runtime check,
+    installer download, checksum verification, and `find_cua_driver()` lookup identically;
+    only what happens at the overlay-preparation step differs between them.
+    """
     driver = tmp_path / "cua-driver"
     driver.write_text("")
     monkeypatch.setattr(cli, "check_runtime", lambda: preflight.CheckResult("runtime", True, "ok"))
     monkeypatch.setattr(cli, "_download_installer", lambda _: b"installer")
     monkeypatch.setattr(cli, "DRIVER_INSTALLER_SHA256", hashlib.sha256(b"installer").hexdigest())
     monkeypatch.setattr(cli, "find_cua_driver", lambda: driver)
+
+
+def test_setup_prepares_overlay_after_driver_permissions(monkeypatch, tmp_path):
+    from yutori_mcp.computer_use import cli
+
+    _patch_successful_driver_setup(monkeypatch, cli, tmp_path)
     prepared = SimpleNamespace(binary=tmp_path / "overlay")
     prepare = patch("yutori.navigator.macos.prepare_macos_overlay", return_value=prepared)
     with prepare as prepare_overlay, patch.object(cli.subprocess, "run"), patch.object(cli, "_doctor", return_value=0):
@@ -947,12 +957,7 @@ def test_setup_prepares_overlay_after_driver_permissions(monkeypatch, tmp_path):
 def test_setup_treats_overlay_file_errors_as_warnings(monkeypatch, tmp_path, capsys):
     from yutori_mcp.computer_use import cli
 
-    driver = tmp_path / "cua-driver"
-    driver.write_text("")
-    monkeypatch.setattr(cli, "check_runtime", lambda: preflight.CheckResult("runtime", True, "ok"))
-    monkeypatch.setattr(cli, "_download_installer", lambda _: b"installer")
-    monkeypatch.setattr(cli, "DRIVER_INSTALLER_SHA256", hashlib.sha256(b"installer").hexdigest())
-    monkeypatch.setattr(cli, "find_cua_driver", lambda: driver)
+    _patch_successful_driver_setup(monkeypatch, cli, tmp_path)
     with (
         patch("yutori.navigator.macos.prepare_macos_overlay", side_effect=OSError("read-only cache")),
         patch.object(cli.subprocess, "run"),


### PR DESCRIPTION
## What

`test_setup_prepares_overlay_after_driver_permissions` and `test_setup_treats_overlay_file_errors_as_warnings` in `tests/test_computer_use.py` each independently stubbed the identical five-call chain needed to get `cli._setup()` past its runtime/download/checksum/`find_cua_driver()` gates before reaching the overlay-preparation step each test actually exercises:

```python
driver = tmp_path / "cua-driver"
driver.write_text("")
monkeypatch.setattr(cli, "check_runtime", lambda: preflight.CheckResult("runtime", True, "ok"))
monkeypatch.setattr(cli, "_download_installer", lambda _: b"installer")
monkeypatch.setattr(cli, "DRIVER_INSTALLER_SHA256", hashlib.sha256(b"installer").hexdigest())
monkeypatch.setattr(cli, "find_cua_driver", lambda: driver)
```

Extracted into `_patch_successful_driver_setup(monkeypatch, cli, tmp_path)`, matching this file's established test-helper-extraction convention (`_patch_smoke_preflight`, `_run_supervised`, `_recording_dispatch`, all in the same file). Each test now calls the helper and keeps only the assertions/patches specific to its own overlay outcome.

## Why it's safe

- Test-only change; no production code touched, no behavior change.
- Both call sites' patched values are byte-identical before this change — the extraction just names the shared setup once.
- `uv run pytest -q`: **367 passed, 1 skipped** (unchanged from baseline before this change).
- `uv run ruff check .`: clean.
- (This repo's CI does not run `ruff format` — confirmed in `.github/workflows/test.yml`, which runs only `pytest` — so pre-existing formatting-only diffs elsewhere are out of scope here and untouched.)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RXEm9QWKVGV5VYgdPoiCf3)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only deduplication with identical stub values; no production code touched.
> 
> **Overview**
> Pulls duplicated monkeypatches out of **`test_setup_prepares_overlay_after_driver_permissions`** and **`test_setup_treats_overlay_file_errors_as_warnings`** into **`_patch_successful_driver_setup()`**, so both tests reach the overlay step with the same runtime/download/checksum/`find_cua_driver()` stubs.
> 
> Each test now only patches and asserts its own overlay behavior (success vs `OSError` warning). **Test-only refactor; no production or assertion behavior change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9f1b30b9ecb8de63e0a23e8773e15f4df1904db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->