### PR TITLE
test(credentials): extract _recording_auth_dispatch() for the repeated auth-command record stub

### DIFF
--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -11,11 +11,28 @@ import json
 import os
 import stat
 import sys
+from collections.abc import Callable
 from unittest.mock import patch
 
 import pytest
 
 from yutori_mcp import credentials
+
+
+def _recording_auth_dispatch() -> tuple[dict[str, object], Callable[..., None]]:
+    """A `_handle_auth_command`-shaped stub that records the command/environment it was called with.
+
+    Shared by the two tests below pinning how a plain `login` vs. an explicit `--env` flag
+    reaches `server._handle_auth_command` through `server.main()`.
+    """
+    seen: dict[str, object] = {}
+
+    def record(command, environment=None):
+        seen["command"] = command
+        seen["environment"] = environment
+        raise SystemExit(0)
+
+    return seen, record
 
 
 @pytest.fixture
@@ -115,12 +132,7 @@ def test_ambient_yutori_env_does_not_change_what_login_means(
     import yutori_mcp.server as server
 
     monkeypatch.setenv("YUTORI_ENV", "dev")
-    seen: dict[str, object] = {}
-
-    def record(command, environment=None):
-        seen["command"] = command
-        seen["environment"] = environment
-        raise SystemExit(0)
+    seen, record = _recording_auth_dispatch()
 
     monkeypatch.setattr(server, "_handle_auth_command", record)
     monkeypatch.setattr(sys, "argv", ["yutori-mcp", "login"])
@@ -133,11 +145,7 @@ def test_ambient_yutori_env_does_not_change_what_login_means(
 def test_an_explicit_env_flag_still_selects_the_environment(monkeypatch):
     import yutori_mcp.server as server
 
-    seen: dict[str, object] = {}
-
-    def record(command, environment=None):
-        seen["environment"] = environment
-        raise SystemExit(0)
+    seen, record = _recording_auth_dispatch()
 
     monkeypatch.setattr(server, "_handle_auth_command", record)
     monkeypatch.setattr(sys, "argv", ["yutori-mcp", "--env", "dev", "login"])


### PR DESCRIPTION
## What

`tests/test_credentials.py` had two tests independently defining the identical `record(command, environment=None)` closure that stubs `server._handle_auth_command` to capture what `server.main()` dispatches it, before raising `SystemExit(0)`:

- `test_ambient_yutori_env_does_not_change_what_login_means`
- `test_an_explicit_env_flag_still_selects_the_environment`

Extracted `_recording_auth_dispatch()` (returns `(seen, record)`) so both tests share one definition instead of hand-rolling it.

## Why this is safe

- Test-only change, no production code touched.
- This exactly matches an established, repeatedly-applied convention in this repo for the analogous case: `_recording_dispatch()` in `tests/test_computer_use.py` extracts the same shape of "record what a dispatch stub was called with, then raise SystemExit" closure for `computer_use.cli.dispatch`. This PR applies the same pattern to `server._handle_auth_command`, which had drifted into duplicating the closure by hand instead.
- No coverage change — both tests assert exactly what they did before (`test_ambient_yutori_env_does_not_change_what_login_means` checks both `command` and `environment`; `test_an_explicit_env_flag_still_selects_the_environment` checks only `environment`), and the shared helper always records both fields so neither test loses information.
- Verified: `uv run pytest -q` → 367 passed, 1 skipped (unchanged from baseline), `uv run ruff check .` clean, `uv run ruff format --check tests/test_credentials.py` clean.

Co-authored-by: Claude <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_016YDRkCQHKMrVQoMWT7ECFP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only deduplication with unchanged assertions and no runtime behavior changes.
> 
> **Overview**
> **Test refactor only** — no production code changes.
> 
> Duplicates the same “record `_handle_auth_command` args then `SystemExit(0)`” stub that lived inline in `test_ambient_yutori_env_does_not_change_what_login_means` and `test_an_explicit_env_flag_still_selects_the_environment` into a shared `_recording_auth_dispatch()` helper (same idea as `_recording_dispatch()` in `test_computer_use.py`). Both tests now call the helper and keep their original assertions; the shared stub always records `command` and `environment`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 485bf846729092a32fb698cbacd0d52b466f32d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->