### PR TITLE
feat(computer-use): move the pinned CuaDriver to 0.23.2

### DIFF
--- a/skills/06-computer-use/SKILL.md
+++ b/skills/06-computer-use/SKILL.md
@@ -27,7 +27,7 @@ uvx yutori-mcp computer-use smoke
 ```
 
 Requirements: macOS 15+, Python 3.10+, `uvx`, a Yutori API key with computer-use access,
-`CuaDriver.app` / `cua-driver==0.19.3`, and Screen Recording plus Accessibility permissions.
+`CuaDriver.app` / `cua-driver==0.23.2`, and Screen Recording plus Accessibility permissions.
 The optional native reasoning overlay may require Xcode Command Line Tools.
 
 ## Run a Task

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -23,5 +23,5 @@ SDK_PROVENANCE_SHA256 = "aa3c8b58281f0dcde3446cc87cfd8b9c4e57b6c5e0b2be56450eef3
 
 # The cua-driver release that implements this tool contract, and the checksum
 # of its installer script. Both are hard gates.
-DRIVER_VERSION = "0.19.3"
-DRIVER_INSTALLER_SHA256 = "52293f8683c6c41ef8df0bb17907f3bd9266314e04f7b0c8f3c4576e7ba139f7"
+DRIVER_VERSION = "0.23.2"
+DRIVER_INSTALLER_SHA256 = "317ba3a49fdba10f2a7f1b9f392c1bc1b7657f3aae85e1e2e43684cf17a1bf3b"


### PR DESCRIPTION
## Summary
- bump `DRIVER_VERSION` 0.19.3 → 0.23.2 and `DRIVER_INSTALLER_SHA256` to the 0.23.2 release `install.sh` digest (identical from 0.20.0 through 0.23.2)
- update the computer-use skill's requirements line

## Compatibility
Checked offline with `cua-driver describe` on both releases for every tool the SDK transport (`yutori.navigator.macos`) and `app.py` invoke: `start_session`, `end_session`, `get_desktop_state`, `click`, `double_click`, `drag`, `scroll`, `type_text`, `press_key`, `hotkey`, `move_cursor`, `launch_app`, `bring_to_front`, `list_windows`, recording and cursor tools. No field removed, nothing newly required; `start_session.capture_scope` is deprecated but accepted. The only breaking upstream change in the range (#3185) removed the `browser-approve` flow, which this runtime never used.

## What 0.23.2 brings
- TCC grants preserved across release updates (trycua/cua#3297)
- daemon stays up during the permission gate instead of re-exec looping (trycua/cua#3314)
- correct Retina backing scale in `get_screen_size` / `get_desktop_state` (trycua/cua#3328)
- verified-foreground input guard for pid-targeted keyboard delivery (trycua/cua#3068); note the SDK's desktop-scope actions do not exercise it yet

## Verification
- `uv run pytest`: 367 passed, 1 skipped
- `computer-use setup` on macOS 27.0 arm64 upgraded 0.19.3 → 0.23.2 in place; Accessibility, Screen Recording and direct-capture grants survived without a prompt; doctor all PASS incl. desktop capture
- `computer-use smoke` on prod: mechanical check + agent run completed (9 × 9 = 81, 4 steps, 43 s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumps a hard-gated native driver dependency used for desktop automation; behavior changes (TCC, Retina scaling, input guards) affect all computer-use runs after upgrade.
> 
> **Overview**
> **Pins the macOS computer-use stack to `cua-driver` / `CuaDriver.app` 0.23.2** by updating `DRIVER_VERSION` and the matching `DRIVER_INSTALLER_SHA256` gate in `constants.py`, so setup, doctor, and install flows only accept that release.
> 
> The computer-use skill requirements line is updated to document **`cua-driver==0.23.2`** for agents and users running `uvx yutori-mcp computer-use setup`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 677034dfc69e10996766ff6e2580407ce9131c03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->