### PR TITLE
feat(computer-use): pin the yutori SDK runtime at 0.9.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.6"
+version = "0.5.7"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"
@@ -30,9 +30,9 @@ dependencies = [
     # breaks the install as soon as 2.x resolves.
     "mcp>=1.0.0,<2.0.0",
     "pydantic>=2.0.0",
-    # SDK 0.9.2 owns the complete Python/Swift macOS runtime. Doctor verifies
+    # SDK 0.9.9 owns the complete Python/Swift macOS runtime. Doctor verifies
     # the installed payload against the exact published wheel before use.
-    "yutori==0.9.2",
+    "yutori==0.9.9",
 ]
 
 [project.optional-dependencies]

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -14,12 +14,12 @@ TOOL_SET = "computer_use_tools-20260815"
 # so a future second mode can't be introduced with one of those spots left on the old
 # literal by accident.
 DELIVERY_MODE_FOREGROUND = "foreground"
-SDK_VERSION = "0.9.2"
+SDK_VERSION = "0.9.9"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.
-SDK_ARTIFACT_SHA256 = "bb2de3d77e73be6abe8e27663e425518dc6fe0170502a7337c5b59456a9e8cad"
-SDK_INSTALLATION_SHA256 = "19af218c916ad34efd8212377ed9b540b87b825fda8e42b98066f8bd723f7d64"
-SDK_PROVENANCE_SHA256 = "aa3c8b58281f0dcde3446cc87cfd8b9c4e57b6c5e0b2be56450eef33c09dd59c"
+SDK_ARTIFACT_SHA256 = "c1e64663033eb3a6550d6b3af8de331825ebdf5e8ecb7f39575b9544a1b59908"
+SDK_INSTALLATION_SHA256 = "5309391db4d8af899cc84f517969545faf75e8878f04d9278d5af8ed9ded0be6"
+SDK_PROVENANCE_SHA256 = "7cab595d2f00e1a9ab5cd121204fbd6dd4c24163ead3eb76f76eef7fba495fc4"
 
 # The cua-driver release that implements this tool contract, and the checksum
 # of its installer script. Both are hard gates.

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -698,9 +698,9 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 
 def test_runtime_constants_select_latest_python_surface():
     assert TOOL_SET == "computer_use_tools-20260815"
-    assert SDK_VERSION == "0.9.2"
+    assert SDK_VERSION == "0.9.9"
     assert all(len(digest) == 64 for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256))
-    assert '"yutori==0.9.2"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
+    assert '"yutori==0.9.9"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
 
 
 def test_installed_sdk_matches_the_published_artifact():

--- a/uv.lock
+++ b/uv.lock
@@ -260,7 +260,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1359,8 +1359,8 @@ name = "uvicorn"
 version = "0.52.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
@@ -1370,7 +1370,7 @@ wheels = [
 
 [[package]]
 name = "yutori"
-version = "0.9.2"
+version = "0.9.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1379,14 +1379,14 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/45/d4e0f47c4ddc414bfa16c691cefa13a6ebe5c76795a7a0528b96c7f74955/yutori-0.9.2.tar.gz", hash = "sha256:5dfdff8c77e6883dc4764133bd7a6d30a23af4f9e1a6d1e1e25590d97a1ef977", size = 309809, upload-time = "2026-08-25T20:44:37.98Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/47/8d7e40e038ae40ac895effcd72fa480a45d8f4d906c7e81655935e91e2af/yutori-0.9.9.tar.gz", hash = "sha256:a8c5ed2a0423ac9e328a252548663a729828c9db8340becc2f16cfdfd20a2b6c", size = 406215, upload-time = "2026-09-01T22:15:43.818Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/b2/0d03b21d2d281f63d8e5190ac22c7d1d834d5c65eee212c12278264ff8ab/yutori-0.9.2-py3-none-any.whl", hash = "sha256:bb2de3d77e73be6abe8e27663e425518dc6fe0170502a7337c5b59456a9e8cad", size = 250746, upload-time = "2026-08-25T20:44:36.397Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/88/c4c90e3ca9b91f2869b2150b0538a667331d0d1a28e1ef60f9f67eee1c9a/yutori-0.9.9-py3-none-any.whl", hash = "sha256:c1e64663033eb3a6550d6b3af8de331825ebdf5e8ecb7f39575b9544a1b59908", size = 289038, upload-time = "2026-09-01T22:15:42.434Z" },
 ]
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.6"
+version = "0.5.7"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -1406,6 +1406,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "yutori", specifier = "==0.9.2" },
+    { name = "yutori", specifier = "==0.9.9" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
## Summary
- `yutori==0.9.2` → `0.9.9` in `pyproject.toml` (+ `uv.lock`), `SDK_VERSION` and the three doctor digests in `constants.py`, the two test expectations, package version 0.5.6 → 0.5.7
- digests computed from the published `yutori-0.9.9-py3-none-any.whl` with `preflight._stable_distribution_digest` and `_provenance_path`, and `check_runtime()` PASSes against that install

## Why
SDK 0.9.9 ships the frontmost focus guard in `MacOSComputer` (yutori-ai/yutori-sdk-python#346): keystrokes are withheld with a fresh frame when the frontmost app changed since the model's last screenshot, instead of typing into whatever window took focus. It also aligns the SDK's `macos` extra with the cua-driver 0.23.2 this package installs since #235.

## Verification
- `uv run pytest`: 367 passed, 1 skipped
- `check_runtime()` against the installed 0.9.9 wheel: PASS
- live `computer-use doctor` + `smoke` on macOS 27 / cua-driver 0.23.2: results posted in a comment below

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Pins the desktop automation SDK and tightens preflight artifact checks; behavior of typing/focus on macOS changes with 0.9.9, but scope is limited to version constants, lockfile, and tests.
> 
> **Overview**
> Bumps the pinned **`yutori`** dependency from **0.9.2** to **0.9.9** and releases **`yutori-mcp` 0.5.7** so computer-use runs against the newer macOS runtime (including the frontmost-app focus guard before keystrokes).
> 
> **`SDK_VERSION`** and the three doctor **SHA256** digests in `constants.py` are updated to match the published **0.9.9** wheel; **`pyproject.toml`**, **`uv.lock`**, and **`test_runtime_constants_select_latest_python_surface`** expectations stay in sync. No application logic changes beyond the version pin and lockfile resolution tweaks (e.g. transitive markers on `exceptiongroup` / `uvicorn`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c768efa6441246c82bd1e4ded71d47a52fd352f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->