### PR TITLE
test(computer-use): extract _stub_process_group_stop() for the repeated stop-closure stub

### DIFF
--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -318,6 +318,19 @@ async def _run_supervised(process, *, api_key="yt-key", deadline_seconds=1, **su
         )
 
 
+def _stub_process_group_stop(process) -> Callable[[Any], Any]:
+    """`side_effect` for a patched `_stop_process_group` that marks `process` SIGTERM'd.
+
+    Stands in for the real stop path so tests can force `_supervise` to observe a terminated
+    child without actually spawning a process group to signal.
+    """
+
+    async def stop(_process):
+        process.returncode = -signal.SIGTERM
+
+    return stop
+
+
 async def test_supervisor_redacts_key_and_keeps_it_out_of_argv():
     secret = "yt-super-secret-value"
     process = _Process(
@@ -405,12 +418,9 @@ async def test_supervisor_rejects_runner_provenance_drift():
         _stream(""),
     )
 
-    async def stop(_process):
-        process.returncode = -signal.SIGTERM
-
     with (
         patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)),
-        patch("yutori_mcp.computer_use.supervisor._stop_process_group", side_effect=stop),
+        patch("yutori_mcp.computer_use.supervisor._stop_process_group", side_effect=_stub_process_group_stop(process)),
     ):
         result = await _supervise(
             command=python_runner_command(),
@@ -529,12 +539,12 @@ async def test_stop_process_group_escalates_to_kill():
 async def test_supervisor_stdout_deadline_returns_limit_and_stops_group():
     process = _Process(asyncio.StreamReader(), asyncio.StreamReader())
 
-    async def stop(_process):
-        process.returncode = -signal.SIGTERM
-
     with (
         patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)),
-        patch("yutori_mcp.computer_use.supervisor._stop_process_group", side_effect=stop) as stopped,
+        patch(
+            "yutori_mcp.computer_use.supervisor._stop_process_group",
+            side_effect=_stub_process_group_stop(process),
+        ) as stopped,
     ):
         result = await _supervise(
             command=python_runner_command(),
@@ -552,13 +562,13 @@ async def test_supervisor_eof_does_not_bypass_the_deadline():
     async def wait_forever():
         await asyncio.Future()
 
-    async def stop(_process):
-        process.returncode = -signal.SIGTERM
-
     process.wait = wait_forever
     with (
         patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)),
-        patch("yutori_mcp.computer_use.supervisor._stop_process_group", side_effect=stop) as stopped,
+        patch(
+            "yutori_mcp.computer_use.supervisor._stop_process_group",
+            side_effect=_stub_process_group_stop(process),
+        ) as stopped,
     ):
         result = await _supervise(
             command=python_runner_command(),
@@ -573,12 +583,12 @@ async def test_supervisor_eof_does_not_bypass_the_deadline():
 async def test_supervisor_cancellation_is_aborted_and_stops_group():
     process = _Process(asyncio.StreamReader(), asyncio.StreamReader())
 
-    async def stop(_process):
-        process.returncode = -signal.SIGTERM
-
     with (
         patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)),
-        patch("yutori_mcp.computer_use.supervisor._stop_process_group", side_effect=stop) as stopped,
+        patch(
+            "yutori_mcp.computer_use.supervisor._stop_process_group",
+            side_effect=_stub_process_group_stop(process),
+        ) as stopped,
     ):
         task = asyncio.create_task(
             _supervise(


### PR DESCRIPTION
## What

Four tests in `tests/test_computer_use.py` — `test_supervisor_rejects_runner_provenance_drift`,
`test_supervisor_stdout_deadline_returns_limit_and_stops_group`,
`test_supervisor_eof_does_not_bypass_the_deadline`, and
`test_supervisor_cancellation_is_aborted_and_stops_group` — each independently defined the
identical closure:

```python
async def stop(_process):
    process.returncode = -signal.SIGTERM
```

used as the `side_effect` for a patched `yutori_mcp.computer_use.supervisor._stop_process_group`,
so `_supervise()` observes the child as SIGTERM'd once the (mocked) stop path runs.

## Why it's an improvement

This is the same shape this file has already consolidated repeatedly (`_run_supervised`,
`_recording_dispatch`, `_patch_successful_driver_setup`, `_patch_smoke_preflight`): a small stub
closure duplicated verbatim across several tests. Extracted `_stub_process_group_stop(process)`
next to the existing `_run_supervised()` helper — each call site now does
`patch(..., side_effect=_stub_process_group_stop(process))` instead of redefining the closure.

## Why it's safe

- Test-only change, no production code touched.
- Behavior-preserving: each of the 4 tests keeps its own `with patch(...)` block (some capture
  `as stopped` and assert on it, one doesn't), only the closure definition is now shared.
- Full suite: `uv run --extra dev pytest -q` → 367 passed, 1 skipped (matches the documented
  baseline exactly).
- `uv run ruff check .` clean (no `[tool.ruff]` config / lint step exists in this repo's CI, so
  `ruff format` drift is pre-existing and out of scope, per this repo's own established
  convention).
- Scoped to 1 file, +26/-16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EstrUP5XQtTE98yeVMJ1Uo

---
_Generated by [Claude Code](https://claude.ai/code/session_01EstrUP5XQtTE98yeVMJ1Uo)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only deduplication with no production code changes; behavior of the four tests is preserved.
> 
> **Overview**
> **Test-only refactor** in `tests/test_computer_use.py`: adds shared helper `_stub_process_group_stop(process)` next to `_run_supervised()`, matching other consolidated stubs in this file.
> 
> Four supervisor tests that patch `_stop_process_group` no longer each define the same inline async closure that sets `process.returncode = -signal.SIGTERM`. They now use `side_effect=_stub_process_group_stop(process)` instead. Assertions and per-test `patch` blocks (including `as stopped` where used) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d177f7fa7a17991586b6f3cffc145ac0dc9ec7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->