### PR TITLE
refactor(computer-use): dedupe the outcome-to-exit-code mapping in cli.py

### DIFF
--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -8,6 +8,7 @@ import subprocess
 import tempfile
 import uuid
 from pathlib import Path
+from typing import Any
 from urllib.request import urlopen
 
 from ..schemas import (
@@ -100,6 +101,12 @@ def _blocked() -> bool:
     return True
 
 
+def _report(result: dict[str, Any]) -> int:
+    """Print the formatted run result and derive the process exit code from its outcome."""
+    print(format_result(result))
+    return 0 if result.get("outcome") == "completed" else 1
+
+
 async def _mechanical_calculator_check() -> str:
     from yutori.navigator.macos import MacOSComputer
     from yutori.navigator.macos.transport import CuaDriverTransport
@@ -177,8 +184,7 @@ async def _smoke_live() -> int:
     except ComputerUseBusyError as error:
         print(error)
         return 1
-    print(format_result(result))
-    return 0 if result.get("outcome") == "completed" else 1
+    return _report(result)
 
 
 async def _print_event(event: dict) -> None:
@@ -217,8 +223,7 @@ async def _run_custom(args: argparse.Namespace) -> int:
         api_base_url=api_base_url,
         on_event=_print_event,
     )
-    print(format_result(result))
-    return 0 if result.get("outcome") == "completed" else 1
+    return _report(result)
 
 
 def apply_computer_use_environment(env: str | None) -> None:


### PR DESCRIPTION
## What

`_smoke_live()` and `_run_custom()` in `src/yutori_mcp/computer_use/cli.py` each ended with the identical two-line block:

```python
print(format_result(result))
return 0 if result.get("outcome") == "completed" else 1
```

Extracted into a small `_report(result)` helper and replaced both call sites with `return _report(result)`.

## Why it's an improvement

This is the same "outcome → exit code" mapping duplicated verbatim between the two CLI entry points. Without a shared home, a future change to what counts as success (or to the print format) can be made at one call site and silently missed at the other — the same rationale behind this repo's many prior extractions (`terminal_result()`, `_result_event()`, `_error_event()`, etc.).

## Why it's safe

- Purely mechanical extraction — byte-identical output and return value for every input.
- Single file, two call sites, ~6 lines touched.
- `ruff check` passes; `ast.parse` confirms valid syntax.

No behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UGqnWXAYncR2yE1r9PNALn

---
_Generated by [Claude Code](https://claude.ai/code/session_01UGqnWXAYncR2yE1r9PNALn)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor in one file with identical control flow and I/O; no auth, data, or runtime logic changes.
> 
> **Overview**
> **Deduplicates** how smoke and custom run commands finish: both previously printed `format_result(result)` and returned exit code `0` only when `outcome == "completed"`.
> 
> A new **`_report(result)`** helper owns that behavior; **`_smoke_live()`** and **`_run_custom()`** now end with `return _report(result)`. Adds a **`dict[str, Any]`** type hint for the result dict.
> 
> **No behavior change** — same printed output and exit codes as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05450b30ff4b8246b912a5cb97b00860437c2e0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->