### PR TITLE
Extract _patched_process_group_stop() for repeated supervisor test setup

### DIFF
--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -12,6 +12,7 @@ import sys
 import time
 import urllib.request
 from collections.abc import Callable
+from contextlib import contextmanager
 from urllib.error import HTTPError
 from pathlib import Path
 from types import SimpleNamespace
@@ -331,6 +332,25 @@ def _stub_process_group_stop(process) -> Callable[[Any], Any]:
     return stop
 
 
+@contextmanager
+def _patched_process_group_stop(process):
+    """Patch subprocess spawn and `_stop_process_group` for one `_supervise` call.
+
+    Covers the tests below that need both `_supervise`'s child process replaced with
+    `process` *and* the process-group stop path observed or stubbed -- `_run_supervised`
+    above only covers the simpler case that leaves `_stop_process_group` unpatched.
+    Yields the `_stop_process_group` mock so callers can assert on it.
+    """
+    with (
+        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)),
+        patch(
+            "yutori_mcp.computer_use.supervisor._stop_process_group",
+            side_effect=_stub_process_group_stop(process),
+        ) as stopped,
+    ):
+        yield stopped
+
+
 async def test_supervisor_redacts_key_and_keeps_it_out_of_argv():
     secret = "yt-super-secret-value"
     process = _Process(
@@ -418,10 +438,7 @@ async def test_supervisor_rejects_runner_provenance_drift():
         _stream(""),
     )
 
-    with (
-        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)),
-        patch("yutori_mcp.computer_use.supervisor._stop_process_group", side_effect=_stub_process_group_stop(process)),
-    ):
+    with _patched_process_group_stop(process):
         result = await _supervise(
             command=python_runner_command(),
             request={"type": "run"},
@@ -539,13 +556,7 @@ async def test_stop_process_group_escalates_to_kill():
 async def test_supervisor_stdout_deadline_returns_limit_and_stops_group():
     process = _Process(asyncio.StreamReader(), asyncio.StreamReader())
 
-    with (
-        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)),
-        patch(
-            "yutori_mcp.computer_use.supervisor._stop_process_group",
-            side_effect=_stub_process_group_stop(process),
-        ) as stopped,
-    ):
+    with _patched_process_group_stop(process) as stopped:
         result = await _supervise(
             command=python_runner_command(),
             request={"type": "run"},
@@ -563,13 +574,7 @@ async def test_supervisor_eof_does_not_bypass_the_deadline():
         await asyncio.Future()
 
     process.wait = wait_forever
-    with (
-        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)),
-        patch(
-            "yutori_mcp.computer_use.supervisor._stop_process_group",
-            side_effect=_stub_process_group_stop(process),
-        ) as stopped,
-    ):
+    with _patched_process_group_stop(process) as stopped:
         result = await _supervise(
             command=python_runner_command(),
             request={"type": "run"},
@@ -583,13 +588,7 @@ async def test_supervisor_eof_does_not_bypass_the_deadline():
 async def test_supervisor_cancellation_is_aborted_and_stops_group():
     process = _Process(asyncio.StreamReader(), asyncio.StreamReader())
 
-    with (
-        patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)),
-        patch(
-            "yutori_mcp.computer_use.supervisor._stop_process_group",
-            side_effect=_stub_process_group_stop(process),
-        ) as stopped,
-    ):
+    with _patched_process_group_stop(process) as stopped:
         task = asyncio.create_task(
             _supervise(
                 command=python_runner_command(),


### PR DESCRIPTION
## What

`tests/test_computer_use.py` had four tests each independently building the identical patch block:

```python
with (
    patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)),
    patch(
        "yutori_mcp.computer_use.supervisor._stop_process_group",
        side_effect=_stub_process_group_stop(process),
    ) as stopped,
):
    ...
```

- `test_supervisor_rejects_runner_provenance_drift`
- `test_supervisor_stdout_deadline_returns_limit_and_stops_group`
- `test_supervisor_eof_does_not_bypass_the_deadline`
- `test_supervisor_cancellation_is_aborted_and_stops_group`

These four are the "left inline" tests noted in a prior extraction's commit message (#222): `_run_supervised()` already consolidates the simpler `_supervise()` test setup, but it only patches `asyncio.create_subprocess_exec` — it has no way to also patch/capture `supervisor._stop_process_group`, which these four tests need (to observe or stub the process-group stop path).

## Change

Extracted `_patched_process_group_stop(process)` as a `@contextmanager` that patches both `asyncio.create_subprocess_exec` and `supervisor._stop_process_group`, yielding the `_stop_process_group` mock. Each of the four sites now does `with _patched_process_group_stop(process):` (or `as stopped:` where the mock is asserted on), matching this file's established test-helper-extraction convention (`_run_supervised`, `_patch_smoke_preflight`).

Test-only, no behavior change — identical patches applied at each site, identical mock returned/asserted on. 1 file, +24/-25.

## Why it's safe

- No production code touched.
- Each call site's assertions are unchanged; only the patch setup is now shared.
- `uv run --extra dev pytest -q` → **367 passed, 1 skipped** (matches the documented repo baseline exactly).
- `ruff check .` → clean.

## Out of scope / not verified

- No lint/format enforcement exists in this repo's CI (only the pytest matrix + a wheel-install smoke check), so this was verified with `ruff check .` ad hoc rather than as a CI-enforced gate — consistent with prior runs' verification in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GhPTg2538XDHBcYPEqHWph


---
_Generated by [Claude Code](https://claude.ai/code/session_01GhPTg2538XDHBcYPEqHWph)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only deduplication of mock setup with no runtime or behavior changes.
> 
> **Overview**
> **Test refactor only** — adds a `_patched_process_group_stop(process)` context manager in `tests/test_computer_use.py` so supervisor tests that need both a mocked child process and a stubbed `_stop_process_group` share one setup block.
> 
> Four tests (`provenance drift`, stdout deadline/limit, EOF vs deadline, cancellation) now use `with _patched_process_group_stop(process)` (or `as stopped` where they assert the stop mock). This complements `_run_supervised`, which only patches `create_subprocess_exec` and cannot capture process-group teardown.
> 
> No production code changes; patch targets and assertions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 271a29a7fec456a82180753a06957dba49ebf9d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->