### PR TITLE
test(server): dedupe the failed-login test setup

### DIFF
--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -210,6 +210,21 @@ class TestMainAuthDispatch:
         assert calls == [(name, None)]
 
 
+def _run_failed_login(capsys, result: LoginResult) -> str:
+    """Dispatch `yutori-mcp login` with `run_login_flow` stubbed to fail with `result`.
+
+    Asserts the shared exit-code and call-arg contract every failed-login test relies
+    on, then returns the captured stdout for the caller's own assertions.
+    """
+    with (
+        patch("sys.argv", ["yutori-mcp", "login"]),
+        patch("yutori.auth.run_login_flow", return_value=result) as mock_run_login_flow,
+    ):
+        _assert_main_exits(1)
+    mock_run_login_flow.assert_called_once_with(key_source="yutori-mcp")
+    return capsys.readouterr().out
+
+
 class TestMainLoginAuthUrl:
     """Ensure `yutori-mcp login` surfaces auth_url on failure."""
 
@@ -219,28 +234,12 @@ class TestMainLoginAuthUrl:
             error="timed out",
             auth_url="https://clerk.example.com/oauth/authorize?x=1",
         )
-        with (
-            patch("sys.argv", ["yutori-mcp", "login"]),
-            patch(
-                "yutori.auth.run_login_flow", return_value=result
-            ) as mock_run_login_flow,
-        ):
-            _assert_main_exits(1)
-        mock_run_login_flow.assert_called_once_with(key_source="yutori-mcp")
-        output = capsys.readouterr().out
+        output = _run_failed_login(capsys, result)
         assert "https://clerk.example.com/oauth/authorize?x=1" in output
 
     def test_login_failure_without_auth_url(self, capsys):
         result = LoginResult(success=False, error="port in use")
-        with (
-            patch("sys.argv", ["yutori-mcp", "login"]),
-            patch(
-                "yutori.auth.run_login_flow", return_value=result
-            ) as mock_run_login_flow,
-        ):
-            _assert_main_exits(1)
-        mock_run_login_flow.assert_called_once_with(key_source="yutori-mcp")
-        output = capsys.readouterr().out
+        output = _run_failed_login(capsys, result)
         assert "browser" not in output.lower()
 
 


### PR DESCRIPTION
## What

`TestMainLoginAuthUrl`'s two tests (`test_login_failure_prints_auth_url` and
`test_login_failure_without_auth_url`) each independently built the identical
setup block: patch `sys.argv` for `login`, patch `yutori.auth.run_login_flow`
to return a `LoginResult`, assert `main()` exits 1, then assert
`run_login_flow` was called once with `key_source="yutori-mcp"`. Only the
`LoginResult` passed in and the final output assertion differed.

Extracted `_run_failed_login(capsys, result)`, matching this file's existing
`_assert_main_exits()` helper convention for shared test scaffolding. Both
tests now build their `LoginResult`, call the helper, and assert on the
returned stdout.

## Why this is an improvement

Same failure-dispatch contract in two places means a change to how a failed
login is dispatched or asserted (e.g. the `key_source` value, or the exit
code) has to be kept in sync by hand in both tests. The helper makes it a
single source of truth.

## Why this is safe

- Test-only change, no production code touched.
- No coverage change — both cases are still exercised independently, with
  their own distinct output assertions.
- `uv run pytest -q` — 367 passed, 1 skipped (matches the pre-change
  baseline exactly).
- `uv run ruff check .` — clean.
- `uv run ruff format --check tests/test_server.py` — clean (ran `ruff
  format` on the touched file so the extracted helper matches the file's
  existing formatting).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CSTTseUJXvqPmCofkngZEF

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSTTseUJXvqPmCofkngZEF)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production code changes; behavior and coverage for both failure cases are unchanged.
> 
> **Overview**
> Refactors **`TestMainLoginAuthUrl`** by extracting **`_run_failed_login(capsys, result)`**, which centralizes the shared failed `yutori-mcp login` dispatch: argv patching, stubbing **`run_login_flow`** with a given **`LoginResult`**, asserting exit code **1**, and verifying **`key_source="yutori-mcp"`**.
> 
> The two tests now only construct their **`LoginResult`** and assert on stdout (auth URL present vs. no browser messaging), matching the existing **`_assert_main_exits`** helper style.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd9d41d2e2c8a6ff8874f8d1ccda49f14f87cf84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->