### PR TITLE
Link computer-use results to the run's platform chat page

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -39,6 +39,7 @@ Example response:
 ```
 Outcome: completed
 Delivery mode: foreground
+Run: https://platform.yutori.com/navigator/chats/5d90f532-6c0f-4159-8e46-2ce55e7084c9
 Final text: 17 * 23 = 391
 Elapsed: 18452 ms
 Perf: total 18.5s over 6 steps (3.1s/step)
@@ -48,6 +49,9 @@ Actions:
 ```
 
 `Outcome` is `completed`, `limit` (hit `minutes` or `max_steps`), `aborted`, or `failed`.
+`Run` links to the run's page on the Yutori platform (platform.yutori.com, or
+platform.dev.yutori.com when `--env dev` is selected); it is omitted when the run ended
+before the model was called.
 
 | Parameter | Required | Description |
 |-----------|----------|-------------|

--- a/src/yutori_mcp/adapter.py
+++ b/src/yutori_mcp/adapter.py
@@ -31,6 +31,13 @@ ENVIRONMENT_BASE_URLS: dict[str, str] = {
 DEFAULT_ENVIRONMENT = "prod"
 ENV_VAR_ENVIRONMENT = "YUTORI_ENV"
 
+# The developer platform that shows each Navigator run, keyed like ENVIRONMENT_BASE_URLS
+# so a run made against the dev API links to the dev platform and never the other way round.
+ENVIRONMENT_PLATFORM_URLS: dict[str, str] = {
+    "prod": "https://platform.yutori.com",
+    "dev": "https://platform.dev.yutori.com",
+}
+
 
 def current_environment() -> str:
     """The environment name this process is targeting."""
@@ -50,6 +57,22 @@ def resolve_base_url(environment: str | None = None) -> str:
         return ENVIRONMENT_BASE_URLS[name]
     except KeyError:
         valid = ", ".join(sorted(ENVIRONMENT_BASE_URLS))
+        raise ValueError(
+            f"Unknown Yutori environment {name!r}; expected one of: {valid}"
+        ) from None
+
+
+def resolve_platform_url(environment: str | None = None) -> str:
+    """Return the developer-platform URL for an environment name.
+
+    Same resolution order as ``resolve_base_url`` so the run link a computer-use
+    result carries always points at the platform that recorded the run.
+    """
+    name = environment or current_environment()
+    try:
+        return ENVIRONMENT_PLATFORM_URLS[name]
+    except KeyError:
+        valid = ", ".join(sorted(ENVIRONMENT_PLATFORM_URLS))
         raise ValueError(
             f"Unknown Yutori environment {name!r}; expected one of: {valid}"
         ) from None

--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -151,7 +151,7 @@ async def _mechanical_calculator_check() -> str:
 
 
 async def _smoke_live() -> int:
-    from ..adapter import resolve_run_credentials
+    from ..adapter import resolve_platform_url, resolve_run_credentials
 
     try:
         with DesktopLock() as lock:
@@ -179,6 +179,7 @@ async def _smoke_live() -> int:
                 max_steps=10,
                 api_key=api_key,
                 api_base_url=api_base_url,
+                platform_url=resolve_platform_url(),
                 lock=lock,
             )
     except ComputerUseBusyError as error:
@@ -200,7 +201,7 @@ async def _print_event(event: dict) -> None:
 
 
 async def _run_custom(args: argparse.Namespace) -> int:
-    from ..adapter import resolve_run_credentials
+    from ..adapter import resolve_platform_url, resolve_run_credentials
 
     # Reuses the MCP tool's input schema so the CLI enforces the same bounds
     # (minutes 1-60, positive steps, start_url requires app) with the same
@@ -221,6 +222,7 @@ async def _run_custom(args: argparse.Namespace) -> int:
         **params.model_dump(),
         api_key=api_key,
         api_base_url=api_base_url,
+        platform_url=resolve_platform_url(),
         on_event=_print_event,
     )
     return _report(result)

--- a/src/yutori_mcp/computer_use/result.py
+++ b/src/yutori_mcp/computer_use/result.py
@@ -94,6 +94,8 @@ def format_result(result: dict[str, Any]) -> str:
         f"Outcome: {result.get('outcome', 'failed')}",
         f"Delivery mode: {result.get('delivery_mode', DELIVERY_MODE_FOREGROUND)}",
     ]
+    if result.get("run_url"):
+        lines.append(f"Run: {result['run_url']}")
     if result.get("final_text"):
         lines.append(f"Final text: {result['final_text']}")
     if result.get("elapsed_ms") is not None:

--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -210,10 +210,12 @@ class ActionReporter:
         run_start: float,
         *,
         clock: Callable[[], float] = time.monotonic,
+        chat: ChatTracker | None = None,
     ) -> None:
         self._emitter = emitter
         self._run_start = run_start
         self._clock = clock
+        self._chat = chat
         self._index = 0
         self._call_start: float | None = None
         self._pending_item: dict[str, Any] | None = None
@@ -255,6 +257,9 @@ class ActionReporter:
                 "command": shell_command_preview(item),
                 "run_in_background": run_in_background,
                 "background_task_id": _background_task_id(result) if run_in_background else None,
+                # Carried on every action so the supervisor can still link the run when it
+                # has to conclude the run itself and never sees the runner's result event.
+                "chat_id": self._chat.chat_id if self._chat is not None else None,
             }
         )
         self._index += 1
@@ -267,6 +272,27 @@ class ApiCounter:
 
     async def on_api_start(self, _kwargs: dict[str, Any]) -> None:
         self.calls += 1
+
+
+class ChatTracker:
+    """Remember the platform's identity for this run: the first model call's request_id.
+
+    The SDK echoes each response's ``request_id`` back as ``prev_request_id``, and the
+    platform files every call in that chain under the first one, so the first response
+    names the chat page the run appears on.
+    """
+
+    def __init__(self) -> None:
+        self.chat_id: str | None = None
+
+    async def on_api_end(self, _kwargs: dict[str, Any], response: Any) -> None:
+        if self.chat_id is not None:
+            return
+        if hasattr(response, "model_dump"):
+            response = response.model_dump()
+        request_id = response.get("request_id") if isinstance(response, dict) else None
+        if isinstance(request_id, str) and request_id:
+            self.chat_id = request_id
 
 
 class RunGuard:
@@ -484,7 +510,8 @@ async def run_request(
 
     deadline = run_start + remaining_seconds
     guard = RunGuard(request["max_steps"], deadline)
-    reporter = ActionReporter(emitter, run_start)
+    chat = ChatTracker()
+    reporter = ActionReporter(emitter, run_start, chat=chat)
     api_counter = ApiCounter()
     computer = MacOSComputer(
         presentation=True,
@@ -517,7 +544,7 @@ async def run_request(
             api_key=api_key,
             base_url=request["api_base_url"],
             model=request["model"],
-            callbacks=[guard, reporter, api_counter],
+            callbacks=[guard, reporter, api_counter, chat],
             instructions=SYSTEM_CONTEXT,
             presentation=computer.presentation,
             screenshot_delay=0,
@@ -560,6 +587,7 @@ async def run_request(
             **_result_event(outcome, final_text),
             "elapsed_ms": elapsed_ms,
             "steps": guard.steps,
+            "chat_id": chat.chat_id,
             "timings": _timings_payload(elapsed_ms, agent, api_counter, reporter, computer),
             **_presentation_payload(computer, status),
         }

--- a/src/yutori_mcp/computer_use/supervisor.py
+++ b/src/yutori_mcp/computer_use/supervisor.py
@@ -265,6 +265,29 @@ async def _supervise(
         await asyncio.gather(stderr_task, return_exceptions=True)
 
 
+def run_chat_id(result: dict[str, Any]) -> str | None:
+    """The platform chat id for a run: the result's own, else the latest one an action carried."""
+    chat_id = result.get("chat_id")
+    if isinstance(chat_id, str) and chat_id:
+        return chat_id
+    for action in reversed(result.get("actions") or []):
+        candidate = action.get("chat_id")
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    return None
+
+
+def attach_run_link(result: dict[str, Any], platform_url: str | None) -> dict[str, Any]:
+    """Add ``chat_id`` and, when the platform is known, the ``run_url`` of this run's page."""
+    chat_id = run_chat_id(result)
+    if chat_id is None:
+        return result
+    result["chat_id"] = chat_id
+    if platform_url:
+        result["run_url"] = f"{platform_url.rstrip('/')}/navigator/chats/{chat_id}"
+    return result
+
+
 def python_runner_command() -> list[str]:
     """The Python runner child's argv: this interpreter, running the runner module.
 
@@ -287,6 +310,7 @@ async def run_task(
     max_steps: int,
     api_key: str,
     api_base_url: str,
+    platform_url: str | None = None,
     lock: DesktopLock | None = None,
     on_event: EventCallback | None = None,
 ) -> dict[str, Any]:
@@ -307,12 +331,13 @@ async def run_task(
             }
             if find_cua_driver() is None:  # Kept defensive; preflight already checked it.
                 return failure("cua-driver not found. Run: yutori-mcp computer-use setup")
-            return await _supervise(
+            result = await _supervise(
                 command=python_runner_command(),
                 request=request,
                 api_key=api_key,
                 deadline=deadline,
                 on_event=on_event,
             )
+            return attach_run_link(result, platform_url)
     except (ComputerUseBusyError, RuntimeError, OSError, ValueError) as error:
         return failure(str(error))

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -611,7 +611,7 @@ def _progress_reporter(
 async def _handle_computer_use(
     _: MCPClientAdapter, arguments: dict[str, Any]
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    from .adapter import resolve_run_credentials
+    from .adapter import resolve_platform_url, resolve_run_credentials
     from .computer_use.lock import ComputerUseBusyError, DesktopLock
     from .computer_use.preflight import blocker_message, first_blocker
     from .computer_use.result import failure
@@ -632,6 +632,7 @@ async def _handle_computer_use(
                     **params.model_dump(),
                     api_key=api_key,
                     api_base_url=api_base_url,
+                    platform_url=resolve_platform_url(),
                     lock=lock,
                     on_event=_progress_reporter(ctx, params.max_steps) if ctx else None,
                 ),

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -9,11 +9,13 @@ from yutori_mcp.adapter import (
     DEFAULT_ENVIRONMENT,
     ENV_VAR_ENVIRONMENT,
     ENVIRONMENT_BASE_URLS,
+    ENVIRONMENT_PLATFORM_URLS,
     MCPClientAdapter,
     YutoriAPIError,
     _strip_none,
     is_scoped_environment,
     resolve_base_url,
+    resolve_platform_url,
     resolve_run_credentials,
 )
 from yutori_mcp.server import _format_api_error
@@ -232,6 +234,34 @@ class TestIsScopedEnvironment:
 
     def test_a_named_non_default_environment_is_scoped(self):
         assert is_scoped_environment("dev") is True
+
+
+# ---------------------------------------------------------------------------
+# resolve_platform_url
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePlatformUrl:
+    """Environment-name -> developer-platform URL, resolved like resolve_base_url."""
+
+    def test_every_api_environment_has_a_platform(self):
+        assert sorted(ENVIRONMENT_PLATFORM_URLS) == sorted(ENVIRONMENT_BASE_URLS)
+
+    def test_defaults_to_prod(self, monkeypatch):
+        monkeypatch.delenv(ENV_VAR_ENVIRONMENT, raising=False)
+        assert resolve_platform_url() == "https://platform.yutori.com"
+
+    def test_env_var_selects_dev_platform(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR_ENVIRONMENT, "dev")
+        assert resolve_platform_url() == "https://platform.dev.yutori.com"
+
+    def test_argument_overrides_env_var(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR_ENVIRONMENT, "dev")
+        assert resolve_platform_url("prod") == ENVIRONMENT_PLATFORM_URLS["prod"]
+
+    def test_unknown_environment_fails_loudly(self):
+        with pytest.raises(ValueError, match="Unknown Yutori environment"):
+            resolve_platform_url("staging")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -39,6 +39,7 @@ from yutori_mcp.computer_use.constants import (
 )
 from yutori_mcp.computer_use.lock import ComputerUseBusyError, DesktopLock
 from yutori_mcp.computer_use.result import failure, format_result, redact, terminal_result
+from yutori_mcp.computer_use.supervisor import attach_run_link, run_chat_id
 from yutori_mcp.computer_use.runner import (
     ActionReporter,
     Emitter,
@@ -674,6 +675,30 @@ async def test_run_task_uses_only_python_runner_and_sdk_driver_discovery(tmp_pat
     request = supervise.await_args.kwargs["request"]
     assert request["model"] == "n2"
     assert "driver_path" not in request and "harness" not in request
+
+
+async def test_run_task_links_the_run_to_the_platform_chat_page(tmp_path):
+    driver = tmp_path / "cua-driver"
+    driver.write_text("")
+    action = {
+        "index": 0,
+        "tool": "screenshot",
+        "status": "executed",
+        "raw_status": "confirmed",
+        "delivery_mode": "foreground",
+        "route": "pixel",
+        "refusal_code": None,
+        "chat_id": "chat-1",
+    }
+    supervised = terminal_result("limit", "deadline", actions=[action])
+    with (
+        patch.object(supervisor, "_supervise", AsyncMock(return_value=supervised)),
+        patch.object(supervisor, "find_cua_driver", return_value=driver),
+    ):
+        result = await run_task(**_run_task_kwargs(tmp_path, platform_url="https://platform.dev.yutori.com"))
+    assert result["chat_id"] == "chat-1"
+    assert result["run_url"] == "https://platform.dev.yutori.com/navigator/chats/chat-1"
+    assert "Run: https://platform.dev.yutori.com/navigator/chats/chat-1" in format_result(result)
 
 
 async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch, tmp_path):
@@ -1432,6 +1457,8 @@ class _FakeAgent:
                 return
             if hasattr(callback, "on_api_start"):
                 await callback.on_api_start({})
+            if hasattr(callback, "on_api_end"):
+                await callback.on_api_end({}, {"request_id": "req-first", "choices": []})
         item = {"name": "left_click", "arguments": {"coordinates": [1, 1]}}
         for callback in self.callbacks:
             if hasattr(callback, "on_computer_call_start"):
@@ -1526,6 +1553,62 @@ async def test_run_request_reports_limit_when_the_deadline_has_already_passed():
         "elapsed_ms": 0,
         "steps": 0,
     }
+
+
+class _PydanticLikeResponse:
+    def __init__(self, request_id):
+        self._request_id = request_id
+
+    def model_dump(self):
+        return {"request_id": self._request_id, "choices": []}
+
+
+async def test_chat_tracker_keeps_the_first_request_id_from_dict_or_model_responses():
+    tracker = runner_module.ChatTracker()
+    await tracker.on_api_end({}, {"choices": []})
+    assert tracker.chat_id is None
+    await tracker.on_api_end({}, _PydanticLikeResponse("req-1"))
+    await tracker.on_api_end({}, {"request_id": "req-2", "choices": []})
+    assert tracker.chat_id == "req-1"
+
+
+async def test_run_request_carries_the_chat_id_on_actions_and_the_result(monkeypatch):
+    monkeypatch.setattr(runner_module, "MacOSComputer", _FakeComputer)
+    monkeypatch.setattr(runner_module, "N2ComputerAgent", _FakeAgent)
+    stream = _CollectStream()
+    request = parse_request(_valid_request(deadline_ms=int((time.time() + 60) * 1000)))
+
+    assert await runner_module.run_request(request, Emitter(stream), "yt-secret") == "completed"
+
+    events = [json.loads(line) for line in stream.lines]
+    action, result = events[-2], events[-1]
+    assert (action["type"], action["chat_id"]) == ("action", "req-first")
+    assert (result["type"], result["chat_id"]) == ("result", "req-first")
+
+
+def test_run_chat_id_prefers_the_result_then_the_latest_action():
+    assert run_chat_id({"chat_id": "from-result", "actions": [{"chat_id": "from-action"}]}) == "from-result"
+    assert run_chat_id({"actions": [{"chat_id": None}, {"chat_id": "later"}, {"tool": "screenshot"}]}) == "later"
+    assert run_chat_id({"actions": []}) is None
+
+
+def test_attach_run_link_builds_the_platform_chat_url():
+    result = terminal_result("limit", "deadline", actions=[{"chat_id": "abc-123"}])
+    assert attach_run_link(result, "https://platform.yutori.com/") is result
+    assert result["chat_id"] == "abc-123"
+    assert result["run_url"] == "https://platform.yutori.com/navigator/chats/abc-123"
+    assert "run_url" not in attach_run_link(terminal_result("failed", "no model call"), "https://platform.yutori.com")
+    assert "run_url" not in attach_run_link({"chat_id": "abc-123", "actions": []}, None)
+
+
+def test_format_result_prints_the_run_link_right_after_the_outcome():
+    text = format_result({"outcome": "completed", "run_url": "https://platform.yutori.com/navigator/chats/abc"})
+    assert text.splitlines()[:3] == [
+        "Outcome: completed",
+        "Delivery mode: foreground",
+        "Run: https://platform.yutori.com/navigator/chats/abc",
+    ]
+    assert "Run:" not in format_result({"outcome": "failed"})
 
 
 def test_format_result_handles_python_runtime_action_fields():


### PR DESCRIPTION
Every computer-use result now ends with a `Run:` line pointing at the run's page on the Yutori platform, in both the CLI output and the MCP tool result. The runner captures the first model call's `request_id` (the id the platform files the whole chain under) with a new `ChatTracker` callback and carries it on every action and result event, so the supervisor can still attach the link when it ends the run itself on a deadline or cancellation. `adapter.resolve_platform_url` maps the selected environment to platform.yutori.com or platform.dev.yutori.com so a dev-API run never links to the prod platform. The link is omitted when a run fails before the model is called. Eleven new tests cover the tracker, runner events, link assembly, environment resolution, and formatted output; TOOLS.md documents the new line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive UX and metadata on computer-use results; no auth or API contract changes beyond optional result fields and formatted text.
> 
> **Overview**
> Computer-use runs now surface a **`Run:`** URL in CLI and MCP output so users can open the matching Navigator chat on the Yutori platform.
> 
> The isolated runner records the first model response’s **`request_id`** via a new **`ChatTracker`** callback and propagates it as **`chat_id`** on every action and on the terminal result—so the supervisor can still build a link when it ends the run on deadline or cancellation without a normal runner result. **`resolve_platform_url`** (paired with prod/dev API env) ensures dev API runs link to **`platform.dev.yutori.com`**, not production. **`attach_run_link`** sets **`run_url`** as `{platform}/navigator/chats/{chat_id}`; the line is omitted if the model never ran. **`TOOLS.md`** documents the new output field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9bca15f6f5b3326df9790fdb22925501c5b75fb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->