### PR TITLE
feat(computer-use): background mode through the MCP tool and CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -337,8 +337,9 @@ pip install yutori-mcp
 
 ### macOS computer use
 
-Optional, macOS 15+ only. Computer use operates the visible desktop, so it needs a local driver
-and system permissions on top of the install above:
+Optional, macOS 15+ only. Computer use operates the visible desktop, or a single app window in
+the background while you keep working, so it needs a local driver and system permissions on top
+of the install above:
 
 ```bash
 uvx yutori-mcp computer-use setup    # installs CuaDriver.app, requests Screen Recording + Accessibility
@@ -353,16 +354,21 @@ those checks any time with `uvx yutori-mcp computer-use doctor`.
 ```bash
 uvx yutori-mcp computer-use smoke
 uvx yutori-mcp computer-use run "In Calculator, compute 17 * 23 and report the result." --app Calculator
+uvx yutori-mcp computer-use run "Add a note titled Standup." --app Notes --mode background
 ```
 
 `smoke` is an end-to-end check: it types into Calculator to confirm the permissions took
 effect, then has the agent compute 9 * 9 in Calculator. `run` does whatever task you
-give it, printing each action as the agent takes it.
+give it, printing each action as the agent takes it. `--mode background` drives only the
+target app's window without taking focus, so you can keep working; add
+`--allow-foreground-fallback` to let an action that did not land in the background briefly
+front the window. `uvx yutori-mcp computer-use stop` ends the active run from another terminal
+(background runs have no on-screen Stop button).
 </details>
 
-The harness in this repository is minimal: it drives the foreground desktop one task at a time,
-no background runs, no multiplexing. For scalable sandbox runs, see
-[n2 on Daytona](https://docs.yutori.com/reference/n2-daytona).
+The harness in this repository is minimal: one task at a time (a machine-wide lock), either on
+the visible desktop or targeting one app window in the background, with no multiplexing. For
+scalable sandbox runs, see [n2 on Daytona](https://docs.yutori.com/reference/n2-daytona).
 
 ## Tools
 

--- a/TOOLS.md
+++ b/TOOLS.md
@@ -8,10 +8,19 @@ All tool inputs enforce validation: webhook URLs must use HTTPS, and `output_fie
 
 ### run_computer_use_task
 
-Operate the foreground Mac desktop with the computer-use agent - clicking, typing, and driving
-apps like a person. Listed only on macOS, and only once the setup in
-[README](README.md#macos-computer-use) is done. One task controls the Mac at a time. Do not
-touch the Mac during a run; visible desktop content is sent to Yutori.
+Operate a Mac with the computer-use agent - clicking, typing, and driving apps like a person.
+Listed only on macOS, and only once the setup in [README](README.md#macos-computer-use) is done.
+One task controls the Mac at a time, in one of two modes:
+
+- `mode: "foreground"` (default) drives the whole visible desktop. Do not touch the Mac during
+  the run; visible desktop content is sent to Yutori.
+- `mode: "background"` drives only the target `app`'s window without taking focus, so you can
+  keep working on the Mac (leave that one window alone). Only that window's content is captured
+  and sent to Yutori. A menu bar item (the Yutori mark) stays up for the whole run; its menu
+  shows the latest frame the agent saw, its latest action, and Stop (also ⇧⌘Esc). Actions the driver cannot deliver in the background come back to the agent
+  as refusals; `allow_foreground_fallback: true` lets it retry such an action once with the
+  window fronted briefly and the prior app restored. Background keyboard delivery is
+  app-dependent (clicks reach more apps than typed keys), so typing-heavy tasks usually want it.
 
 **Basic example:**
 
@@ -34,6 +43,16 @@ touch the Mac during a run; visible desktop content is sent to Yutori.
 }
 ```
 
+**Background example (drive one window while you keep working):**
+
+```json
+{
+  "task": "Add a note titled 'Standup' with today's three agenda items.",
+  "app": "Notes",
+  "mode": "background"
+}
+```
+
 Example response:
 
 ```
@@ -48,6 +67,21 @@ Actions:
 - #2 left_click: executed (raw: confirmed; mode: foreground; route: pixel; refusal: None) took 138 ms
 ```
 
+Example background response:
+
+```
+Outcome: completed
+Delivery mode: background
+Window target: Notes (pid 4242, window 71)
+Final text: Created the Standup note with the three agenda items.
+Elapsed: 24107 ms
+Delivery: 0 foreground escalation(s), 1 background refusal(s)
+Perf: total 24.1s over 8 steps (3.0s/step)
+Actions:
+- #1 left_click: executed (raw: confirmed; mode: background; route: accessibility; refusal: None); effect: unverifiable took 233 ms
+- #2 type: uncertain (raw: unverifiable; mode: background; route: synthetic_events; refusal: None); effect: unverifiable took 610 ms
+```
+
 `Outcome` is `completed`, `limit` (hit `minutes` or `max_steps`), `aborted`, or `failed`.
 `Run` links to the run's page on the Yutori platform (platform.yutori.com, or
 platform.dev.yutori.com when `--env dev` is selected); it is omitted when the run ended
@@ -60,6 +94,8 @@ before the model was called.
 | `start_url` | No | URL to open before the task starts; requires `app` |
 | `minutes` | No | Wall-clock deadline in minutes (1-60). Default: 30 |
 | `max_steps` | No | Max desktop actions, 1 or more. Default: 60 |
+| `mode` | No | `foreground` (default) drives the visible desktop; `background` drives only `app`'s window without taking focus. Background requires `app` |
+| `allow_foreground_fallback` | No | Background only. Retry an action that did not land with the window fronted briefly. Default: false |
 
 `max_steps` has no upper bound. On long runs, compact or summarize older screenshots and tool
 results so the conversation stays within `max_context_len`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,9 +30,8 @@ dependencies = [
     # breaks the install as soon as 2.x resolves.
     "mcp>=1.0.0,<2.0.0",
     "pydantic>=2.0.0",
-    # SDK 0.9.10 owns the complete Python/Swift macOS runtime. Doctor verifies
-    # the installed payload against the exact published wheel before use.
-    "yutori==0.9.10",
+    # SDK 0.9.11 adds the window-scoped macOS runtime used by background mode.
+    "yutori==0.9.11",
 ]
 
 [project.optional-dependencies]

--- a/skills/06-computer-use/SKILL.md
+++ b/skills/06-computer-use/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: yutori-computer-use
-description: Run local Mac desktop tasks with Yutori computer use. Use when the user wants to operate macOS apps, websites in a local browser, or cross-app workflows on the visible desktop.
+description: Run local Mac desktop tasks with Yutori computer use. Use when the user wants to operate macOS apps, websites in a local browser, or cross-app workflows on the visible desktop, or to drive one app's window in the background while they keep working.
 argument-hint: "[desktop task]"
 ---
 
 # Computer Use
 
-Run tasks on the user's visible Mac desktop with Yutori computer use.
+Run tasks on the user's visible Mac desktop with Yutori computer use, or drive a single app's
+window in the background while the user keeps working.
 
 ## Setup
 
@@ -54,6 +55,22 @@ Use optional fields when helpful:
 }
 ```
 
+When the user asks to run a task "in the background" or "while I keep working", use background
+mode (requires `app`; the model sees and drives only that app's window and never takes focus).
+Infer `app` from the task ("in Notes", "in Safari"); if no single app is named, ask which app to
+target before calling the tool. "In the foreground" or no mention means the default foreground run:
+
+```json
+{
+  "task": "$ARGUMENTS",
+  "app": "Notes",
+  "mode": "background"
+}
+```
+
+Add `"allow_foreground_fallback": true` only if the user accepts the target window briefly
+flashing to the front when an action cannot be delivered in the background.
+
 If the MCP tool is unavailable, ask the user to run the CLI task runner:
 
 ```bash
@@ -66,9 +83,24 @@ For an app-specific task:
 uvx yutori-mcp computer-use run "$ARGUMENTS" --app Safari --start-url https://example.com
 ```
 
+For a background run:
+
+```bash
+uvx yutori-mcp computer-use run "$ARGUMENTS" --app Notes --mode background
+```
+
+To stop the active run from the Mac (background runs have no on-screen Stop button):
+
+```bash
+uvx yutori-mcp computer-use stop
+```
+
 ## Safety
 
-- Tell the user not to touch the Mac while the task runs.
+- In foreground mode, tell the user not to touch the Mac while the task runs.
+- In background mode, tell the user they can keep working but should leave the target app's window alone, and that only that window is captured. A menu bar item shows the latest frame and offers Stop (also ⇧⌘Esc). Keyboard input may not reach a minimized window.
+- Use `mode: "background"` only with `app`; use `allow_foreground_fallback` only with background mode, and warn that it may briefly flash the target window.
+- Background keyboard delivery is app-dependent: some apps accept background clicks but not typed keys (Calculator, for one), and the agent then reports the refusal instead of typing. For typing-heavy background tasks, suggest `allow_foreground_fallback`.
 - Use `app` for single-app tasks so the runner starts from the intended context.
 - Use `start_url` only with `app`.
 - Keep `minutes` between 1 and 60 and `max_steps` positive.

--- a/src/yutori_mcp/computer_use/app.py
+++ b/src/yutori_mcp/computer_use/app.py
@@ -157,7 +157,10 @@ async def prepare_app(
             pass
         await computer.wait(_FRONTING_SETTLE_MS)
     else:
-        await computer.unhide_app(pid)
+        # Unhiding is best-effort just like foreground fronting: the window may
+        # already be usable, and window discovery below is the authoritative gate.
+        with suppress(CuaDriverError):
+            await computer.unhide_app(pid)
         if window is None:
             window = await _await_window(computer, pid, app)
         await computer.wait(_BACKGROUND_SETTLE_MS)

--- a/src/yutori_mcp/computer_use/app.py
+++ b/src/yutori_mcp/computer_use/app.py
@@ -1,4 +1,4 @@
-"""MCP-owned target-app launch and fronting policy."""
+"""MCP-owned target-app launch policy: front the app for foreground runs, reveal it quietly for background ones."""
 
 from __future__ import annotations
 
@@ -16,6 +16,11 @@ from yutori.navigator.macos.transport import (
 _BUNDLE_ID_PATTERN = re.compile(r"^[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)+$")
 _APP_BUNDLE_IDS = {"finder": "com.apple.finder"}
 _FRONTING_SETTLE_MS = 800
+# A freshly unhidden window needs a moment before its first capture; a cold launch may
+# take a few polls before it has any window at all.
+_BACKGROUND_SETTLE_MS = 300
+_WINDOW_POLL_MS = 250
+_WINDOW_POLL_ATTEMPTS = 12
 
 
 def structured_content(result: dict[str, Any]) -> dict[str, Any]:
@@ -43,20 +48,32 @@ def _windows(payload: dict[str, Any]) -> list[dict[str, Any]]:
     return windows
 
 
+def _area(window: dict[str, Any]) -> float:
+    return float(window["bounds"]["width"]) * float(window["bounds"]["height"])
+
+
 def pick_best_window(windows: list[dict[str, Any]], min_edge_points: float = 100) -> dict[str, Any] | None:
-    """Prefer a visible current-Space window, excluding helper strips."""
+    """Prefer the frontmost visible current-Space content window, excluding helper strips.
+
+    Content windows (both edges at least ``min_edge_points``) that are off screen or hidden
+    still beat helper strips: a background launch leaves every window off screen, and a
+    menu-bar strip can out-area the app's real window.
+    """
     if not windows:
         return None
+    content = [
+        window for window in windows if min(window["bounds"]["width"], window["bounds"]["height"]) >= min_edge_points
+    ]
     visible = [
         window
-        for window in windows
-        if window.get("is_on_screen") is not False
-        and window.get("on_current_space") is not False
-        and min(window["bounds"]["width"], window["bounds"]["height"]) >= min_edge_points
+        for window in content
+        if window.get("is_on_screen") is not False and window.get("on_current_space") is not False
     ]
-    if visible:
-        return max(visible, key=lambda window: window.get("z_index") or 0)
-    return max(windows, key=lambda window: window["bounds"]["width"] * window["bounds"]["height"])
+    on_space = [window for window in content if window.get("on_current_space") is not False]
+    for candidates in (visible, on_space, content):
+        if candidates:
+            return max(candidates, key=lambda window: (window.get("z_index") or 0, _area(window)))
+    return max(windows, key=_area)
 
 
 def _is_missing_app(error: CuaDriverToolError) -> bool:
@@ -81,8 +98,24 @@ async def _running_app(computer: MacOSComputer, requested: str) -> dict[str, Any
     return _find_running_app(structured_content(result), requested)
 
 
-async def prepare_app(computer: MacOSComputer, app: str, start_url: str | None) -> dict[str, Any]:
-    """Launch and best-effort front one allowed target application."""
+async def _await_window(computer: MacOSComputer, pid: int, app: str) -> dict[str, Any]:
+    for _ in range(_WINDOW_POLL_ATTEMPTS):
+        window = pick_best_window(_windows(await computer.list_windows(pid)))
+        if window is not None:
+            return window
+        await computer.wait(_WINDOW_POLL_MS)
+    raise RuntimeError(f"{app!r} is running (pid {pid}) but showed no window to target in background mode")
+
+
+async def prepare_app(
+    computer: MacOSComputer, app: str, start_url: str | None, *, front: bool = True
+) -> dict[str, Any]:
+    """Launch one allowed target application and make it drivable.
+
+    ``front=True`` (foreground runs) best-effort fronts it. ``front=False`` (background runs)
+    never steals focus: ``launch_app`` leaves the app hidden, so it is unhidden behind the
+    user's windows and the window to drive is resolved and returned as ``window_id``.
+    """
     urls = [start_url] if start_url else None
     bundle_id = app if _BUNDLE_ID_PATTERN.match(app) else _APP_BUNDLE_IDS.get(app.casefold())
     launch_error: CuaDriverToolError | None = None
@@ -112,14 +145,24 @@ async def prepare_app(computer: MacOSComputer, app: str, start_url: str | None) 
         pid = running["pid"]
 
     window = pick_best_window(_windows(payload))
-    try:
-        await computer.bring_to_front(pid, window.get("window_id") if window else None)
-    except CuaDriverUncertainActionError:
-        pass
-    except CuaDriverToolError:
-        with suppress(CuaDriverError):
-            await computer.bring_to_front(pid)
-    except CuaDriverError:
-        pass
-    await computer.wait(_FRONTING_SETTLE_MS)
-    return {"name": str(payload.get("name") or app), "pid": pid}
+    if front:
+        try:
+            await computer.bring_to_front(pid, window.get("window_id") if window else None)
+        except CuaDriverUncertainActionError:
+            pass
+        except CuaDriverToolError:
+            with suppress(CuaDriverError):
+                await computer.bring_to_front(pid)
+        except CuaDriverError:
+            pass
+        await computer.wait(_FRONTING_SETTLE_MS)
+    else:
+        await computer.unhide_app(pid)
+        if window is None:
+            window = await _await_window(computer, pid, app)
+        await computer.wait(_BACKGROUND_SETTLE_MS)
+    return {
+        "name": str(payload.get("name") or app),
+        "pid": pid,
+        "window_id": window.get("window_id") if window else None,
+    }

--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -14,10 +14,17 @@ from urllib.request import urlopen
 from ..schemas import (
     COMPUTER_USE_DEFAULT_MAX_STEPS,
     COMPUTER_USE_DEFAULT_MINUTES,
+    COMPUTER_USE_DEFAULT_MODE,
     COMPUTER_USE_MAX_MINUTES,
     ComputerUseTaskInput,
 )
-from .constants import DRIVER_INSTALLER_SHA256, DRIVER_VERSION
+from .constants import (
+    DELIVERY_MODE_BACKGROUND,
+    DELIVERY_MODE_FOREGROUND,
+    DELIVERY_MODES,
+    DRIVER_INSTALLER_SHA256,
+    DRIVER_VERSION,
+)
 from .lock import ComputerUseBusyError, DesktopLock
 from .preflight import (
     blocker_message,
@@ -29,7 +36,7 @@ from .preflight import (
     run_checks,
 )
 from .result import format_action_line, format_result
-from .supervisor import run_task
+from .supervisor import run_task, stop_active_run
 
 
 def _doctor() -> int:
@@ -188,16 +195,31 @@ async def _smoke_live() -> int:
     return _report(result)
 
 
-async def _print_event(event: dict) -> None:
-    if event.get("type") == "ready":
-        print("runner ready; driving the desktop")
-        return
-    line = format_action_line(event)
-    if event.get("elapsed_ms") is not None:
-        line += f" [at {event['elapsed_ms']} ms]"
-    if event.get("command"):
-        line += f"\n  $ {event['command']}"
-    print(line, flush=True)
+def hands_off_notice(mode: str) -> str:
+    """What the operator must (not) do with the Mac while a run of ``mode`` is in progress."""
+    if mode == DELIVERY_MODE_BACKGROUND:
+        return "The model drives only the target app's window in the background; keep working, but leave that window alone."
+    return "The model takes over this Mac's desktop now; do not touch it during the run."
+
+
+def _event_printer(mode: str, app: str | None):
+    surface = f"the {app} window in the background" if mode == DELIVERY_MODE_BACKGROUND else "the desktop"
+
+    async def print_event(event: dict) -> None:
+        if event.get("type") == "ready":
+            print(f"runner ready; driving {surface}")
+            return
+        line = format_action_line(event)
+        if event.get("elapsed_ms") is not None:
+            line += f" [at {event['elapsed_ms']} ms]"
+        if event.get("command"):
+            line += f"\n  $ {event['command']}"
+        print(line, flush=True)
+
+    return print_event
+
+
+_print_event = _event_printer(DELIVERY_MODE_FOREGROUND, None)
 
 
 async def _run_custom(args: argparse.Namespace) -> int:
@@ -213,17 +235,19 @@ async def _run_custom(args: argparse.Namespace) -> int:
         start_url=args.start_url,
         minutes=args.minutes,
         max_steps=args.max_steps,
+        mode=args.mode,
+        allow_foreground_fallback=args.allow_foreground_fallback,
     )
     if _blocked():
         return 1
-    print("The model takes over this Mac's desktop now; do not touch it during the run.")
+    print(hands_off_notice(params.mode))
     api_key, api_base_url, platform_url = resolve_run_credentials_and_platform_url()
     result = await run_task(
         **params.model_dump(),
         api_key=api_key,
         api_base_url=api_base_url,
         platform_url=platform_url,
-        on_event=_print_event,
+        on_event=_event_printer(params.mode, params.app),
     )
     return _report(result)
 
@@ -251,7 +275,8 @@ def register_parser(
     commands.add_parser("setup", help="Install and configure the pinned CuaDriver")
     commands.add_parser("doctor", help="Run all computer-use readiness checks")
     commands.add_parser("smoke", help="Run Calculator mechanical and live checks")
-    run_parser = commands.add_parser("run", help="Run one custom task on the visible desktop")
+    commands.add_parser("stop", help="Stop the active computer-use run (the local stop for background runs)")
+    run_parser = commands.add_parser("run", help="Run one custom task on the visible desktop or in one app window")
     run_parser.add_argument("task", help="Task for the model to perform")
     run_parser.add_argument("--app", default=None, help="Application to target")
     run_parser.add_argument("--start-url", dest="start_url", default=None, help="URL to open in the app")
@@ -268,16 +293,31 @@ def register_parser(
         default=COMPUTER_USE_DEFAULT_MAX_STEPS,
         help="Maximum actions",
     )
+    run_parser.add_argument(
+        "--mode",
+        choices=DELIVERY_MODES,
+        default=COMPUTER_USE_DEFAULT_MODE,
+        help="foreground drives the visible desktop; background drives only --app's window without taking focus",
+    )
+    run_parser.add_argument(
+        "--allow-foreground-fallback",
+        dest="allow_foreground_fallback",
+        action="store_true",
+        help="Background only: retry an action that did not land with the window fronted briefly",
+    )
 
 
 def dispatch(command: str, args: argparse.Namespace | None = None) -> int:
-    if command not in {"setup", "doctor", "smoke", "run"}:
+    if command not in {"setup", "doctor", "smoke", "run", "stop"}:
         raise ValueError(f"Unknown computer-use command: {command}")
     try:
         if command == "setup":
             return _setup()
         if command == "doctor":
             return _doctor()
+        if command == "stop":
+            print(stop_active_run())
+            return 0
         if command == "run":
             if args is None:
                 raise ValueError("computer-use run needs its parsed arguments")

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -4,16 +4,19 @@ from __future__ import annotations
 
 from .. import __version__
 
-PROTOCOL_VERSION = 1
+PROTOCOL_VERSION = 2
 MCP_VERSION = __version__
 MODEL = "n2"
 TOOL_SET = "computer_use_tools-20260815"
-# The only delivery mode this runtime implements today. Repeated verbatim across every
-# `action`/`result` protocol event (runner.py, and result.py's terminal_result() shape,
-# which the supervisor's timeout/cancellation fallbacks now build through); centralized
-# so a future second mode can't be introduced with one of those spots left on the old
-# literal by accident.
+# The two delivery modes this runtime implements. "foreground" drives the visible desktop
+# (the model sees the whole screen and the user keeps their hands off); "background" drives
+# one target app window through the SDK's window scope without taking the user's focus.
+# Every `action`/`result` protocol event carries one of these (runner.py, and result.py's
+# terminal_result() shape, which the supervisor's timeout/cancellation fallbacks build
+# through); centralized so no call site can drift onto a stray literal.
 DELIVERY_MODE_FOREGROUND = "foreground"
+DELIVERY_MODE_BACKGROUND = "background"
+DELIVERY_MODES = (DELIVERY_MODE_FOREGROUND, DELIVERY_MODE_BACKGROUND)
 SDK_VERSION = "0.9.10"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -17,11 +17,11 @@ TOOL_SET = "computer_use_tools-20260815"
 DELIVERY_MODE_FOREGROUND = "foreground"
 DELIVERY_MODE_BACKGROUND = "background"
 DELIVERY_MODES = (DELIVERY_MODE_FOREGROUND, DELIVERY_MODE_BACKGROUND)
-SDK_VERSION = "0.9.10"
+SDK_VERSION = "0.9.11"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.
-SDK_ARTIFACT_SHA256 = "ede183e6796b10451de4ba00da63d61872e46e4bb4fea66fdaa4d58133e334b5"
-SDK_INSTALLATION_SHA256 = "43dd4313e8c09a93db8fc37c490cbb3c0435bd0b91f03a628d8807320be6ecc0"
+SDK_ARTIFACT_SHA256 = "5a10b9c5240fc5c859a7e680001cb51ef16bbcc0d1cd5b0ea2e3b9ed8995e261"
+SDK_INSTALLATION_SHA256 = "4c7eae3cd1ccefce1c4cb30383d8f8c8267153e014b0b1ab954574733387cf3e"
 SDK_PROVENANCE_SHA256 = "7cab595d2f00e1a9ab5cd121204fbd6dd4c24163ead3eb76f76eef7fba495fc4"
 
 # The cua-driver release that implements this tool contract, and the checksum

--- a/src/yutori_mcp/computer_use/result.py
+++ b/src/yutori_mcp/computer_use/result.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .constants import DELIVERY_MODE_FOREGROUND
+from .constants import DELIVERY_MODE_BACKGROUND, DELIVERY_MODE_FOREGROUND
 
 REDACTED = "[REDACTED]"
 
@@ -84,9 +84,18 @@ def format_action_line(event: dict[str, Any], *, index_default: Any = None) -> s
     line = f"action #{index}: {event.get('tool')} -> {event.get('status')}"
     if event.get("refusal_code"):
         line += f" ({event['refusal_code']})"
+    if event.get("escalated"):
+        line += " [fronted]"
     if event.get("duration_ms") is not None:
         line += f" took {event['duration_ms']} ms"
     return line
+
+
+def _window_target_line(target: Any) -> str | None:
+    if not isinstance(target, dict) or target.get("pid") is None:
+        return None
+    label = target.get("app_name") or target.get("title") or "window"
+    return f"Window target: {label} (pid {target['pid']}, window {target.get('window_id')})"
 
 
 def format_result(result: dict[str, Any]) -> str:
@@ -96,13 +105,28 @@ def format_result(result: dict[str, Any]) -> str:
     ]
     if result.get("run_url"):
         lines.append(f"Run: {result['run_url']}")
+    if (window_target := _window_target_line(result.get("window_target"))) is not None:
+        lines.append(window_target)
     if result.get("final_text"):
         lines.append(f"Final text: {result['final_text']}")
     if result.get("elapsed_ms") is not None:
         lines.append(f"Elapsed: {result['elapsed_ms']} ms")
     if result.get("reasoning_overlay_requested"):
         state = "active" if result.get("reasoning_overlay_effective") else "unavailable"
-        lines.append(f"Reasoning overlay: {state}; codec: {result.get('codec') or 'unknown'}")
+        # Background runs show a menu bar item (latest frame + Stop) instead of the overlay.
+        surface = "Menu bar status" if result.get("delivery_mode") == DELIVERY_MODE_BACKGROUND else "Reasoning overlay"
+        lines.append(f"{surface}: {state}; codec: {result.get('codec') or 'unknown'}")
+    escalations = result.get("fallback_escalations") or 0
+    skips = result.get("fallback_skips") or 0
+    refusals = result.get("background_refusals") or 0
+    if result.get("delivery_mode") == DELIVERY_MODE_BACKGROUND or escalations or skips or refusals:
+        line = f"Delivery: {escalations} foreground escalation(s), {refusals} background refusal(s)"
+        if skips:
+            # Foreground retries the SDK withheld because the window had already changed.
+            line += f", {skips} retry(ies) skipped after the window changed"
+        lines.append(line)
+    if result.get("preview_frames"):
+        lines.append(f"Live view: {result['preview_frames']} frame(s) streamed to the menu bar item")
     lines.extend(format_perf(result))
     actions = result.get("actions", [])
     if actions:
@@ -112,6 +136,10 @@ def format_result(result: dict[str, Any]) -> str:
                 "- #{index} {tool}: {status} (raw: {raw_status}; mode: {delivery_mode}; "
                 "route: {route}; refusal: {refusal_code})".format(**action)
             )
+            if action.get("effect"):
+                line += f"; effect: {action['effect']}"
+            if action.get("escalated"):
+                line += " [fronted]"
             if action.get("duration_ms") is not None:
                 line += f" took {action['duration_ms']} ms"
             if action.get("command"):
@@ -120,7 +148,13 @@ def format_result(result: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def terminal_result(outcome: str, message: str, *, actions: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+def terminal_result(
+    outcome: str,
+    message: str,
+    *,
+    actions: list[dict[str, Any]] | None = None,
+    delivery_mode: str = DELIVERY_MODE_FOREGROUND,
+) -> dict[str, Any]:
     """Build the supervisor-side terminal result dict every caller returns to the host.
 
     Single source of truth for this shape. The supervisor synthesizes one of these
@@ -132,12 +166,17 @@ def terminal_result(outcome: str, message: str, *, actions: list[dict[str, Any]]
     """
     return {
         "outcome": outcome,
-        "delivery_mode": DELIVERY_MODE_FOREGROUND,
+        "delivery_mode": delivery_mode,
         "final_text": message,
         "actions": actions or [],
     }
 
 
-def failure(message: str, *, actions: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+def failure(
+    message: str,
+    *,
+    actions: list[dict[str, Any]] | None = None,
+    delivery_mode: str = DELIVERY_MODE_FOREGROUND,
+) -> dict[str, Any]:
     """The terminal result for a run that could not be carried out."""
-    return terminal_result("failed", message, actions=actions)
+    return terminal_result("failed", message, actions=actions, delivery_mode=delivery_mode)

--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -862,7 +862,7 @@ def main() -> int:
         message = _redacted_error_text(error, api_key)
         emitter.emit(
             {
-                **_result_event("failed", message),
+                **_result_event("failed", message, request["mode"]),
                 "steps": 0,
             }
         )

--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import os
 import re
@@ -26,7 +27,9 @@ from yutori.navigator.macos import (
 
 from .app import prepare_app
 from .constants import (
+    DELIVERY_MODE_BACKGROUND,
     DELIVERY_MODE_FOREGROUND,
+    DELIVERY_MODES,
     DRIVER_VERSION,
     PROTOCOL_VERSION,
     SDK_ARTIFACT_SHA256,
@@ -36,8 +39,9 @@ from .constants import (
 )
 from .result import redact
 
-SYSTEM_CONTEXT = (
-    "You control the entire macOS screen. This is macOS, not Linux: do not use "
+_FOREGROUND_OPENING = "You control the entire macOS screen. "
+_SHARED_CONTEXT = (
+    "This is macOS, not Linux: do not use "
     "Ubuntu or Linux UI conventions. Use macOS conventions: cmd, not ctrl, for "
     "standard shortcuts. Prefer reliable keyboard shortcuts such as cmd+w to close the "
     "current window, cmd+q to quit, and cmd+shift+s for Save As. If one visual attempt "
@@ -48,13 +52,23 @@ SYSTEM_CONTEXT = (
     "change, the target may be busy rather than mis-aimed: retry the same click up to "
     "three times, checking a fresh screenshot between attempts, and if it still does "
     "not respond, reach the same result another way — a menu item, a keyboard "
-    "shortcut, or a different control — instead of clicking it again. Once you have "
+    "shortcut, or a different control — instead of clicking it again. "
+)
+_FOREGROUND_FINISH = (
+    "Once you have "
     "confirmed a step worked, leave that result in view: bring the file, window, or "
     "view it changed to the front, reopening or refreshing it if the change was made "
     "somewhere the screen does not show, so progress stays visible while the task is "
     "still running. When you finish, open the final artifact (the document, file, "
     "page, or app view holding the result) so it is visible on screen, then take a "
-    "screenshot to confirm it before you summarize. Shell commands run headlessly "
+    "screenshot to confirm it before you summarize. "
+)
+_BACKGROUND_FINISH = (
+    "There is no need to bring results into view when you finish: take a final "
+    "screenshot of the window to confirm the result, then summarize. "
+)
+_SHARED_TAIL = (
+    "Shell commands run headlessly "
     "in bash as the logged-in user; do not use sudo. Do not use osascript or shell "
     "commands to inspect or control GUI applications because macOS Automation consent "
     "can block them indefinitely. Use screenshots and computer actions for GUI work "
@@ -71,6 +85,40 @@ SYSTEM_CONTEXT = (
     "Do not open or change System Settings, application settings, accounts, "
     "permissions, or defaults unless the user explicitly asked for that settings change."
 )
+
+
+def _background_opening(app: str) -> str:
+    return (
+        f"You control exactly one application window: {app}. Every screenshot shows only "
+        "that window, and coordinates are relative to it. You cannot see the Dock, the menu "
+        "bar, or any other application, and you must never try to switch apps, open other "
+        "applications, or bring anything to the front: the user is actively working on this "
+        "Mac, and your clicks and keystrokes are delivered to the target window in the "
+        "background without taking their focus. Keyboard shortcuts (cmd+...) work inside the "
+        "target app; modifier-clicks (cmd-click, shift-click) are unavailable. If an action is "
+        "reported as not landing, take a fresh screenshot and reach the same result through a "
+        "different control or shortcut rather than repeating it. If the window is minimized or "
+        "hidden, keyboard input may not reach it: report that and stop instead of trying to "
+        "restore it. Do not move or resize the window. Never use the shell to open, launch, or "
+        "activate applications or files (for example `open -a`): that takes the user's focus. "
+        "If the app stops accepting input, report the blocker instead of producing the result "
+        "through the shell. "
+    )
+
+
+def system_context(mode: str, app: str | None = None) -> str:
+    """The model's standing instructions for one delivery mode.
+
+    Foreground runs own the whole screen and keep results visible; background runs see and
+    drive one application window while the user keeps working.
+    """
+    if mode == DELIVERY_MODE_BACKGROUND:
+        opening = _background_opening(app or "the target application")
+        return opening + _SHARED_CONTEXT + _BACKGROUND_FINISH + _SHARED_TAIL
+    return _FOREGROUND_OPENING + _SHARED_CONTEXT + _FOREGROUND_FINISH + _SHARED_TAIL
+
+
+SYSTEM_CONTEXT = system_context(DELIVERY_MODE_FOREGROUND)
 STOP_SUMMARY_PROMPT = "Stop here. Briefly summarize what you accomplished and what you found."
 FINAL_TEXT_MARKERS = ("[DONE]", "[INFEASIBLE]")
 _SHELL_TOOL_NAMES = frozenset({"bash", "shell_command", "run_command"})
@@ -104,6 +152,20 @@ def _require_positive_int(request: dict[str, Any], field: str) -> int:
     return value
 
 
+def _require_mode(request: dict[str, Any]) -> str:
+    value = request.get("mode")
+    if value not in DELIVERY_MODES:
+        raise RequestError("INVALID_REQUEST", f"mode must be one of {', '.join(DELIVERY_MODES)}.")
+    return str(value)
+
+
+def _require_bool(request: dict[str, Any], field: str) -> bool:
+    value = request.get(field)
+    if not isinstance(value, bool):
+        raise RequestError("INVALID_REQUEST", f"{field} must be a boolean.")
+    return value
+
+
 def parse_request(payload: Any) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise RequestError("INVALID_REQUEST", "Request must be a JSON object.")
@@ -116,6 +178,12 @@ def parse_request(payload: Any) -> dict[str, Any]:
     start_url = _require_optional_string(payload, "start_url")
     if start_url is not None and app is None:
         raise RequestError("INVALID_REQUEST", "start_url requires app.")
+    mode = _require_mode(payload)
+    allow_foreground_fallback = _require_bool(payload, "allow_foreground_fallback")
+    if mode == DELIVERY_MODE_BACKGROUND and app is None:
+        raise RequestError("INVALID_REQUEST", "mode 'background' requires app.")
+    if allow_foreground_fallback and mode != DELIVERY_MODE_BACKGROUND:
+        raise RequestError("INVALID_REQUEST", "allow_foreground_fallback requires mode 'background'.")
     deadline_ms = _require_positive_int(payload, "deadline_ms")
     max_steps = _require_positive_int(payload, "max_steps")
     return {
@@ -124,6 +192,8 @@ def parse_request(payload: Any) -> dict[str, Any]:
         "start_url": start_url,
         "deadline_ms": deadline_ms,
         "max_steps": max_steps,
+        "mode": mode,
+        "allow_foreground_fallback": allow_foreground_fallback,
         "model": _require_string(payload, "model"),
         "api_base_url": _require_string(payload, "api_base_url"),
     }
@@ -211,11 +281,17 @@ class ActionReporter:
         *,
         clock: Callable[[], float] = time.monotonic,
         chat: ChatTracker | None = None,
+        delivery_mode: str = DELIVERY_MODE_FOREGROUND,
+        action_delivery: Callable[[], dict[str, Any]] | None = None,
     ) -> None:
         self._emitter = emitter
         self._run_start = run_start
         self._clock = clock
         self._chat = chat
+        self._delivery_mode = delivery_mode
+        # Reads the SDK's verdict on the latest driver action (window scope only) so each
+        # event reports the delivery that actually happened, not just the configured mode.
+        self.action_delivery = action_delivery
         self._index = 0
         self._call_start: float | None = None
         self._pending_item: dict[str, Any] | None = None
@@ -242,6 +318,7 @@ class ActionReporter:
         run_in_background = bool(
             str(item.get("name") or "").lower() == "bash" and arguments.get("run_in_background") is True
         )
+        delivery = self.action_delivery() if self.action_delivery is not None else {}
         self._emitter.emit(
             {
                 "type": "action",
@@ -249,9 +326,11 @@ class ActionReporter:
                 "tool": str(item.get("name") or "unknown").lower(),
                 "status": _status_for(raw_status),
                 "raw_status": raw_status,
-                "delivery_mode": DELIVERY_MODE_FOREGROUND,
-                "route": "pixel",
-                "refusal_code": "driver_refused" if raw_status == "refused" else None,
+                "delivery_mode": delivery.get("delivery_mode") or self._delivery_mode,
+                "route": delivery.get("route") or "pixel",
+                "refusal_code": delivery.get("refusal_code") or ("driver_refused" if raw_status == "refused" else None),
+                "effect": delivery.get("effect"),
+                "escalated": bool(delivery.get("escalated")),
                 "elapsed_ms": max(0, round((self._clock() - self._run_start) * 1000)),
                 "duration_ms": duration_ms,
                 "command": shell_command_preview(item),
@@ -433,13 +512,97 @@ def _timings_payload(
     }
 
 
+def _supports_background_mode() -> bool:
+    """Whether the installed SDK's MacOSComputer has window scope (yutori >= 0.9.10)."""
+    try:
+        return "scope" in inspect.signature(MacOSComputer.__init__).parameters
+    except (TypeError, ValueError):
+        return False
+
+
+def _computer_kwargs(
+    request: dict[str, Any],
+    *,
+    deadline: float,
+    cancellation: CancellationLatch,
+    api_key: str,
+) -> dict[str, Any]:
+    """MacOSComputer construction per mode; the foreground shape is the long-standing one."""
+    kwargs: dict[str, Any] = {
+        "presentation": True,
+        "allow_local_shell": True,
+        "execution_deadline": deadline,
+        "cancellation": cancellation,
+        "known_secrets": (api_key,),
+    }
+    if request["mode"] == DELIVERY_MODE_BACKGROUND:
+        # Window scope captures and drives one window. The SDK shows no full-screen overlay for
+        # it; with presentation on it keeps a menu bar item with the latest frame and Stop.
+        kwargs.update(
+            scope="window",
+            allow_foreground_fallback=request["allow_foreground_fallback"],
+        )
+    return kwargs
+
+
+async def _bind_window_target(computer: MacOSComputer, target: dict[str, Any]) -> None:
+    """Point a window-scope session at the window prepare_app resolved."""
+    from yutori.navigator.macos import MacOSWindowTarget  # window scope: yutori >= 0.9.10
+
+    window_id = target.get("window_id")
+    if not isinstance(window_id, int):
+        raise RuntimeError(f"{target.get('name')!r} has no window to drive in background mode")
+    await computer.set_window_target(MacOSWindowTarget(target["pid"], window_id, app_name=target.get("name")))
+
+
+def _action_delivery(computer: MacOSComputer) -> Callable[[], dict[str, Any]]:
+    """Delivery facts for one top-level tool call, aggregated over the driver actions it issued.
+
+    A `computer_batch` issues several driver actions; the call counts as foreground-delivered
+    when any of them escalated, and reports the last route/effect and the first refusal code.
+    Calls that drove no driver action (shell, screenshot) report nothing.
+    """
+    seen = {"count": 0}
+
+    def read() -> dict[str, Any]:
+        outcomes = tuple(getattr(computer, "action_outcomes", ()) or ())
+        fresh = outcomes[seen["count"] :]
+        seen["count"] = len(outcomes)
+        if not fresh:
+            return {}
+        escalated = any(outcome.escalated for outcome in fresh)
+        last = fresh[-1]
+        return {
+            "delivery_mode": DELIVERY_MODE_FOREGROUND if escalated else last.requested_delivery,
+            "route": last.route,
+            "effect": last.effect,
+            "escalated": escalated,
+            "refusal_code": next((outcome.refusal_code for outcome in fresh if outcome.refusal_code), None),
+        }
+
+    return read
+
+
+def _window_telemetry(computer: MacOSComputer) -> dict[str, Any]:
+    counts = getattr(computer, "delivery_counts", None) or {}
+    return {
+        "fallback_escalations": int(counts.get("foreground_escalations", 0)),
+        "fallback_skips": int(counts.get("fallback_skips", 0)),
+        "background_refusals": int(counts.get("background_refusals", 0)),
+        "window_rebinds": int(counts.get("window_rebinds", 0)),
+        "focus_guard_trips": int(getattr(computer, "focus_guard_trips", 0) or 0),
+        "preview_frames": int(getattr(computer, "preview_frames_sent", 0) or 0),
+        "window_target": getattr(computer, "window_target_info", None),
+    }
+
+
 def _presentation_payload(computer: MacOSComputer, status: MacOSPresentationStatus) -> dict[str, Any]:
     codec = status.codec
     if codec is None and computer.current_observation is not None:
         codec = computer.current_observation.media_type.rsplit("/", 1)[-1]
     telemetry = list(computer.presentation.telemetry) if computer.presentation is not None else []
     return {
-        "reasoning_overlay_requested": True,
+        "reasoning_overlay_requested": bool(getattr(computer, "presentation_requested", True)),
         "reasoning_overlay_effective": status.available,
         "presentation": asdict(status),
         "presentation_telemetry": telemetry,
@@ -473,7 +636,9 @@ def _error_event(code: str, message: str) -> dict[str, Any]:
     return {"type": "error", "code": code, "message": message}
 
 
-def _result_event(outcome: str, final_text: str | None) -> dict[str, Any]:
+def _result_event(
+    outcome: str, final_text: str | None, delivery_mode: str = DELIVERY_MODE_FOREGROUND
+) -> dict[str, Any]:
     """The four keys every runner-to-supervisor "result" event shares.
 
     A deadline that expires before the run starts, a normal run outcome, and an unexpected
@@ -485,7 +650,7 @@ def _result_event(outcome: str, final_text: str | None) -> dict[str, Any]:
     return {
         "type": "result",
         "outcome": outcome,
-        "delivery_mode": DELIVERY_MODE_FOREGROUND,
+        "delivery_mode": delivery_mode,
         "final_text": final_text,
     }
 
@@ -497,28 +662,45 @@ async def run_request(
     cancellation: CancellationLatch | None = None,
 ) -> str:
     run_start = time.monotonic()
+    mode = request["mode"]
+    background = mode == DELIVERY_MODE_BACKGROUND
     remaining_seconds = request["deadline_ms"] / 1000 - time.time()
     if remaining_seconds <= 0:
         emitter.emit(
             {
-                **_result_event("limit", "The deadline expired before the run started."),
+                **_result_event("limit", "The deadline expired before the run started.", mode),
                 "elapsed_ms": 0,
                 "steps": 0,
             }
         )
         return "limit"
+    if background and not _supports_background_mode():
+        emitter.emit(
+            _error_event(
+                "UNSUPPORTED_MODE",
+                f"mode 'background' needs a yutori SDK with window scope; the pinned SDK {SDK_VERSION} has none.",
+            )
+        )
+        return "failed"
 
     deadline = run_start + remaining_seconds
     guard = RunGuard(request["max_steps"], deadline)
     chat = ChatTracker()
-    reporter = ActionReporter(emitter, run_start, chat=chat)
     api_counter = ApiCounter()
     computer = MacOSComputer(
-        presentation=True,
-        allow_local_shell=True,
-        execution_deadline=deadline,
-        cancellation=cancellation or CancellationLatch(),
-        known_secrets=(api_key,),
+        **_computer_kwargs(
+            request,
+            deadline=deadline,
+            cancellation=cancellation or CancellationLatch(),
+            api_key=api_key,
+        )
+    )
+    reporter = ActionReporter(
+        emitter,
+        run_start,
+        chat=chat,
+        delivery_mode=mode,
+        action_delivery=_action_delivery(computer) if background else None,
     )
     agent: Any = None
     outcome = "failed"
@@ -526,14 +708,20 @@ async def run_request(
     try:
         await computer.__aenter__()
         if request["app"]:
-            # Consume the pre-launch frame captured during session startup so
-            # the first model observation is guaranteed to show the target.
-            await computer.screenshot()
-            target = await prepare_app(computer, request["app"], request["start_url"])
+            if not background:
+                # Consume the pre-launch frame captured during session startup so
+                # the first model observation is guaranteed to show the target.
+                # (Window scope captures nothing until a window is bound.)
+                await computer.screenshot()
+            target = await prepare_app(computer, request["app"], request["start_url"], front=not background)
             computer.target_pid = target["pid"]
+            if background:
+                await _bind_window_target(computer, target)
 
             async def recover_target() -> int | None:
-                recovered = await prepare_app(computer, request["app"], request["start_url"])
+                recovered = await prepare_app(computer, request["app"], request["start_url"], front=not background)
+                if background:
+                    await _bind_window_target(computer, recovered)
                 return recovered["pid"]
 
             computer.recover_target = recover_target
@@ -545,7 +733,7 @@ async def run_request(
             base_url=request["api_base_url"],
             model=request["model"],
             callbacks=[guard, reporter, api_counter, chat],
-            instructions=SYSTEM_CONTEXT,
+            instructions=system_context(mode, request["app"]),
             presentation=computer.presentation,
             screenshot_delay=0,
             execution_deadline=deadline,
@@ -584,12 +772,13 @@ async def run_request(
     elapsed_ms = max(0, round((time.monotonic() - run_start) * 1000))
     emitter.emit(
         {
-            **_result_event(outcome, final_text),
+            **_result_event(outcome, final_text, mode),
             "elapsed_ms": elapsed_ms,
             "steps": guard.steps,
             "chat_id": chat.chat_id,
             "timings": _timings_payload(elapsed_ms, agent, api_counter, reporter, computer),
             **_presentation_payload(computer, status),
+            **_window_telemetry(computer),
         }
     )
     return outcome
@@ -651,6 +840,7 @@ def main() -> int:
             "observation_format": "webp",
             "observation_format_fallback": True,
             "observation_fallback_format": "jpeg",
+            # The request is not parsed yet; the result event carries the truthful value.
             "reasoning_overlay_requested": True,
         }
     )

--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -513,7 +513,7 @@ def _timings_payload(
 
 
 def _supports_background_mode() -> bool:
-    """Whether the installed SDK's MacOSComputer has window scope (yutori >= 0.9.10)."""
+    """Whether the installed SDK's MacOSComputer has window scope (yutori >= 0.9.11)."""
     try:
         return "scope" in inspect.signature(MacOSComputer.__init__).parameters
     except (TypeError, ValueError):
@@ -547,7 +547,7 @@ def _computer_kwargs(
 
 async def _bind_window_target(computer: MacOSComputer, target: dict[str, Any]) -> None:
     """Point a window-scope session at the window prepare_app resolved."""
-    from yutori.navigator.macos import MacOSWindowTarget  # window scope: yutori >= 0.9.10
+    from yutori.navigator.macos import MacOSWindowTarget  # window scope: yutori >= 0.9.11
 
     window_id = target.get("window_id")
     if not isinstance(window_id, int):

--- a/src/yutori_mcp/computer_use/supervisor.py
+++ b/src/yutori_mcp/computer_use/supervisor.py
@@ -5,12 +5,17 @@ import json
 import logging
 import os
 import signal
+import subprocess
 import sys
 import time
 from collections.abc import Awaitable, Callable
+from contextlib import suppress
+from pathlib import Path
 from typing import Any
 
 from .constants import (
+    DELIVERY_MODE_FOREGROUND,
+    DELIVERY_MODES,
     DRIVER_VERSION,
     MCP_VERSION,
     MODEL,
@@ -35,6 +40,70 @@ EventCallback = Callable[[dict[str, Any]], Awaitable[None]]
 EVENT_CALLBACK_TIMEOUT_SECONDS = 5.0
 RUNNER_SHUTDOWN_GRACE_SECONDS = 5.0
 RUNNER_FRAME_LIMIT_BYTES = 8 * 1024 * 1024
+RUNNER_MODULE = "yutori_mcp.computer_use.runner"
+
+
+def runner_pid_path() -> Path:
+    """Where the supervisor advertises the live runner's pid for `computer-use stop`.
+
+    Next to the desktop lock. Advisory only: the lock stays the concurrency gate, and the
+    file names a process group that `stop` verifies is really a runner before signalling.
+    """
+    return Path.home() / ".yutori" / "computer-use.pid"
+
+
+def _record_runner_pid(pid: int) -> None:
+    with suppress(OSError):
+        path = runner_pid_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"{pid}\n")
+
+
+def _clear_runner_pid(pid: int) -> None:
+    with suppress(OSError, ValueError):
+        path = runner_pid_path()
+        if int(path.read_text().strip()) == pid:
+            path.unlink()
+
+
+def _process_command(pid: int) -> str | None:
+    try:
+        listing = subprocess.run(
+            ["/bin/ps", "-o", "command=", "-p", str(pid)],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=2,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return None
+    return listing or None
+
+
+def stop_active_run() -> str:
+    """Ask the live runner to stop; its SIGTERM handler ends the run with outcome `aborted`.
+
+    A background run has no on-screen Stop button, so this is the operator's local stop.
+    The runner is its own process group leader (`start_new_session=True`), so signalling
+    the group also reaches any model-owned shells.
+    """
+    path = runner_pid_path()
+    try:
+        pid = int(path.read_text().strip())
+    except (OSError, ValueError):
+        return "No computer-use run is active."
+    command = _process_command(pid)
+    if command is None or RUNNER_MODULE not in command:
+        with suppress(OSError):
+            path.unlink()
+        return "No computer-use run is active (removed a stale pid file)."
+    try:
+        os.killpg(pid, signal.SIGTERM)
+    except ProcessLookupError:
+        with suppress(OSError):
+            path.unlink()
+        return "No computer-use run is active (removed a stale pid file)."
+    return f"Asked the computer-use runner (pid {pid}) to stop; the run ends with outcome 'aborted'."
 
 
 async def _notify(on_event: EventCallback | None, event: dict[str, Any]) -> EventCallback | None:
@@ -149,6 +218,8 @@ def _event_shape_error(event: dict[str, Any]) -> str | None:
     invalid = [
         name for name, expected in required.items() if name not in event or not isinstance(event[name], expected)
     ]
+    if "delivery_mode" in required and "delivery_mode" not in invalid and event["delivery_mode"] not in DELIVERY_MODES:
+        invalid.append("delivery_mode")
     return f"invalid or missing fields: {', '.join(invalid)}" if invalid else None
 
 
@@ -175,10 +246,12 @@ async def _supervise(
         cwd=os.path.expanduser("~"),
     )
     assert process.stdin and process.stdout and process.stderr
+    _record_runner_pid(process.pid)
     stderr_task = asyncio.create_task(_drain_stderr(process.stderr, api_key))
     actions: list[dict[str, Any]] = []
     terminal: dict[str, Any] | None = None
     ready = False
+    mode = str(request.get("mode") or DELIVERY_MODE_FOREGROUND)
 
     def protocol_failure(detail: str) -> dict[str, Any]:
         """A runner protocol violation, reported with the actions observed so far.
@@ -189,7 +262,7 @@ async def _supervise(
         means a new branch cannot word the subject differently or, worse, omit
         ``actions`` and silently drop the action history from the result.
         """
-        return failure(f"Computer-use runner {detail}", actions=actions)
+        return failure(f"Computer-use runner {detail}", actions=actions, delivery_mode=mode)
 
     try:
         process.stdin.write(json.dumps(request, separators=(",", ":")).encode() + b"\n")
@@ -244,22 +317,25 @@ async def _supervise(
             return failure(
                 f"{terminal.get('code', 'RUNNER_ERROR')}: {terminal.get('message', 'Runner error')}",
                 actions=actions,
+                delivery_mode=mode,
             )
         terminal["actions"] = actions
         return terminal
     except asyncio.TimeoutError:
         await _stop_process_group(process)
-        return terminal_result("limit", "The absolute deadline expired.", actions=actions)
+        return terminal_result("limit", "The absolute deadline expired.", actions=actions, delivery_mode=mode)
     except asyncio.CancelledError:
         await _stop_process_group(process)
         return terminal_result(
             "aborted",
             "Computer-use task was cancelled; the runner process group was terminated.",
             actions=actions,
+            delivery_mode=mode,
         )
     finally:
         if process.returncode is None:
             await _stop_process_group(process)
+        _clear_runner_pid(process.pid)
         if not stderr_task.done():
             stderr_task.cancel()
         await asyncio.gather(stderr_task, return_exceptions=True)
@@ -311,6 +387,8 @@ async def run_task(
     api_key: str,
     api_base_url: str,
     platform_url: str | None = None,
+    mode: str = DELIVERY_MODE_FOREGROUND,
+    allow_foreground_fallback: bool = False,
     lock: DesktopLock | None = None,
     on_event: EventCallback | None = None,
 ) -> dict[str, Any]:
@@ -326,11 +404,13 @@ async def run_task(
                 "start_url": start_url,
                 "deadline_ms": deadline_ms,
                 "max_steps": max_steps,
+                "mode": mode,
+                "allow_foreground_fallback": allow_foreground_fallback,
                 "model": MODEL,
                 "api_base_url": api_base_url,
             }
             if find_cua_driver() is None:  # Kept defensive; preflight already checked it.
-                return failure("cua-driver not found. Run: yutori-mcp computer-use setup")
+                return failure("cua-driver not found. Run: yutori-mcp computer-use setup", delivery_mode=mode)
             result = await _supervise(
                 command=python_runner_command(),
                 request=request,
@@ -340,4 +420,4 @@ async def run_task(
             )
             return attach_run_link(result, platform_url)
     except (ComputerUseBusyError, RuntimeError, OSError, ValueError) as error:
-        return failure(str(error))
+        return failure(str(error), delivery_mode=mode)

--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -393,12 +393,18 @@ COMPUTER_USE_DEFAULT_MINUTES = 30
 COMPUTER_USE_MAX_MINUTES = 60
 # Shared with computer_use/cli.py's `--max-steps` argparse default and server.py's
 # run_computer_use_task signature default, mirroring COMPUTER_USE_DEFAULT_MINUTES above so the
-# three call sites cannot drift apart if the default ever changes.
+# three call sites cannot drift apart if the default ever changes. The same holds for
+# COMPUTER_USE_DEFAULT_MODE and the `mode` / `allow_foreground_fallback` fields below, which
+# cli.py's `--mode` / `--allow-foreground-fallback` and server.py's signature mirror.
 COMPUTER_USE_DEFAULT_MAX_STEPS = 60
+# Mirrors computer_use/constants.py DELIVERY_MODES (this module stays free of computer_use
+# imports so the schema can load without the runtime); a test pins the two together.
+ComputerUseMode = Literal["foreground", "background"]
+COMPUTER_USE_DEFAULT_MODE: ComputerUseMode = "foreground"
 
 
 class ComputerUseTaskInput(ToolInput):
-    task: str = Field(..., description="Task to perform on the visible Mac desktop")
+    task: str = Field(..., description="Task to perform on the Mac desktop or in the target app's window")
     app: str | None = Field(default=None, description="Optional application to target")
     start_url: str | None = Field(
         default=None, description="Optional URL to open in the target app"
@@ -412,10 +418,38 @@ class ComputerUseTaskInput(ToolInput):
     max_steps: int = Field(
         default=COMPUTER_USE_DEFAULT_MAX_STEPS, ge=1, description="Maximum actions before stopping the run"
     )
+    mode: ComputerUseMode = Field(
+        default=COMPUTER_USE_DEFAULT_MODE,
+        description=(
+            "'foreground' (default) drives the whole visible desktop; the user must not touch the Mac. "
+            "'background' drives only the target app's window without taking focus, so the user can keep "
+            "working; only that window is captured. Requires app."
+        ),
+    )
+    allow_foreground_fallback: bool = Field(
+        default=False,
+        description=(
+            "Background mode only. When true, an action the driver reports as not landing in the "
+            "background is retried once with the target window fronted briefly and the prior app restored."
+        ),
+    )
+
     @model_validator(mode="after")
     def require_app_for_start_url(self) -> ComputerUseTaskInput:
         if self.start_url is not None and self.app is None:
             raise ValueError("start_url requires app")
+        return self
+
+    @model_validator(mode="after")
+    def require_app_for_background(self) -> ComputerUseTaskInput:
+        if self.mode == "background" and self.app is None:
+            raise ValueError("mode='background' requires app")
+        return self
+
+    @model_validator(mode="after")
+    def require_background_for_fallback(self) -> ComputerUseTaskInput:
+        if self.allow_foreground_fallback and self.mode != "background":
+            raise ValueError("allow_foreground_fallback requires mode='background'")
         return self
 
 

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -161,6 +161,7 @@ async def _invoke(tool_name: str, args: dict[str, Any]) -> str:
     handler = _TOOL_HANDLERS[tool_name]
     try:
         if tool_name == "run_computer_use_task":
+            from .computer_use.constants import DELIVERY_MODES
             from .computer_use.result import failure, format_result
 
             try:
@@ -173,7 +174,11 @@ async def _invoke(tool_name: str, args: dict[str, Any]) -> str:
                 logger.error(
                     "Computer-use task failed before the runner returned a result"
                 )
-                result = failure(str(error))
+                requested_mode = args.get("mode")
+                delivery_mode = (
+                    str(requested_mode) if requested_mode in DELIVERY_MODES else COMPUTER_USE_DEFAULT_MODE
+                )
+                result = failure(str(error), delivery_mode=delivery_mode)
             return format_result(result)
         client = get_adapter()
         result, context = await handler(client, args)
@@ -634,7 +639,7 @@ async def _handle_computer_use(
         with lock:
             blocker = first_blocker()
             if blocker is not None:
-                return failure(blocker_message(blocker)), {}
+                return failure(blocker_message(blocker), delivery_mode=params.mode), {}
             api_key, api_base_url, platform_url = resolve_run_credentials_and_platform_url()
             return (
                 await run_task(
@@ -652,7 +657,7 @@ async def _handle_computer_use(
                 {},
             )
     except ComputerUseBusyError as error:
-        return failure(str(error)), {}
+        return failure(str(error), delivery_mode=params.mode), {}
 
 
 # Tool-name -> handler registry, consulted by _invoke() above. Mirrors

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -35,9 +35,11 @@ from .schema_utils import output_fields_to_output_schema
 from .schemas import (
     COMPUTER_USE_DEFAULT_MAX_STEPS,
     COMPUTER_USE_DEFAULT_MINUTES,
+    COMPUTER_USE_DEFAULT_MODE,
     DEFAULT_LIST_LIMIT,
     BrowserChoice,
     BrowsingTaskInput,
+    ComputerUseMode,
     ComputerUseTaskInput,
     CreateScoutInput,
     EditScoutInput,
@@ -407,6 +409,8 @@ async def run_computer_use_task(
     start_url: str | None = None,
     minutes: float = COMPUTER_USE_DEFAULT_MINUTES,
     max_steps: int = COMPUTER_USE_DEFAULT_MAX_STEPS,
+    mode: ComputerUseMode = COMPUTER_USE_DEFAULT_MODE,
+    allow_foreground_fallback: bool = False,
     ctx: Context | None = None,
 ) -> str:
     # `ctx` is FastMCP's injected request context (excluded from the client-facing
@@ -579,7 +583,11 @@ async def _handle_edit_scout(
 
 
 def _progress_reporter(
-    ctx: Context, max_steps: int
+    ctx: Context,
+    max_steps: int,
+    *,
+    mode: str = COMPUTER_USE_DEFAULT_MODE,
+    app: str | None = None,
 ) -> Callable[[dict[str, Any]], Awaitable[None]]:
     """Turn runner events into MCP progress + log notifications.
 
@@ -592,7 +600,8 @@ def _progress_reporter(
 
     async def on_event(event: dict[str, Any]) -> None:
         if event.get("type") == "ready":
-            message = f"Computer-use runner ready; driving the desktop (up to {max_steps} steps)."
+            surface = f"the {app} window in the background" if mode == "background" else "the desktop"
+            message = f"Computer-use runner ready; driving {surface} (up to {max_steps} steps)."
             await ctx.report_progress(progress=0, message=message)
             await ctx.info(message)
             return
@@ -634,7 +643,11 @@ async def _handle_computer_use(
                     api_base_url=api_base_url,
                     platform_url=platform_url,
                     lock=lock,
-                    on_event=_progress_reporter(ctx, params.max_steps) if ctx else None,
+                    on_event=(
+                        _progress_reporter(ctx, params.max_steps, mode=params.mode, app=params.app)
+                        if ctx
+                        else None
+                    ),
                 ),
                 {},
             )
@@ -698,8 +711,11 @@ def _register_computer_use_tool() -> None:
         return
     mcp.tool(
         description=(
-            "Operate the foreground Mac desktop using Yutori computer use. "
-            "Do not touch the Mac during the run. Visible desktop content is sent to Yutori."
+            "Operate a Mac with Yutori computer use. mode='foreground' (default) drives the whole "
+            "visible desktop: do not touch the Mac during the run, and visible desktop content is sent "
+            "to Yutori. mode='background' drives only the target app's window without taking focus, so "
+            "the user can keep working; only that window's content is sent. Use it when the user asks to "
+            "run something in the background or while they keep working. Background requires app."
         ),
         annotations=_DESTRUCTIVE_OPEN_WORLD,
     )(run_computer_use_task)

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import asyncio
 import hashlib
 import importlib.metadata
@@ -13,6 +14,7 @@ import time
 import urllib.request
 from collections.abc import Callable
 from contextlib import contextmanager
+from dataclasses import dataclass
 from urllib.error import HTTPError
 from pathlib import Path
 from types import SimpleNamespace
@@ -27,7 +29,9 @@ from yutori.navigator.macos.transport import CuaDriverToolError, CuaDriverUncert
 from yutori_mcp.computer_use import preflight, runner as runner_module, supervisor
 from yutori_mcp.computer_use.app import pick_best_window, prepare_app
 from yutori_mcp.computer_use.constants import (
+    DELIVERY_MODE_BACKGROUND,
     DELIVERY_MODE_FOREGROUND,
+    DELIVERY_MODES,
     DRIVER_VERSION,
     MCP_VERSION,
     PROTOCOL_VERSION,
@@ -55,7 +59,7 @@ from yutori_mcp.computer_use.supervisor import (
     python_runner_command,
     run_task,
 )
-from yutori_mcp.schemas import COMPUTER_USE_DEFAULT_MINUTES, ComputerUseTaskInput
+from yutori_mcp.schemas import COMPUTER_USE_DEFAULT_MINUTES, COMPUTER_USE_DEFAULT_MODE, ComputerUseMode, ComputerUseTaskInput
 
 
 @pytest.mark.parametrize("minutes", [0.9, 60.1])
@@ -1146,7 +1150,7 @@ async def test_prepare_app_retries_bundle_as_name_and_fronts_best_window():
         wait=AsyncMock(),
     )
     target = await prepare_app(computer, "com.apple.calculator", "https://example.com")
-    assert target == {"name": "Calculator", "pid": 42}
+    assert target == {"name": "Calculator", "pid": 42, "window_id": 7}
     assert computer.launch_app.await_args_list[0].kwargs == {
         "bundle_id": "com.apple.calculator",
         "urls": ["https://example.com"],
@@ -1164,7 +1168,7 @@ async def test_prepare_app_launches_finder_by_bundle_id():
 
     target = await prepare_app(computer, "Finder", None)
 
-    assert target == {"name": "Finder", "pid": 42}
+    assert target == {"name": "Finder", "pid": 42, "window_id": None}
     computer.launch_app.assert_awaited_once_with(bundle_id="com.apple.finder", urls=None)
 
 
@@ -1194,7 +1198,7 @@ async def test_prepare_app_fronts_running_persistent_app_after_launch_failure():
         wait=AsyncMock(),
     )
     target = await prepare_app(computer, "Finder", None)
-    assert target == {"name": "Finder", "pid": 42}
+    assert target == {"name": "Finder", "pid": 42, "window_id": None}
     computer._call_tool.assert_awaited_once_with("list_apps", {}, read_only=True)
     computer.bring_to_front.assert_awaited_once_with(42, None)
 
@@ -1206,7 +1210,7 @@ async def test_prepare_app_does_not_retry_uncertain_fronting():
         wait=AsyncMock(),
     )
     target = await prepare_app(computer, "Calculator", None)
-    assert target == {"name": "Calculator", "pid": 42}
+    assert target == {"name": "Calculator", "pid": 42, "window_id": None}
     computer.bring_to_front.assert_awaited_once_with(42, None)
     computer.wait.assert_awaited_once_with(800)
 
@@ -1231,13 +1235,15 @@ async def test_smoke_reports_preflight_detail_and_fix(monkeypatch, tmp_path, cap
 
 def _valid_request(**overrides):
     request = {
-        "protocol_version": 1,
+        "protocol_version": PROTOCOL_VERSION,
         "type": "run",
         "task": "open calculator",
         "app": None,
         "start_url": None,
         "deadline_ms": 1_000_000,
         "max_steps": 10,
+        "mode": "foreground",
+        "allow_foreground_fallback": False,
         "model": "n2",
         "api_base_url": "https://api.dev.yutori.com/v1",
     }
@@ -1254,10 +1260,15 @@ def test_parse_request_accepts_python_only_shape():
 @pytest.mark.parametrize(
     "overrides,code",
     [
-        ({"protocol_version": 2}, "UNSUPPORTED_PROTOCOL_VERSION"),
+        ({"protocol_version": PROTOCOL_VERSION + 1}, "UNSUPPORTED_PROTOCOL_VERSION"),
         ({"type": "walk"}, "INVALID_REQUEST"),
         ({"task": ""}, "INVALID_REQUEST"),
         ({"start_url": "https://x", "app": None}, "INVALID_REQUEST"),
+        ({"mode": "sideways"}, "INVALID_REQUEST"),
+        ({"mode": None}, "INVALID_REQUEST"),
+        ({"mode": "background", "app": None}, "INVALID_REQUEST"),
+        ({"allow_foreground_fallback": "yes"}, "INVALID_REQUEST"),
+        ({"allow_foreground_fallback": True, "mode": "foreground"}, "INVALID_REQUEST"),
         ({"deadline_ms": 0}, "INVALID_REQUEST"),
         ({"max_steps": -1}, "INVALID_REQUEST"),
         ({"api_base_url": None}, "INVALID_REQUEST"),
@@ -1405,8 +1416,15 @@ class _FakeComputer:
 
     def __init__(self, **kwargs):
         self.kwargs = kwargs
-        self.presentation = _FakePresentation()
-        self.presentation_status = MacOSPresentationStatus(True, True, "active", "yutori", codec="webp")
+        self.presentation_requested = kwargs.get("presentation", True)
+        self.presentation = _FakePresentation() if self.presentation_requested else None
+        self.presentation_status = MacOSPresentationStatus(
+            self.presentation_requested,
+            self.presentation is not None,
+            "active" if self.presentation is not None else "unavailable",
+            "yutori" if self.presentation is not None else "hidden",
+            codec="webp",
+        )
         self.cancellation = _FakeCancellation()
         self.current_observation = None
         self.target_pid = None
@@ -1427,10 +1445,31 @@ class _FakeComputer:
             "screenshots": 2,
         }
         self.closed = False
+        self.screenshots = 0
+        self.window_targets: list[Any] = []
+        self.action_outcomes: tuple[Any, ...] = ()
+        self.focus_guard_trips = 0
+        self.delivery_counts = {
+            "background_attempts": 0,
+            "foreground_escalations": 0,
+            "fallback_skips": 0,
+            "background_refusals": 0,
+            "window_rebinds": 0,
+        }
+        self.window_target_info = None
+        self.__dict__.update(self.telemetry_overrides)
         self.__class__.instances.append(self)
+
+    telemetry_overrides: dict[str, Any] = {}
 
     async def __aenter__(self):
         return self
+
+    async def screenshot(self):
+        self.screenshots += 1
+
+    async def set_window_target(self, target):
+        self.window_targets.append(target)
 
     async def aclose(self):
         self.closed = True
@@ -1657,3 +1696,586 @@ def test_repository_contains_no_node_runtime_surface():
     assert "secrets.SDK_DEPLOY_KEY" not in text
     assert "PYSDK_DEPLOY_KEY" not in text
     assert "git+ssh" not in text
+
+
+# --- background mode ----------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _FakeWindowTarget:
+    pid: int
+    window_id: int
+    title: str | None = None
+    app_name: str | None = None
+
+
+def _background_request(**overrides):
+    request = _valid_request(app="Notes", mode="background", deadline_ms=int((time.time() + 60) * 1000))
+    request.update(overrides)
+    return request
+
+
+def test_computer_use_mode_defaults_and_validators():
+    params = ComputerUseTaskInput(task="t")
+    assert params.mode == "foreground" and params.allow_foreground_fallback is False
+    with pytest.raises(ValidationError, match="mode='background' requires app"):
+        ComputerUseTaskInput(task="t", mode="background")
+    with pytest.raises(ValidationError, match="allow_foreground_fallback requires mode='background'"):
+        ComputerUseTaskInput(task="t", app="Notes", allow_foreground_fallback=True)
+    with pytest.raises(ValidationError):
+        ComputerUseTaskInput(task="t", app="Notes", mode="sideways")
+    background = ComputerUseTaskInput(task="t", app="Notes", mode="background", allow_foreground_fallback=True)
+    assert background.model_dump()["mode"] == "background"
+    assert background.model_dump()["allow_foreground_fallback"] is True
+
+
+def test_computer_use_mode_literal_matches_runtime_delivery_modes():
+    from typing import get_args
+
+    assert set(get_args(ComputerUseMode)) == set(DELIVERY_MODES)
+    assert COMPUTER_USE_DEFAULT_MODE == DELIVERY_MODE_FOREGROUND
+
+
+def test_run_computer_use_task_signature_mirrors_the_schema_defaults():
+    import inspect
+
+    from yutori_mcp import server
+
+    parameters = inspect.signature(server.run_computer_use_task).parameters
+    fields = ComputerUseTaskInput.model_fields
+    assert parameters["mode"].default == fields["mode"].default == COMPUTER_USE_DEFAULT_MODE
+    assert parameters["allow_foreground_fallback"].default is fields["allow_foreground_fallback"].default is False
+    assert list(parameters)[-1] == "ctx"
+
+
+async def test_server_forwards_mode_and_fallback_to_the_runner(monkeypatch, tmp_path):
+    from yutori_mcp import server
+    from yutori_mcp.computer_use import lock as lock_module
+
+    forwarded: dict[str, Any] = {}
+
+    async def run_with_lock(**kwargs: Any) -> dict[str, str]:
+        forwarded.update(kwargs)
+        return {"outcome": "completed", "delivery_mode": "background"}
+
+    monkeypatch.setattr(lock_module, "DesktopLock", lambda: DesktopLock(tmp_path / "desktop.lock"))
+    monkeypatch.setattr(preflight, "first_blocker", lambda: None)
+    monkeypatch.setattr(supervisor, "run_task", run_with_lock)
+    monkeypatch.setattr(
+        "yutori_mcp.adapter.resolve_run_credentials_and_platform_url",
+        lambda: ("k", "https://api.yutori.com/v1", "https://platform.yutori.com"),
+    )
+
+    result, _ = await server._handle_computer_use(
+        None, {"task": "add a note", "app": "Notes", "mode": "background", "allow_foreground_fallback": True}
+    )
+    assert result["delivery_mode"] == "background"
+    assert forwarded["mode"] == "background" and forwarded["allow_foreground_fallback"] is True
+    assert forwarded["app"] == "Notes"
+    assert forwarded["platform_url"] == "https://platform.yutori.com"
+
+
+def test_cli_run_parser_accepts_mode_and_fallback_flags():
+    from yutori_mcp.computer_use import cli
+
+    parser = argparse.ArgumentParser()
+    cli.register_parser(parser.add_subparsers(dest="command"))
+    args = parser.parse_args(
+        ["computer-use", "run", "add a note", "--app", "Notes", "--mode", "background", "--allow-foreground-fallback"]
+    )
+    assert args.mode == "background" and args.allow_foreground_fallback is True
+    default = parser.parse_args(["computer-use", "run", "add a note"])
+    assert default.mode == COMPUTER_USE_DEFAULT_MODE and default.allow_foreground_fallback is False
+    with pytest.raises(SystemExit):
+        parser.parse_args(["computer-use", "run", "x", "--mode", "sideways"])
+
+
+def test_hands_off_notice_depends_on_the_mode():
+    from yutori_mcp.computer_use import cli
+
+    assert cli.hands_off_notice("foreground") == (
+        "The model takes over this Mac's desktop now; do not touch it during the run."
+    )
+    assert "keep working" in cli.hands_off_notice("background")
+    assert "leave that window alone" in cli.hands_off_notice("background")
+
+
+async def test_cli_run_forwards_the_mode_and_prints_the_matching_notice(monkeypatch, capsys):
+    from yutori_mcp.computer_use import cli
+
+    run = AsyncMock(return_value={"outcome": "completed", "delivery_mode": "background", "final_text": "done"})
+    monkeypatch.setattr(cli, "_blocked", lambda: False)
+    monkeypatch.setattr(cli, "run_task", run)
+    monkeypatch.setattr(
+        "yutori_mcp.adapter.resolve_run_credentials_and_platform_url",
+        lambda: ("k", "https://api.yutori.com/v1", "https://platform.yutori.com"),
+    )
+    args = SimpleNamespace(
+        task="add a note",
+        app="Notes",
+        start_url=None,
+        minutes=30,
+        max_steps=60,
+        mode="background",
+        allow_foreground_fallback=True,
+    )
+    assert await cli._run_custom(args) == 0
+    assert run.await_args.kwargs["mode"] == "background"
+    assert run.await_args.kwargs["allow_foreground_fallback"] is True
+    assert run.await_args.kwargs["platform_url"] == "https://platform.yutori.com"
+    out = capsys.readouterr().out
+    assert cli.hands_off_notice("background") in out
+    assert "Delivery mode: background" in out
+    with pytest.raises(ValidationError, match="requires app"):
+        await cli._run_custom(SimpleNamespace(**{**vars(args), "app": None}))
+
+
+async def test_run_task_request_carries_mode_and_fallback(tmp_path):
+    driver = tmp_path / "cua-driver"
+    driver.write_text("")
+    supervise = AsyncMock(return_value={"outcome": "completed"})
+    with (
+        patch.object(supervisor, "_supervise", supervise),
+        patch.object(supervisor, "find_cua_driver", return_value=driver),
+    ):
+        await run_task(**_run_task_kwargs(tmp_path, app="Notes", mode="background", allow_foreground_fallback=True))
+    request = supervise.await_args.kwargs["request"]
+    assert request["protocol_version"] == PROTOCOL_VERSION == 2
+    assert request["mode"] == "background" and request["allow_foreground_fallback"] is True
+
+
+async def test_run_task_defaults_to_foreground_and_reports_failures_in_the_requested_mode(tmp_path):
+    with patch.object(supervisor, "find_cua_driver", return_value=None):
+        foreground = await run_task(**_run_task_kwargs(tmp_path))
+        background = await run_task(**_run_task_kwargs(tmp_path, app="Notes", mode="background"))
+    assert foreground["outcome"] == "failed" and foreground["delivery_mode"] == "foreground"
+    assert background["outcome"] == "failed" and background["delivery_mode"] == "background"
+
+
+async def test_supervisor_synthesized_results_carry_the_requested_mode():
+    process = _Process(_stream(json.dumps(_ready_event())), _stream())
+    with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=process)):
+        result = await _supervise(
+            command=python_runner_command(),
+            request={"type": "run", "mode": "background"},
+            api_key="yt-key",
+            deadline=time.monotonic() + 1,
+        )
+    assert result["outcome"] == "failed" and result["delivery_mode"] == "background"
+    assert "exited without a result" in result["final_text"]
+
+
+def test_event_shape_checks_delivery_modes_and_accepts_the_new_action_fields():
+    action = {
+        "type": "action",
+        "index": 0,
+        "tool": "left_click",
+        "status": "executed",
+        "raw_status": "confirmed",
+        "delivery_mode": "background",
+        "route": "accessibility",
+        "refusal_code": None,
+        "effect": "confirmed",
+        "escalated": True,
+    }
+    assert supervisor._event_shape_error(action) is None
+    assert supervisor._event_shape_error({**action, "delivery_mode": "sideways"}) == (
+        "invalid or missing fields: delivery_mode"
+    )
+    assert supervisor._event_shape_error(_result_event(delivery_mode="background")) is None
+    assert supervisor._event_shape_error(_result_event(delivery_mode="sideways")) == (
+        "invalid or missing fields: delivery_mode"
+    )
+
+
+def test_parse_request_accepts_background_with_app():
+    parsed = parse_request(_valid_request(app="Notes", mode="background", allow_foreground_fallback=True))
+    assert parsed["mode"] == "background" and parsed["allow_foreground_fallback"] is True
+    assert parse_request(_valid_request())["mode"] == "foreground"
+
+
+def test_computer_kwargs_keep_the_foreground_shape_and_add_window_scope_for_background():
+    cancellation = object()
+    foreground = runner_module._computer_kwargs(
+        parse_request(_valid_request()), deadline=1.0, cancellation=cancellation, api_key="k"
+    )
+    assert foreground == {
+        "presentation": True,
+        "allow_local_shell": True,
+        "execution_deadline": 1.0,
+        "cancellation": cancellation,
+        "known_secrets": ("k",),
+    }
+    background = runner_module._computer_kwargs(
+        parse_request(_valid_request(app="Notes", mode="background", allow_foreground_fallback=True)),
+        deadline=1.0,
+        cancellation=cancellation,
+        api_key="k",
+    )
+    assert background == {
+        **foreground,
+        "scope": "window",
+        "allow_foreground_fallback": True,
+    }
+
+
+def test_system_context_varies_only_in_the_mode_specific_parts():
+    foreground = runner_module.system_context("foreground")
+    background = runner_module.system_context("background", "Notes")
+    assert foreground == runner_module.SYSTEM_CONTEXT
+    assert foreground.startswith("You control the entire macOS screen.")
+    assert background.startswith("You control exactly one application window: Notes.")
+    assert "entire macOS screen" not in background and "bring anything to the front" in background
+    assert "Never use the shell to open, launch, or activate applications" in background
+    assert "open -a" not in foreground
+    assert "leave that result in view" not in background
+    for shared in ("cmd, not ctrl", "Shell commands run headlessly", "Do not open or change System Settings"):
+        assert shared in foreground and shared in background
+    assert "the target application" in runner_module.system_context("background")
+
+
+def test_supports_background_mode_reads_the_sdk_signature(monkeypatch):
+    class WithScope:
+        def __init__(self, *, scope="desktop"):
+            pass
+
+    class Legacy:
+        def __init__(self, *, presentation=True):
+            pass
+
+    monkeypatch.setattr(runner_module, "MacOSComputer", WithScope)
+    assert runner_module._supports_background_mode() is True
+    monkeypatch.setattr(runner_module, "MacOSComputer", Legacy)
+    assert runner_module._supports_background_mode() is False
+
+
+async def test_run_request_background_binds_the_window_and_never_fronts(monkeypatch):
+    _FakeComputer.instances.clear()
+    _FakeAgent.instances.clear()
+    prepared = AsyncMock(return_value={"name": "Notes", "pid": 42, "window_id": 7})
+    monkeypatch.setattr(runner_module, "MacOSComputer", _FakeComputer)
+    monkeypatch.setattr(runner_module, "N2ComputerAgent", _FakeAgent)
+    monkeypatch.setattr(runner_module, "prepare_app", prepared)
+    monkeypatch.setattr(runner_module, "_supports_background_mode", lambda: True)
+    monkeypatch.setattr("yutori.navigator.macos.MacOSWindowTarget", _FakeWindowTarget, raising=False)
+    monkeypatch.setattr(
+        _FakeComputer,
+        "telemetry_overrides",
+        {
+            "delivery_counts": {
+                "background_attempts": 5,
+                "foreground_escalations": 2,
+                "fallback_skips": 3,
+                "background_refusals": 1,
+                "window_rebinds": 1,
+            },
+            "window_target_info": {"pid": 42, "window_id": 7, "app_name": "Notes"},
+        },
+    )
+    stream = _CollectStream()
+    request = parse_request(_background_request(allow_foreground_fallback=True))
+
+    assert await runner_module.run_request(request, Emitter(stream), "yt-secret") == "completed"
+
+    computer = _FakeComputer.instances[-1]
+    agent = _FakeAgent.instances[-1]
+    assert computer.kwargs["scope"] == "window" and computer.kwargs["presentation"] is True
+    assert computer.kwargs["allow_foreground_fallback"] is True
+    assert computer.screenshots == 0  # no pre-launch desktop frame in window scope
+    assert prepared.await_args.args[1:] == ("Notes", None) and prepared.await_args.kwargs == {"front": False}
+    assert computer.window_targets == [_FakeWindowTarget(42, 7, app_name="Notes")]
+    assert computer.target_pid == 42
+    assert agent.kwargs["instructions"].startswith("You control exactly one application window: Notes.")
+    assert agent.kwargs["presentation"] is computer.presentation
+    result = json.loads(stream.lines[-1])
+    assert result["delivery_mode"] == "background"
+    assert result["reasoning_overlay_requested"] is True and result["reasoning_overlay_effective"] is True
+    assert result["fallback_escalations"] == 2 and result["background_refusals"] == 1
+    assert result["fallback_skips"] == 3
+    assert result["window_rebinds"] == 1 and result["focus_guard_trips"] == 0
+    assert result["preview_frames"] == 0
+    assert result["window_target"] == {"pid": 42, "window_id": 7, "app_name": "Notes"}
+    action = next(json.loads(line) for line in stream.lines if json.loads(line)["type"] == "action")
+    assert action["delivery_mode"] == "background" and action["route"] == "pixel"
+    assert action["effect"] is None and action["escalated"] is False
+
+    prepared.return_value = {"name": "Notes", "pid": 43, "window_id": 9}
+    assert await computer.recover_target() == 43
+    assert prepared.await_args.kwargs == {"front": False}
+    assert computer.window_targets[-1] == _FakeWindowTarget(43, 9, app_name="Notes")
+
+
+async def test_run_request_foreground_still_consumes_the_prelaunch_frame_and_fronts(monkeypatch):
+    _FakeComputer.instances.clear()
+    prepared = AsyncMock(return_value={"name": "Notes", "pid": 42, "window_id": 7})
+    monkeypatch.setattr(runner_module, "MacOSComputer", _FakeComputer)
+    monkeypatch.setattr(runner_module, "N2ComputerAgent", _FakeAgent)
+    monkeypatch.setattr(runner_module, "prepare_app", prepared)
+    stream = _CollectStream()
+    request = parse_request(_valid_request(app="Notes", deadline_ms=int((time.time() + 60) * 1000)))
+
+    assert await runner_module.run_request(request, Emitter(stream), "yt-secret") == "completed"
+
+    computer = _FakeComputer.instances[-1]
+    assert computer.screenshots == 1
+    assert prepared.await_args.kwargs == {"front": True}
+    assert computer.window_targets == []
+    result = json.loads(stream.lines[-1])
+    assert result["delivery_mode"] == "foreground" and result["window_target"] is None
+    assert result["fallback_escalations"] == 0 and result["background_refusals"] == 0
+
+
+async def test_run_request_background_without_sdk_support_fails_before_touching_the_desktop(monkeypatch):
+    class Untouchable:
+        def __init__(self, **_kwargs):
+            raise AssertionError("MacOSComputer must not be constructed")
+
+    monkeypatch.setattr(runner_module, "MacOSComputer", Untouchable)
+    monkeypatch.setattr(runner_module, "_supports_background_mode", lambda: False)
+    stream = _CollectStream()
+
+    assert await runner_module.run_request(parse_request(_background_request()), Emitter(stream), "k") == "failed"
+
+    (event,) = [json.loads(line) for line in stream.lines]
+    assert event["type"] == "error" and event["code"] == "UNSUPPORTED_MODE"
+    assert SDK_VERSION in event["message"]
+
+
+async def test_action_reporter_reports_the_delivery_the_sdk_observed():
+    computer = SimpleNamespace(action_outcomes=[])
+    stream = _CollectStream()
+    reporter = ActionReporter(
+        Emitter(stream),
+        time.monotonic(),
+        delivery_mode="background",
+        action_delivery=runner_module._action_delivery(computer),
+    )
+    item = {"name": "computer_batch", "arguments": {"actions": []}}
+    # One batch: a background click, an escalated type, then a background key press.
+    computer.action_outcomes.extend(
+        [
+            SimpleNamespace(
+                requested_delivery="background", route="accessibility", effect="unverifiable", escalated=False,
+                refusal_code=None,
+            ),
+            SimpleNamespace(
+                requested_delivery="foreground", route="synthetic_events", effect="unverifiable", escalated=True,
+                refusal_code="delivery_failed",
+            ),
+            SimpleNamespace(
+                requested_delivery="background", route="synthetic_events", effect="confirmed", escalated=False,
+                refusal_code=None,
+            ),
+        ]
+    )
+    await reporter.on_computer_call_start(item)
+    await reporter.on_computer_call_end(item, [{"output": "ok"}])
+    await reporter.on_computer_call_start({"name": "bash", "arguments": {"command": "ls"}})
+    await reporter.on_computer_call_end({"name": "bash", "arguments": {"command": "ls"}}, [{"output": "ok"}])
+    first, second = (json.loads(line) for line in stream.lines)
+    assert (first["delivery_mode"], first["route"], first["effect"], first["escalated"]) == (
+        "foreground",
+        "synthetic_events",
+        "confirmed",
+        True,
+    )
+    assert first["refusal_code"] == "delivery_failed"
+    # No new driver outcome for the shell call: fall back to the configured mode.
+    assert (second["delivery_mode"], second["route"], second["effect"], second["escalated"]) == (
+        "background",
+        "pixel",
+        None,
+        False,
+    )
+
+
+def _background_window(window_id: int = 7, **overrides: Any) -> dict[str, Any]:
+    window = {
+        "window_id": window_id,
+        "bounds": {"width": 400, "height": 500},
+        "is_on_screen": False,
+        "on_current_space": None,
+        "z_index": 3,
+    }
+    window.update(overrides)
+    return window
+
+
+async def test_prepare_app_background_unhides_and_returns_the_window_without_fronting():
+    computer = SimpleNamespace(
+        launch_app=AsyncMock(return_value={"pid": 42, "name": "Notes", "windows": [_background_window()]}),
+        unhide_app=AsyncMock(return_value=True),
+        bring_to_front=AsyncMock(side_effect=AssertionError("background runs must never front the app")),
+        list_windows=AsyncMock(),
+        wait=AsyncMock(),
+    )
+    target = await prepare_app(computer, "Notes", None, front=False)
+    assert target == {"name": "Notes", "pid": 42, "window_id": 7}
+    computer.unhide_app.assert_awaited_once_with(42)
+    computer.bring_to_front.assert_not_awaited()
+    computer.list_windows.assert_not_awaited()
+    computer.wait.assert_awaited_once_with(300)
+
+
+async def test_prepare_app_background_polls_for_a_window_after_a_cold_launch():
+    computer = SimpleNamespace(
+        launch_app=AsyncMock(return_value={"pid": 42, "name": "Notes", "windows": []}),
+        unhide_app=AsyncMock(return_value=True),
+        list_windows=AsyncMock(side_effect=[{"windows": []}, {"windows": [_background_window(9)]}]),
+        wait=AsyncMock(),
+    )
+    target = await prepare_app(computer, "Notes", None, front=False)
+    assert target["window_id"] == 9
+    assert computer.list_windows.await_args_list == [((42,),), ((42,),)]
+    assert [call.args for call in computer.wait.await_args_list] == [(250,), (300,)]
+
+
+async def test_prepare_app_background_gives_up_when_no_window_appears(monkeypatch):
+    from yutori_mcp.computer_use import app as app_module
+
+    monkeypatch.setattr(app_module, "_WINDOW_POLL_ATTEMPTS", 2)
+    computer = SimpleNamespace(
+        launch_app=AsyncMock(return_value={"pid": 42, "name": "Notes"}),
+        unhide_app=AsyncMock(return_value=False),
+        list_windows=AsyncMock(return_value={"windows": []}),
+        wait=AsyncMock(),
+    )
+    with pytest.raises(RuntimeError, match="showed no window to target in background mode"):
+        await prepare_app(computer, "Notes", None, front=False)
+    assert computer.list_windows.await_count == 2
+
+
+def test_pick_best_window_prefers_offscreen_content_windows_over_helper_strips():
+    strip = {"window_id": 1, "bounds": {"width": 3360, "height": 30}, "is_on_screen": False, "z_index": 114}
+    content = _background_window(2, bounds={"width": 230, "height": 408}, z_index=67)
+    assert pick_best_window([strip, content])["window_id"] == 2
+    visible = _background_window(3, is_on_screen=True, on_current_space=True, z_index=1)
+    assert pick_best_window([strip, content, visible])["window_id"] == 3
+
+
+def test_format_result_renders_background_fields():
+    text = format_result(
+        {
+            "outcome": "completed",
+            "delivery_mode": "background",
+            "final_text": "done",
+            "reasoning_overlay_requested": True,
+            "reasoning_overlay_effective": True,
+            "codec": "jpeg",
+            "fallback_escalations": 1,
+            "background_refusals": 2,
+            "window_target": {"pid": 42, "window_id": 7, "app_name": "Notes"},
+            "actions": [
+                {
+                    "index": 0,
+                    "tool": "left_click",
+                    "status": "executed",
+                    "raw_status": "confirmed",
+                    "delivery_mode": "foreground",
+                    "route": "accessibility",
+                    "refusal_code": None,
+                    "effect": "confirmed",
+                    "escalated": True,
+                    "duration_ms": 5,
+                }
+            ],
+        }
+    )
+    assert "Delivery mode: background" in text
+    assert "Window target: Notes (pid 42, window 7)" in text
+    assert "Delivery: 1 foreground escalation(s), 2 background refusal(s)" in text
+    assert "mode: foreground; route: accessibility; refusal: None); effect: confirmed [fronted] took 5 ms" in text
+    assert "Menu bar status: active; codec: jpeg" in text
+    assert "Reasoning overlay" not in text
+
+
+def test_format_result_reports_skipped_retries_only_when_present():
+    base = {"outcome": "completed", "delivery_mode": "background", "final_text": "done"}
+    assert "Delivery: 0 foreground escalation(s), 0 background refusal(s)" in format_result(base)
+    assert "skipped" not in format_result(base)
+    assert "Live view" not in format_result(base)
+    assert "Live view: 7 frame(s) streamed to the menu bar item" in format_result({**base, "preview_frames": 7})
+    with_skips = format_result({**base, "fallback_skips": 2})
+    assert "Delivery: 0 foreground escalation(s), 0 background refusal(s), 2 retry(ies) skipped after the window changed" in with_skips
+
+
+def test_format_result_foreground_output_has_no_background_lines():
+    text = format_result({"outcome": "completed", "delivery_mode": "foreground", "final_text": "done"})
+    assert "Delivery:" not in text and "Window target" not in text
+
+
+def test_terminal_result_and_failure_carry_the_requested_mode():
+    assert terminal_result("limit", "x", delivery_mode=DELIVERY_MODE_BACKGROUND)["delivery_mode"] == "background"
+    assert failure("x", delivery_mode=DELIVERY_MODE_BACKGROUND) == terminal_result(
+        "failed", "x", delivery_mode=DELIVERY_MODE_BACKGROUND
+    )
+    assert failure("x")["delivery_mode"] == DELIVERY_MODE_FOREGROUND
+
+
+def test_docs_describe_background_mode():
+    root = Path(__file__).parents[1]
+    assert '"mode": "background"' in (root / "TOOLS.md").read_text()
+    assert "allow_foreground_fallback" in (root / "TOOLS.md").read_text()
+    assert "no background runs" not in (root / "README.md").read_text()
+    skill = " ".join((root / "skills/06-computer-use/SKILL.md").read_text().split())
+    assert "--mode background" in skill
+    assert '"in the background"' in skill and "ask which app to target" in skill
+
+
+# --- computer-use stop --------------------------------------------------------------------
+
+
+async def test_supervisor_advertises_the_runner_pid_only_while_it_runs(monkeypatch, tmp_path):
+    pid_path = tmp_path / "computer-use.pid"
+    monkeypatch.setattr(supervisor, "runner_pid_path", lambda: pid_path)
+    process = _Process(_stream(json.dumps(_ready_event()), json.dumps(_result_event())), _stream())
+    seen: list[str] = []
+
+    async def on_event(event):
+        seen.append(pid_path.read_text().strip())
+
+    result = await _run_supervised(process, on_event=on_event)
+    assert result["outcome"] == "completed"
+    assert seen == ["123"]
+    assert not pid_path.exists()
+
+
+def test_stop_active_run_signals_the_runner_process_group(monkeypatch, tmp_path):
+    pid_path = tmp_path / "computer-use.pid"
+    pid_path.write_text("4242\n")
+    monkeypatch.setattr(supervisor, "runner_pid_path", lambda: pid_path)
+    monkeypatch.setattr(supervisor, "_process_command", lambda pid: f"python -I -m {supervisor.RUNNER_MODULE}")
+    with patch("yutori_mcp.computer_use.supervisor.os.killpg") as killpg:
+        message = supervisor.stop_active_run()
+    killpg.assert_called_once_with(4242, signal.SIGTERM)
+    assert "pid 4242" in message and "aborted" in message
+    assert pid_path.exists()  # the supervisor removes it once the runner exits
+
+
+@pytest.mark.parametrize("command", [None, "/bin/bash -l"])
+def test_stop_active_run_ignores_and_removes_a_stale_pid_file(monkeypatch, tmp_path, command):
+    pid_path = tmp_path / "computer-use.pid"
+    pid_path.write_text("4242\n")
+    monkeypatch.setattr(supervisor, "runner_pid_path", lambda: pid_path)
+    monkeypatch.setattr(supervisor, "_process_command", lambda pid: command)
+    with patch("yutori_mcp.computer_use.supervisor.os.killpg") as killpg:
+        message = supervisor.stop_active_run()
+    killpg.assert_not_called()
+    assert message.startswith("No computer-use run is active")
+    assert not pid_path.exists()
+
+
+def test_stop_active_run_reports_no_run_without_a_pid_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(supervisor, "runner_pid_path", lambda: tmp_path / "missing.pid")
+    assert supervisor.stop_active_run() == "No computer-use run is active."
+
+
+def test_cli_stop_prints_the_stop_outcome(monkeypatch, capsys):
+    from yutori_mcp.computer_use import cli
+
+    monkeypatch.setattr(cli, "stop_active_run", lambda: "No computer-use run is active.")
+    parser = argparse.ArgumentParser()
+    cli.register_parser(parser.add_subparsers(dest="command"))
+    args = parser.parse_args(["computer-use", "stop"])
+    assert cli.dispatch(args.computer_use_command, args) == 0
+    assert capsys.readouterr().out == "No computer-use run is active.\n"

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -1354,6 +1354,27 @@ class _CollectStream:
         pass
 
 
+def test_runner_main_unexpected_failure_preserves_the_requested_background_mode(monkeypatch):
+    stream = _CollectStream()
+
+    async def fail(_request, _emitter, _api_key):
+        raise RuntimeError("unexpected runner failure")
+
+    monkeypatch.setattr(runner_module, "_take_api_key", lambda: "yt-key")
+    monkeypatch.setattr(runner_module, "_claim_protocol_stream", lambda: stream)
+    monkeypatch.setattr(
+        runner_module,
+        "_read_request_line",
+        lambda: json.dumps(_valid_request(app="Notes", mode="background")),
+    )
+    monkeypatch.setattr(runner_module, "_run_until_terminated", fail)
+
+    assert runner_module.main() == 1
+    terminal = json.loads(stream.lines[-1])
+    assert terminal["outcome"] == "failed"
+    assert terminal["delivery_mode"] == DELIVERY_MODE_BACKGROUND
+
+
 async def test_action_events_sanitize_commands_and_never_include_output(monkeypatch):
     secret = "private-value-1234"
     monkeypatch.setenv("SERVICE_API_KEY", secret)
@@ -1775,6 +1796,40 @@ async def test_server_forwards_mode_and_fallback_to_the_runner(monkeypatch, tmp_
     assert forwarded["platform_url"] == "https://platform.yutori.com"
 
 
+async def test_server_early_failures_preserve_the_requested_background_mode(monkeypatch, tmp_path):
+    from yutori_mcp import server
+    from yutori_mcp.computer_use import lock as lock_module
+
+    lock_path = tmp_path / "desktop.lock"
+    monkeypatch.setattr(lock_module, "DesktopLock", lambda: DesktopLock(lock_path))
+    blocker = preflight.CheckResult("driver", False, "missing", "run setup")
+    monkeypatch.setattr(preflight, "first_blocker", lambda: blocker)
+
+    arguments = {"task": "add a note", "app": "Notes", "mode": "background"}
+    blocked, _ = await server._handle_computer_use(None, arguments)
+    assert blocked["delivery_mode"] == DELIVERY_MODE_BACKGROUND
+
+    monkeypatch.setattr(preflight, "first_blocker", lambda: pytest.fail("busy run must not reach preflight"))
+    with DesktopLock(lock_path):
+        busy, _ = await server._handle_computer_use(None, arguments)
+    assert busy["delivery_mode"] == DELIVERY_MODE_BACKGROUND
+
+
+async def test_invoke_unexpected_failure_preserves_the_requested_background_mode(monkeypatch):
+    from yutori_mcp import server
+
+    async def fail_before_result(_client, _arguments):
+        raise RuntimeError("unexpected host failure")
+
+    monkeypatch.setitem(server._TOOL_HANDLERS, "run_computer_use_task", fail_before_result)
+    text = await server._invoke(
+        "run_computer_use_task",
+        {"task": "add a note", "app": "Notes", "mode": "background"},
+    )
+    assert "Outcome: failed" in text
+    assert "Delivery mode: background" in text
+
+
 def test_cli_run_parser_accepts_mode_and_fallback_flags():
     from yutori_mcp.computer_use import cli
 
@@ -2128,6 +2183,21 @@ async def test_prepare_app_background_polls_for_a_window_after_a_cold_launch():
     assert target["window_id"] == 9
     assert computer.list_windows.await_args_list == [((42,),), ((42,),)]
     assert [call.args for call in computer.wait.await_args_list] == [(250,), (300,)]
+
+
+async def test_prepare_app_background_still_resolves_a_window_when_unhide_fails():
+    computer = SimpleNamespace(
+        launch_app=AsyncMock(return_value={"pid": 42, "name": "Notes", "windows": []}),
+        unhide_app=AsyncMock(side_effect=CuaDriverToolError("unhide failed")),
+        list_windows=AsyncMock(return_value={"windows": [_background_window(9)]}),
+        wait=AsyncMock(),
+    )
+
+    target = await prepare_app(computer, "Notes", None, front=False)
+
+    assert target == {"name": "Notes", "pid": 42, "window_id": 9}
+    computer.unhide_app.assert_awaited_once_with(42)
+    computer.list_windows.assert_awaited_once_with(42)
 
 
 async def test_prepare_app_background_gives_up_when_no_window_appears(monkeypatch):

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -736,9 +736,9 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 
 def test_runtime_constants_select_latest_python_surface():
     assert TOOL_SET == "computer_use_tools-20260815"
-    assert SDK_VERSION == "0.9.10"
+    assert SDK_VERSION == "0.9.11"
     assert all(len(digest) == 64 for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256))
-    assert '"yutori==0.9.10"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
+    assert '"yutori==0.9.11"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
 
 
 def test_installed_sdk_matches_the_published_artifact():

--- a/uv.lock
+++ b/uv.lock
@@ -4,10 +4,10 @@ requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform != 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.11' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
     "(python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
+    "python_full_version < '3.11' and sys_platform == 'win32'",
     "python_full_version < '3.11' and sys_platform != 'win32'",
 ]
 
@@ -260,7 +260,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -294,8 +294,8 @@ name = "httpcore2"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
-    { name = "truststore", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "h11" },
+    { name = "truststore" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
@@ -1088,8 +1088,8 @@ source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform != 'win32'",
-    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform == 'win32'",
     "(python_full_version >= '3.11' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32') or (python_full_version == '3.11.*' and sys_platform == 'emscripten')",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/2a/9618a122aeb2a169a28b03889a2995fe297588964333d4a7d67bdf46e147/rpds_py-2026.6.3.tar.gz", hash = "sha256:1cebd1337c242e4ec2293e541f712b2da849b29f48f0c293684b71c0632625d4", size = 64051, upload-time = "2026-06-30T07:17:53.009Z" }
@@ -1359,8 +1359,8 @@ name = "uvicorn"
 version = "0.52.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
-    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "click" },
+    { name = "h11" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
@@ -1370,7 +1370,7 @@ wheels = [
 
 [[package]]
 name = "yutori"
-version = "0.9.10"
+version = "0.9.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1379,9 +1379,9 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/47/421f62313c9a7521af2a551d77e384208d3fc355491d001227b001f54df9/yutori-0.9.10.tar.gz", hash = "sha256:01c13334120b74a38a9e0b1ba51a5c219329f79a3ee046d1245f4eb68068986b", size = 417954, upload-time = "2026-09-02T22:38:53.601Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/28/5af28edc0680b5f93c1c2f0f78f272aad374279e274921eeb4b106738eea/yutori-0.9.11.tar.gz", hash = "sha256:9f1f5bcb14c112f7ca55123edc672517bde8e469264547f3cb8d3975b532262e", size = 444239, upload-time = "2026-09-03T21:12:12.165Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/71/79/e57f6e885a3de7724f05ccceb646a3a1381319874ffbed4fe774298b56e3/yutori-0.9.10-py3-none-any.whl", hash = "sha256:ede183e6796b10451de4ba00da63d61872e46e4bb4fea66fdaa4d58133e334b5", size = 292864, upload-time = "2026-09-02T22:38:52.176Z" },
+    { url = "https://files.pythonhosted.org/packages/66/b9/d7b78c5c13821c475a37cf946173466f5377cf933e8ac2775f00593f1e18/yutori-0.9.11-py3-none-any.whl", hash = "sha256:5a10b9c5240fc5c859a7e680001cb51ef16bbcc0d1cd5b0ea2e3b9ed8995e261", size = 309491, upload-time = "2026-09-03T21:12:10.479Z" },
 ]
 
 [[package]]
@@ -1406,6 +1406,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "yutori", specifier = "==0.9.10" },
+    { name = "yutori", specifier = "==0.9.11" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
## Summary

- `run_computer_use_task` and `computer-use run` gain `mode` (`"foreground"` | `"background"`, default foreground) and `allow_foreground_fallback`. Background requires `app`: the runner constructs the SDK computer in window scope with the overlay off, launches the app without fronting it (`prepare_app(front=False)` unhides it behind the user's windows and resolves the window to drive), binds that window, and gives the model a window-only system context. Foreground behaviour, including the pre-launch desktop frame, the fronting ladder, and the system prompt text, is unchanged byte for byte.
- Protocol v2 carries `mode` and `allow_foreground_fallback`; action events report the delivery the SDK observed (`delivery_mode`, `route`, `effect`, `escalated`) and result events carry the configured mode plus `fallback_escalations`, `background_refusals`, `window_rebinds`, `focus_guard_trips`, and `window_target`. Supervisor-synthesized results keep the requested mode.
- Background runs request the SDK's menu bar status item (yutori-ai/yutori-sdk-python#365): the Yutori mark stays in the menu bar for the whole run, and its menu shows the latest frame the agent saw, its latest action, and Stop (also ⇧⌘Esc). The result line reads `Menu bar status: active` for background runs.
- `computer-use stop` signals the live runner's process group through an advisory pid file next to the desktop lock, as a terminal-side stop.
- Docs: TOOLS.md, README, and the computer-use skill describe both modes and the app-dependent keyboard delivery.

## Dependency

Depends on the yutori SDK window-scope release (yutori-ai/yutori-sdk-python#359 plus the status item #365, shipping together as 0.9.11 via #361; 0.9.10 went out with the overlay shell rail). Until the pin moves, a background request fails cleanly with `UNSUPPORTED_MODE`; the pin bump lands as the final commit on this branch.

## Live view

With yutori-ai/yutori-sdk-python#369 the status item's menu gains **Show live view**: the menu thumbnail and a small always-on-top panel mirror the driven window at ~2 fps while someone is looking (a second driver connection, so the run is not slowed). The result reports `Live view: N frame(s) streamed to the menu bar item` when frames were streamed. Upgrading the SDK changes the overlay host, so `yutori-mcp computer-use setup` must be re-run once after the pin bump (otherwise the status item degrades fail-soft and `doctor` warns).

## Validation

- `uv run --extra dev pytest -q` (405 passed, 1 skipped)
- `uv run --extra dev ruff check src tests`
- Live SDK-level check: strict background mode against Calculator (background clicks computed 9×9 = 81 with another app frontmost; background typing was refused as the driver reports); fallback mode typed 7×7 = 49 and restored focus.
- End-to-end n2 run through `run_task` (this branch + the window-scope SDK worktree in a throwaway venv, strict background mode): task "clear the display, compute 12 * 34" completed with `408` in 24 s over 3 model steps; every action was delivered in the background via the accessibility route, and the frontmost app stayed on Conductor for all 13 samples taken during the run. Result rendered as `Delivery mode: background` / `Window target: Calculator (pid …, window …)` / `Delivery: 0 foreground escalation(s), 0 background refusal(s)`. The MCP-tool run with the published pin follows the 0.9.11 release.
- Second end-to-end run with `allow_foreground_fallback` and a task that requires typing ("type 15*15 and press Return"): completed with `225` in 49 s over 6 steps, 2 foreground escalations, and the frontmost app stayed on Safari for all 25 samples. It also showed the driver's `delivery_failed` verdict can be wrong for part of a typed sequence (the first attempt read `15×1,515×15`), so the SDK now skips the foreground retry when the window already changed, and this branch reports a batch as foreground-delivered when any action in it escalated and surfaces skipped retries in the `Delivery:` line.
- Rerun of the typing task with the guard in place: completed with `225` in 32 s over 5 steps, 0 escalations, 0 refusals, no duplicated input, frontmost app on Conductor for all 17 samples.
- With the menu bar status item (SDK #365) requested: the Calculator task completed with `408` in 47 s, the result reads `Menu bar status: active; codec: webp`, the Yutori mark was visible in the menu bar mid-run (screenshot checked), and the frontmost app stayed on Safari for 23 of 24 samples (the other was Conductor, the terminal).
- Complex task (Numbers: build a 3-month expense sheet, SUM row, save as .ods) with fallback: the first attempt exposed that a closed Open dialog lingers as a zombie window (black frames, `off_space_or_ax_unresolved`), now handled by the SDK's rebind; the second attempt built the titled document and the three expense rows in the background within the 9-minute budget but did not reach the SUM row or the save (`limit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS desktop automation (focus, capture scope, and driver delivery) and bumps the supervisor–runner protocol to v2; mistakes could affect the user’s live session, though validation and fail-closed `UNSUPPORTED_MODE` reduce exposure.
> 
> **Overview**
> Adds **background** macOS computer use alongside the existing **foreground** desktop takeover. `run_computer_use_task`, `computer-use run`, and protocol **v2** accept `mode` (`foreground` | `background`) and `allow_foreground_fallback`; background **requires `app`** and drives only that window via the pinned **yutori 0.9.11** window-scope SDK, without stealing focus.
> 
> The runner binds a resolved window (`prepare_app(front=False)` unhides and polls for a window), uses mode-specific model instructions, reports per-action delivery facts (route, effect, escalations), and surfaces background telemetry in results (window target, refusals, menu bar status). **`computer-use stop`** signals the active runner through an advisory pid file.
> 
> Docs/skills and `TOOLS.md` describe both modes; foreground behavior and prompts stay the same when `mode` is omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca9d5340bbc610001b8dd964b45afd0fa00c8597. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->