### PR TITLE
Pin the yutori SDK runtime at 0.9.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.7"
+version = "0.5.8"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"
@@ -30,9 +30,9 @@ dependencies = [
     # breaks the install as soon as 2.x resolves.
     "mcp>=1.0.0,<2.0.0",
     "pydantic>=2.0.0",
-    # SDK 0.9.9 owns the complete Python/Swift macOS runtime. Doctor verifies
+    # SDK 0.9.10 owns the complete Python/Swift macOS runtime. Doctor verifies
     # the installed payload against the exact published wheel before use.
-    "yutori==0.9.9",
+    "yutori==0.9.10",
 ]
 
 [project.optional-dependencies]

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -14,11 +14,11 @@ TOOL_SET = "computer_use_tools-20260815"
 # so a future second mode can't be introduced with one of those spots left on the old
 # literal by accident.
 DELIVERY_MODE_FOREGROUND = "foreground"
-SDK_VERSION = "0.9.9"
+SDK_VERSION = "0.9.10"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.
-SDK_ARTIFACT_SHA256 = "c1e64663033eb3a6550d6b3af8de331825ebdf5e8ecb7f39575b9544a1b59908"
-SDK_INSTALLATION_SHA256 = "5309391db4d8af899cc84f517969545faf75e8878f04d9278d5af8ed9ded0be6"
+SDK_ARTIFACT_SHA256 = "ede183e6796b10451de4ba00da63d61872e46e4bb4fea66fdaa4d58133e334b5"
+SDK_INSTALLATION_SHA256 = "43dd4313e8c09a93db8fc37c490cbb3c0435bd0b91f03a628d8807320be6ecc0"
 SDK_PROVENANCE_SHA256 = "7cab595d2f00e1a9ab5cd121204fbd6dd4c24163ead3eb76f76eef7fba495fc4"
 
 # The cua-driver release that implements this tool contract, and the checksum

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -707,9 +707,9 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 
 def test_runtime_constants_select_latest_python_surface():
     assert TOOL_SET == "computer_use_tools-20260815"
-    assert SDK_VERSION == "0.9.9"
+    assert SDK_VERSION == "0.9.10"
     assert all(len(digest) == 64 for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256))
-    assert '"yutori==0.9.9"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
+    assert '"yutori==0.9.10"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
 
 
 def test_installed_sdk_matches_the_published_artifact():

--- a/uv.lock
+++ b/uv.lock
@@ -1370,7 +1370,7 @@ wheels = [
 
 [[package]]
 name = "yutori"
-version = "0.9.9"
+version = "0.9.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1379,14 +1379,14 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/47/8d7e40e038ae40ac895effcd72fa480a45d8f4d906c7e81655935e91e2af/yutori-0.9.9.tar.gz", hash = "sha256:a8c5ed2a0423ac9e328a252548663a729828c9db8340becc2f16cfdfd20a2b6c", size = 406215, upload-time = "2026-09-01T22:15:43.818Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/47/421f62313c9a7521af2a551d77e384208d3fc355491d001227b001f54df9/yutori-0.9.10.tar.gz", hash = "sha256:01c13334120b74a38a9e0b1ba51a5c219329f79a3ee046d1245f4eb68068986b", size = 417954, upload-time = "2026-09-02T22:38:53.601Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/88/c4c90e3ca9b91f2869b2150b0538a667331d0d1a28e1ef60f9f67eee1c9a/yutori-0.9.9-py3-none-any.whl", hash = "sha256:c1e64663033eb3a6550d6b3af8de331825ebdf5e8ecb7f39575b9544a1b59908", size = 289038, upload-time = "2026-09-01T22:15:42.434Z" },
+    { url = "https://files.pythonhosted.org/packages/71/79/e57f6e885a3de7724f05ccceb646a3a1381319874ffbed4fe774298b56e3/yutori-0.9.10-py3-none-any.whl", hash = "sha256:ede183e6796b10451de4ba00da63d61872e46e4bb4fea66fdaa4d58133e334b5", size = 292864, upload-time = "2026-09-02T22:38:52.176Z" },
 ]
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.7"
+version = "0.5.8"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -1406,6 +1406,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "yutori", specifier = "==0.9.9" },
+    { name = "yutori", specifier = "==0.9.10" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
Pins `yutori==0.9.10`, which ships the macOS overlay shell-command rail and the menu bar Stop item drawn with the Yutori mark (yutori-sdk-python #356), and bumps yutori-mcp to 0.5.8 so the new pin can reach users. `SDK_ARTIFACT_SHA256` is the PyPI wheel's sha256 (verified by downloading the wheel), `SDK_INSTALLATION_SHA256` was computed with `preflight._stable_distribution_digest` against a fresh install of that wheel, and the provenance file is unchanged so its digest stays. The lockfile is refreshed and the constants test updated. Verified with the full suite against the real wheel, including `test_installed_sdk_matches_the_published_artifact`, and `computer-use doctor` passes on the pinned install with no editable override; the released overlay assets are byte-identical to the ones the compiled overlay cache was built from, so no re-setup is needed on this Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical dependency and digest pin with no application logic changes; risk is mainly that a mismatched local SDK install will fail preflight until upgraded.
> 
> **Overview**
> **Release bump** that pins the computer-use runtime to **`yutori==0.9.10`** and ships **`yutori-mcp` 0.5.8** so installs resolve the new SDK.
> 
> The pin is enforced end-to-end: `pyproject.toml` and `uv.lock` require **0.9.10**, and `SDK_VERSION` plus **`SDK_ARTIFACT_SHA256`** / **`SDK_INSTALLATION_SHA256`** in `constants.py` are updated so doctor/preflight and the runner’s ready handshake still reject wheels or unpacked installs that don’t match the published artifact. **`SDK_PROVENANCE_SHA256`** is unchanged. Tests in `test_runtime_constants_select_latest_python_surface` are aligned with the new version string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60b530a012afb9c8dd703984e3fd3f68afdf6b4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->