### PR TITLE
refactor(adapter): dedupe environment-URL resolution

### DIFF
--- a/src/yutori_mcp/adapter.py
+++ b/src/yutori_mcp/adapter.py
@@ -44,22 +44,31 @@ def current_environment() -> str:
     return os.environ.get(ENV_VAR_ENVIRONMENT) or DEFAULT_ENVIRONMENT
 
 
+def _resolve_environment_url(mapping: dict[str, str], environment: str | None) -> str:
+    """Look up ``environment`` (or the ambient one) in ``mapping``.
+
+    Shared resolution order for every "environment name -> URL" mapping in this
+    module: explicit ``environment`` argument, then the ``YUTORI_ENV`` environment
+    variable, then prod. Raises ``ValueError`` for names not in ``mapping`` so a
+    typo fails loudly instead of silently targeting production.
+    """
+    name = environment or current_environment()
+    try:
+        return mapping[name]
+    except KeyError:
+        valid = ", ".join(sorted(mapping))
+        raise ValueError(
+            f"Unknown Yutori environment {name!r}; expected one of: {valid}"
+        ) from None
+
+
 def resolve_base_url(environment: str | None = None) -> str:
     """Return the API base URL for an environment name.
 
     Resolution order: explicit ``environment`` argument, then the
-    ``YUTORI_ENV`` environment variable, then prod. Raises ``ValueError``
-    for names not in ENVIRONMENT_BASE_URLS so a typo fails loudly instead
-    of silently targeting production.
+    ``YUTORI_ENV`` environment variable, then prod.
     """
-    name = environment or current_environment()
-    try:
-        return ENVIRONMENT_BASE_URLS[name]
-    except KeyError:
-        valid = ", ".join(sorted(ENVIRONMENT_BASE_URLS))
-        raise ValueError(
-            f"Unknown Yutori environment {name!r}; expected one of: {valid}"
-        ) from None
+    return _resolve_environment_url(ENVIRONMENT_BASE_URLS, environment)
 
 
 def resolve_platform_url(environment: str | None = None) -> str:
@@ -68,14 +77,7 @@ def resolve_platform_url(environment: str | None = None) -> str:
     Same resolution order as ``resolve_base_url`` so the run link a computer-use
     result carries always points at the platform that recorded the run.
     """
-    name = environment or current_environment()
-    try:
-        return ENVIRONMENT_PLATFORM_URLS[name]
-    except KeyError:
-        valid = ", ".join(sorted(ENVIRONMENT_PLATFORM_URLS))
-        raise ValueError(
-            f"Unknown Yutori environment {name!r}; expected one of: {valid}"
-        ) from None
+    return _resolve_environment_url(ENVIRONMENT_PLATFORM_URLS, environment)
 
 
 def is_scoped_environment(environment: str | None) -> bool:


### PR DESCRIPTION
## What

`resolve_base_url()` and `resolve_platform_url()` in `src/yutori_mcp/adapter.py` had byte-for-byte identical resolution logic (explicit `environment` argument → `YUTORI_ENV` → prod, with the same "Unknown Yutori environment" `ValueError` on a miss) — the only difference was which dict each one indexed (`ENVIRONMENT_BASE_URLS` vs `ENVIRONMENT_PLATFORM_URLS`).

## Why

This is duplicated logic across two adjacent functions in the same module. Extracting the shared lookup into a small private helper, `_resolve_environment_url(mapping, environment)`, means the resolution order and the exact error-message shape can't silently drift apart between the two call sites if either mapping grows (e.g. a future third environment) or the error text changes in only one place by mistake.

## Why it's safe

- **No tool schema or public API change.** `_resolve_environment_url` is a new private (underscore-prefixed) helper; `resolve_base_url` and `resolve_platform_url` keep their exact signatures, return types, resolution order, and error message format.
- **No observable behavior change.** Verified by running the full test suite (`uv run --extra dev pytest -q`): 378 passed, 1 skipped (the skip is the published-SDK-wheel-hash test, which is gated on an unrelated env var and skips in this sandbox the same way it would before this change). `tests/test_adapter.py` and `tests/test_server.py` specifically exercise both functions' success and unknown-environment paths and pass unchanged.
- **Scoped to one file.** Only `src/yutori_mcp/adapter.py` changed; no call sites elsewhere needed updates since both public function signatures are untouched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UQCzHcA7sEmeynTvdK1P7A

---
_Generated by [Claude Code](https://claude.ai/code/session_01UQCzHcA7sEmeynTvdK1P7A)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file refactor with no public API or behavior change; existing adapter tests cover both URL resolvers.
> 
> **Overview**
> **`resolve_base_url` and `resolve_platform_url`** previously duplicated the same lookup flow (argument → `YUTORI_ENV` → default, with identical `ValueError` on unknown names). That logic now lives in a private **`_resolve_environment_url(mapping, environment)`** helper; each public function only passes its dict (`ENVIRONMENT_BASE_URLS` vs `ENVIRONMENT_PLATFORM_URLS`).
> 
> Signatures, resolution order, and error message shape for the two public helpers are unchanged—this is an internal dedupe in `adapter.py` only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d86c24e7687a5373b47d66252ac9f978f2dfe2c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->