### PR TITLE
refactor(adapter): dedupe run-credentials + platform-url resolution

### DIFF
--- a/src/yutori_mcp/adapter.py
+++ b/src/yutori_mcp/adapter.py
@@ -102,6 +102,18 @@ def resolve_run_credentials(environment: str | None = None) -> tuple[str | None,
     return resolve_api_key_for_environment(name), resolve_base_url(name)
 
 
+def resolve_run_credentials_and_platform_url(environment: str | None = None) -> tuple[str | None, str, str]:
+    """The (api_key, base_url, platform_url) triple a launched computer-use run needs.
+
+    Extends resolve_run_credentials() with the platform URL every run result now carries
+    as run_url, resolved from the same environment so a run's credentials and the link to
+    its own platform chat page can never come from two different environments.
+    """
+    name = environment or current_environment()
+    api_key, base_url = resolve_run_credentials(name)
+    return api_key, base_url, resolve_platform_url(name)
+
+
 class YutoriAPIError(Exception):
     """Raised when the Yutori API returns an error (MCP-facing wrapper)."""
 

--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -151,7 +151,7 @@ async def _mechanical_calculator_check() -> str:
 
 
 async def _smoke_live() -> int:
-    from ..adapter import resolve_platform_url, resolve_run_credentials
+    from ..adapter import resolve_run_credentials_and_platform_url
 
     try:
         with DesktopLock() as lock:
@@ -170,7 +170,7 @@ async def _smoke_live() -> int:
             if copied != "42":
                 print("Mechanical Calculator check failed through CuaDriver: clipboard result did not match '42'.")
                 return 1
-            api_key, api_base_url = resolve_run_credentials()
+            api_key, api_base_url, platform_url = resolve_run_credentials_and_platform_url()
             result = await run_task(
                 task="In Calculator, clear the display, compute 9 * 9, and report the result.",
                 app="Calculator",
@@ -179,7 +179,7 @@ async def _smoke_live() -> int:
                 max_steps=10,
                 api_key=api_key,
                 api_base_url=api_base_url,
-                platform_url=resolve_platform_url(),
+                platform_url=platform_url,
                 lock=lock,
             )
     except ComputerUseBusyError as error:
@@ -201,7 +201,7 @@ async def _print_event(event: dict) -> None:
 
 
 async def _run_custom(args: argparse.Namespace) -> int:
-    from ..adapter import resolve_platform_url, resolve_run_credentials
+    from ..adapter import resolve_run_credentials_and_platform_url
 
     # Reuses the MCP tool's input schema so the CLI enforces the same bounds
     # (minutes 1-60, positive steps, start_url requires app) with the same
@@ -217,12 +217,12 @@ async def _run_custom(args: argparse.Namespace) -> int:
     if _blocked():
         return 1
     print("The model takes over this Mac's desktop now; do not touch it during the run.")
-    api_key, api_base_url = resolve_run_credentials()
+    api_key, api_base_url, platform_url = resolve_run_credentials_and_platform_url()
     result = await run_task(
         **params.model_dump(),
         api_key=api_key,
         api_base_url=api_base_url,
-        platform_url=resolve_platform_url(),
+        platform_url=platform_url,
         on_event=_print_event,
     )
     return _report(result)

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -611,7 +611,7 @@ def _progress_reporter(
 async def _handle_computer_use(
     _: MCPClientAdapter, arguments: dict[str, Any]
 ) -> tuple[dict[str, Any], dict[str, Any]]:
-    from .adapter import resolve_platform_url, resolve_run_credentials
+    from .adapter import resolve_run_credentials_and_platform_url
     from .computer_use.lock import ComputerUseBusyError, DesktopLock
     from .computer_use.preflight import blocker_message, first_blocker
     from .computer_use.result import failure
@@ -626,13 +626,13 @@ async def _handle_computer_use(
             blocker = first_blocker()
             if blocker is not None:
                 return failure(blocker_message(blocker)), {}
-            api_key, api_base_url = resolve_run_credentials()
+            api_key, api_base_url, platform_url = resolve_run_credentials_and_platform_url()
             return (
                 await run_task(
                     **params.model_dump(),
                     api_key=api_key,
                     api_base_url=api_base_url,
-                    platform_url=resolve_platform_url(),
+                    platform_url=platform_url,
                     lock=lock,
                     on_event=_progress_reporter(ctx, params.max_steps) if ctx else None,
                 ),

--- a/tests/test_adapter.py
+++ b/tests/test_adapter.py
@@ -17,6 +17,7 @@ from yutori_mcp.adapter import (
     resolve_base_url,
     resolve_platform_url,
     resolve_run_credentials,
+    resolve_run_credentials_and_platform_url,
 )
 from yutori_mcp.server import _format_api_error
 
@@ -282,6 +283,35 @@ class TestResolveRunCredentials:
         monkeypatch.setenv(ENV_VAR_ENVIRONMENT, "dev")
         with patch("yutori_mcp.adapter.resolve_api_key_for_environment", return_value="yt-prod-key") as resolve_key:
             assert resolve_run_credentials("prod") == ("yt-prod-key", ENVIRONMENT_BASE_URLS["prod"])
+        resolve_key.assert_called_once_with("prod")
+
+
+# ---------------------------------------------------------------------------
+# resolve_run_credentials_and_platform_url
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRunCredentialsAndPlatformUrl:
+    """The (api_key, base_url, platform_url) triple a launched run needs to link itself."""
+
+    def test_extends_run_credentials_with_the_matching_platform(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR_ENVIRONMENT, "dev")
+        with patch("yutori_mcp.adapter.resolve_api_key_for_environment", return_value="yt-dev-key") as resolve_key:
+            assert resolve_run_credentials_and_platform_url() == (
+                "yt-dev-key",
+                ENVIRONMENT_BASE_URLS["dev"],
+                ENVIRONMENT_PLATFORM_URLS["dev"],
+            )
+        resolve_key.assert_called_once_with("dev")
+
+    def test_explicit_environment_overrides_the_ambient_one(self, monkeypatch):
+        monkeypatch.setenv(ENV_VAR_ENVIRONMENT, "dev")
+        with patch("yutori_mcp.adapter.resolve_api_key_for_environment", return_value="yt-prod-key") as resolve_key:
+            assert resolve_run_credentials_and_platform_url("prod") == (
+                "yt-prod-key",
+                ENVIRONMENT_BASE_URLS["prod"],
+                ENVIRONMENT_PLATFORM_URLS["prod"],
+            )
         resolve_key.assert_called_once_with("prod")
 
 

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -720,8 +720,8 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
     monkeypatch.setattr(preflight, "first_blocker", first_blocker)
     monkeypatch.setattr(supervisor, "run_task", run_with_lock)
     monkeypatch.setattr(
-        "yutori_mcp.adapter.resolve_run_credentials",
-        lambda: ("api-key", "https://api.yutori.com/v1"),
+        "yutori_mcp.adapter.resolve_run_credentials_and_platform_url",
+        lambda: ("api-key", "https://api.yutori.com/v1", "https://platform.yutori.com"),
     )
 
     result, raw = await server._handle_computer_use(None, {"task": "open calculator"})
@@ -1113,8 +1113,8 @@ async def test_smoke_allows_two_minutes_for_live_check(monkeypatch, tmp_path):
     monkeypatch.setattr(cli, "run_task", run)
     monkeypatch.setattr(cli, "format_result", lambda _result: "complete")
     monkeypatch.setattr(
-        "yutori_mcp.adapter.resolve_run_credentials",
-        lambda: ("dev-key", "https://api.yutori.com/v1"),
+        "yutori_mcp.adapter.resolve_run_credentials_and_platform_url",
+        lambda: ("dev-key", "https://api.yutori.com/v1", "https://platform.yutori.com"),
     )
 
     assert await cli._smoke_live() == 0


### PR DESCRIPTION
## What

`_smoke_live()`, `_run_custom()`, and `_handle_computer_use()` each called both `resolve_run_credentials()` and `resolve_platform_url()` with no explicit environment argument — two separate calls that each independently resolve the ambient environment (`current_environment()`) to look something up. Added `resolve_run_credentials_and_platform_url(environment=None) -> tuple[str | None, str, str]` to `adapter.py`, which resolves the environment name once and returns the `(api_key, base_url, platform_url)` triple, and switched all three call sites to it.

## Why

This is the same duplication shape `resolve_run_credentials()` itself was extracted (PR #204/#211) to prevent for `api_key`/`base_url`: multiple call sites independently re-deriving values from one implicit environment, with the risk that a future change to the resolution order only gets applied at some of the sites. `resolve_platform_url()` was added alongside the `run_url` feature (landing right before this PR) without folding into that existing consolidation, reintroducing the exact "two related lookups, one ambient environment, duplicated across 3 call sites" pattern.

## Why it's safe

- **No tool schema or public API change.** `resolve_run_credentials()` and `resolve_platform_url()` are both untouched (still directly unit-tested); the new function is additive. `_smoke_live`, `_run_custom`, and `_handle_computer_use` keep identical behavior — same environment resolution order, same values passed to `run_task()`.
- **No observable behavior change.** Verified with the full test suite (`uv run --extra dev pytest -q`): 380 passed, 1 skipped (up from the prior baseline's 378 passed/1 skipped — the +2 are new direct unit tests for the extracted helper). Existing tests exercising `_smoke_live`/`_handle_computer_use` were updated to mock the new consolidated entry point instead of the two calls it replaces, preserving the same coverage.
- **Scoped to the exact 3 call sites that had the duplication**, plus the new helper and its tests — 5 files, +55/-13 net.
- `ruff check .` is clean.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GG52f1KVmHAxBqWLUwzh5N

---
_Generated by [Claude Code](https://claude.ai/code/session_01GG52f1KVmHAxBqWLUwzh5N)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with no MCP tool or public API changes; same credential and URL values are passed to run_task as before.
> 
> **Overview**
> Adds **`resolve_run_credentials_and_platform_url()`** in `adapter.py`, which resolves the ambient (or explicit) environment once and returns **`(api_key, base_url, platform_url)`** so API credentials and the platform link for `run_url` always come from the same environment.
> 
> **Computer-use entry points** — MCP `_handle_computer_use`, CLI `_smoke_live`, and `_run_custom` — now call this helper instead of separate **`resolve_run_credentials()`** and **`resolve_platform_url()`** calls. Behavior and values passed to **`run_task()`** are unchanged; only the resolution path is centralized.
> 
> Unit tests cover the new helper; existing computer-use tests mock the consolidated function instead of the two older ones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe0e889bd6131a6de62424528b0aa66f53c20396. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->