### PR TITLE
chore(release): 0.5.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.8"
+version = "0.5.9"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1386,7 +1386,7 @@ wheels = [
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.8"
+version = "0.5.9"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
Bumps yutori-mcp to 0.5.9 after landing background-mode computer use and the verified yutori SDK 0.9.11 runtime.\n\nValidation: 423 tests passed, published SDK artifact verification passed, package build passed, doctor passed, and a live Calculator background run completed with zero foreground escalations and zero background refusals.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version and lockfile sync with no functional code changes in the diff.
> 
> **Overview**
> **Release-only change:** bumps the `yutori-mcp` package version from **0.5.8** to **0.5.9** in `pyproject.toml` and updates the matching editable package entry in `uv.lock`.
> 
> No application, MCP server, or dependency constraint changes appear in this diff—only the version metadata for publishing **0.5.9** (which the release notes tie to background-mode computer use and the pinned `yutori==0.9.11` runtime already in the project).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fec246b6ea7f9fd59d6f4a3eabe9437268723169. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->