### PR TITLE
refactor(computer-use): extract _report() for the print-result-and-exit-code pattern in cli.py

### DIFF
--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -99,6 +99,12 @@ def _blocked() -> bool:
     return True
 
 
+def _report(result: dict) -> int:
+    """Print a task result and translate its outcome into a process exit code."""
+    print(format_result(result))
+    return 0 if result.get("outcome") == "completed" else 1
+
+
 async def _mechanical_calculator_check() -> str:
     from yutori.navigator.macos import MacOSComputer
     from yutori.navigator.macos.transport import CuaDriverTransport
@@ -176,8 +182,7 @@ async def _smoke_live() -> int:
     except ComputerUseBusyError as error:
         print(error)
         return 1
-    print(format_result(result))
-    return 0 if result.get("outcome") == "completed" else 1
+    return _report(result)
 
 
 async def _print_event(event: dict) -> None:
@@ -216,8 +221,7 @@ async def _run_custom(args: argparse.Namespace) -> int:
         api_base_url=api_base_url,
         on_event=_print_event,
     )
-    print(format_result(result))
-    return 0 if result.get("outcome") == "completed" else 1
+    return _report(result)
 
 
 def apply_computer_use_environment(env: str | None) -> None:


### PR DESCRIPTION
Closing without merging: while this branch was in progress, `main` advanced (via #242's background-mode feature work) past a point that already includes this exact refactor, merged separately as #238 (`refactor(computer-use): dedupe the outcome-to-exit-code mapping in cli.py`, commit `c8b11c2`) — same `_report()` extraction, same call sites, same signature. This PR was built off a stale local snapshot of `main` and is now a pure duplicate/no-op against current `main`.

No action needed here; `main` already has the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZgBXuU6a5cUQR63AzJ1yY