### PR TITLE
refactor(computer-use): extract describe_delivery_surface() for the ready-event surface phrase

### DIFF
--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -35,7 +35,7 @@ from .preflight import (
     first_blocker,
     run_checks,
 )
-from .result import format_action_line, format_result
+from .result import describe_delivery_surface, format_action_line, format_result
 from .supervisor import run_task, stop_active_run
 
 
@@ -203,7 +203,7 @@ def hands_off_notice(mode: str) -> str:
 
 
 def _event_printer(mode: str, app: str | None):
-    surface = f"the {app} window in the background" if mode == DELIVERY_MODE_BACKGROUND else "the desktop"
+    surface = describe_delivery_surface(mode, app)
 
     async def print_event(event: dict) -> None:
         if event.get("type") == "ready":

--- a/src/yutori_mcp/computer_use/result.py
+++ b/src/yutori_mcp/computer_use/result.py
@@ -73,6 +73,16 @@ def format_perf(result: dict[str, Any]) -> list[str]:
     return lines
 
 
+def describe_delivery_surface(mode: str, app: str | None) -> str:
+    """What a "ready" event is driving, phrased for the CLI and MCP progress renderers.
+
+    Both callers announce this identically ("driving the desktop" vs. "driving the {app}
+    window in the background") when a run starts, so the phrase lives here once rather than
+    as two independently-typed string literals that could drift.
+    """
+    return f"the {app} window in the background" if mode == DELIVERY_MODE_BACKGROUND else "the desktop"
+
+
 def format_action_line(event: dict[str, Any], *, index_default: Any = None) -> str:
     """The "action #N: tool -> status" prefix shared by the CLI and MCP progress renderers.
 

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -601,11 +601,11 @@ def _progress_reporter(
     not an upper bound for it — a fabricated total would render a bar that
     overshoots. The human-readable message carries the step budget instead.
     """
-    from .computer_use.result import format_action_line
+    from .computer_use.result import describe_delivery_surface, format_action_line
 
     async def on_event(event: dict[str, Any]) -> None:
         if event.get("type") == "ready":
-            surface = f"the {app} window in the background" if mode == "background" else "the desktop"
+            surface = describe_delivery_surface(mode, app)
             message = f"Computer-use runner ready; driving {surface} (up to {max_steps} steps)."
             await ctx.report_progress(progress=0, message=message)
             await ctx.info(message)


### PR DESCRIPTION
`cli.py`'s `_event_printer()` and `server.py`'s `_progress_reporter()` each independently computed the same phrase for a run's "ready" event:

```python
f"the {app} window in the background" if mode == "background" else "the desktop"
```

`cli.py` used the `DELIVERY_MODE_BACKGROUND` constant for the comparison; `server.py` had drifted to the raw `"background"` string literal instead. Extracted `describe_delivery_surface(mode, app)` into `result.py` — the module that already holds the other CLI/MCP-shared formatter, `format_action_line()`, per its own docstring ("shared by CLI and MCP progress renderers") — and pointed both call sites at it.

## Safety verification
- No behavior change: identical phrasing for both modes, same constant comparison (now via `DELIVERY_MODE_BACKGROUND` in both places instead of one hardcoded string).
- Full suite: 423 passed, 1 skipped (matches baseline exactly).
- `ruff check .`: all checks passed.
- Diff is 3 files, 14 insertions / 4 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZgBXuU6a5cUQR63AzJ1yY

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZgBXuU6a5cUQR63AzJ1yY)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor of display strings only; behavior and messaging should stay the same aside from aligning background-mode detection with the shared constant.
> 
> **Overview**
> Extracts **`describe_delivery_surface(mode, app)`** into `result.py` next to **`format_action_line`**, so the CLI and MCP “runner ready” messages share one phrase for *the desktop* vs. *the {app} window in the background*.
> 
> **`cli.py`** `_event_printer` and **`server.py`** `_progress_reporter` now call that helper instead of duplicating the same ternary. The MCP path previously compared `mode` to the raw `"background"` string while the CLI used **`DELIVERY_MODE_BACKGROUND`**; both paths now use the shared constant via the helper, with no intended user-visible wording change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2c1001d69793207d6347b9e2128cda7e8831252. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->