### PR TITLE
chore(computer-use): pin SDK 0.9.12 and release yutori-mcp 0.5.10

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -17,7 +17,10 @@ One task controls the Mac at a time, in one of two modes:
 - `mode: "background"` drives only the target `app`'s window without taking focus, so you can
   keep working on the Mac (leave that one window alone). Only that window's content is captured
   and sent to Yutori. A menu bar item (the Yutori mark) stays up for the whole run; its menu
-  shows the latest frame the agent saw, its latest action, and Stop (also ⇧⌘Esc). Actions the driver cannot deliver in the background come back to the agent
+  shows the latest frame the agent saw, its latest action, Show activity, and Stop (also ⇧⌘Esc).
+  Show activity opens a window with the live frame above the run's conversation with the model
+  -- its thinking, every action, and every shell command; foreground runs offer the same window
+  from the same menu, without the frame. Actions the driver cannot deliver in the background come back to the agent
   as refusals; `allow_foreground_fallback: true` lets it retry such an action once with the
   window fronted briefly and the prior app restored. Background keyboard delivery is
   app-dependent (clicks reach more apps than typed keys), so typing-heavy tasks usually want it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.9"
+version = "0.5.10"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"
@@ -30,8 +30,8 @@ dependencies = [
     # breaks the install as soon as 2.x resolves.
     "mcp>=1.0.0,<2.0.0",
     "pydantic>=2.0.0",
-    # SDK 0.9.11 adds the window-scoped macOS runtime used by background mode.
-    "yutori==0.9.11",
+    # SDK 0.9.12 adds the activity window: the run's conversation with the model, in both modes.
+    "yutori==0.9.12",
 ]
 
 [project.optional-dependencies]

--- a/skills/06-computer-use/SKILL.md
+++ b/skills/06-computer-use/SKILL.md
@@ -97,8 +97,8 @@ uvx yutori-mcp computer-use stop
 
 ## Safety
 
-- In foreground mode, tell the user not to touch the Mac while the task runs.
-- In background mode, tell the user they can keep working but should leave the target app's window alone, and that only that window is captured. A menu bar item shows the latest frame and offers Stop (also ⇧⌘Esc). Keyboard input may not reach a minimized window.
+- In foreground mode, tell the user not to touch the Mac while the task runs; the same Show activity window is available from the menu bar item if they want to read what the agent is doing.
+- In background mode, tell the user they can keep working but should leave the target app's window alone, and that only that window is captured. A menu bar item shows the latest frame, offers Show activity (a window with the run's conversation with the model: its thinking, every action, and every shell command), and offers Stop (also ⇧⌘Esc). Keyboard input may not reach a minimized window.
 - Use `mode: "background"` only with `app`; use `allow_foreground_fallback` only with background mode, and warn that it may briefly flash the target window.
 - Background keyboard delivery is app-dependent: some apps accept background clicks but not typed keys (Calculator, for one), and the agent then reports the refusal instead of typing. For typing-heavy background tasks, suggest `allow_foreground_fallback`.
 - Use `app` for single-app tasks so the runner starts from the intended context.

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -17,11 +17,11 @@ TOOL_SET = "computer_use_tools-20260815"
 DELIVERY_MODE_FOREGROUND = "foreground"
 DELIVERY_MODE_BACKGROUND = "background"
 DELIVERY_MODES = (DELIVERY_MODE_FOREGROUND, DELIVERY_MODE_BACKGROUND)
-SDK_VERSION = "0.9.11"
+SDK_VERSION = "0.9.12"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.
-SDK_ARTIFACT_SHA256 = "5a10b9c5240fc5c859a7e680001cb51ef16bbcc0d1cd5b0ea2e3b9ed8995e261"
-SDK_INSTALLATION_SHA256 = "4c7eae3cd1ccefce1c4cb30383d8f8c8267153e014b0b1ab954574733387cf3e"
+SDK_ARTIFACT_SHA256 = "c852a9ca61dc7d6d06c6038071322c244380edc76e565c7facf250d428e2c5aa"
+SDK_INSTALLATION_SHA256 = "0bfc0789fcb7f258b6306e332378215acda71824281c53b84742e6ad17b81b17"
 SDK_PROVENANCE_SHA256 = "7cab595d2f00e1a9ab5cd121204fbd6dd4c24163ead3eb76f76eef7fba495fc4"
 
 # The cua-driver release that implements this tool contract, and the checksum

--- a/src/yutori_mcp/computer_use/result.py
+++ b/src/yutori_mcp/computer_use/result.py
@@ -124,6 +124,7 @@ def format_result(result: dict[str, Any]) -> str:
     if result.get("reasoning_overlay_requested"):
         state = "active" if result.get("reasoning_overlay_effective") else "unavailable"
         # Background runs show a menu bar item (latest frame + Stop) instead of the overlay.
+        # Either way the run also offers the activity window, opened from that menu.
         surface = "Menu bar status" if result.get("delivery_mode") == DELIVERY_MODE_BACKGROUND else "Reasoning overlay"
         lines.append(f"{surface}: {state}; codec: {result.get('codec') or 'unknown'}")
     escalations = result.get("fallback_escalations") or 0
@@ -136,7 +137,7 @@ def format_result(result: dict[str, Any]) -> str:
             line += f", {skips} retry(ies) skipped after the window changed"
         lines.append(line)
     if result.get("preview_frames"):
-        lines.append(f"Live view: {result['preview_frames']} frame(s) streamed to the menu bar item")
+        lines.append(f"Activity window: {result['preview_frames']} frame(s) streamed while it was open")
     lines.extend(format_perf(result))
     actions = result.get("actions", [])
     if actions:

--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -537,7 +537,8 @@ def _computer_kwargs(
     }
     if request["mode"] == DELIVERY_MODE_BACKGROUND:
         # Window scope captures and drives one window. The SDK shows no full-screen overlay for
-        # it; with presentation on it keeps a menu bar item with the latest frame and Stop.
+        # it; with presentation on it keeps a menu bar item with the latest frame, Stop, the shell rail,
+        # and the activity window.
         kwargs.update(
             scope="window",
             allow_foreground_fallback=request["allow_foreground_fallback"],

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -736,9 +736,9 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 
 def test_runtime_constants_select_latest_python_surface():
     assert TOOL_SET == "computer_use_tools-20260815"
-    assert SDK_VERSION == "0.9.11"
+    assert SDK_VERSION == "0.9.12"
     assert all(len(digest) == 64 for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256))
-    assert '"yutori==0.9.11"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
+    assert '"yutori==0.9.12"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
 
 
 def test_installed_sdk_matches_the_published_artifact():
@@ -2263,8 +2263,8 @@ def test_format_result_reports_skipped_retries_only_when_present():
     base = {"outcome": "completed", "delivery_mode": "background", "final_text": "done"}
     assert "Delivery: 0 foreground escalation(s), 0 background refusal(s)" in format_result(base)
     assert "skipped" not in format_result(base)
-    assert "Live view" not in format_result(base)
-    assert "Live view: 7 frame(s) streamed to the menu bar item" in format_result({**base, "preview_frames": 7})
+    assert "Activity window" not in format_result(base)
+    assert "Activity window: 7 frame(s) streamed while it was open" in format_result({**base, "preview_frames": 7})
     with_skips = format_result({**base, "fallback_skips": 2})
     assert "Delivery: 0 foreground escalation(s), 0 background refusal(s), 2 retry(ies) skipped after the window changed" in with_skips
 

--- a/uv.lock
+++ b/uv.lock
@@ -260,7 +260,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -294,8 +294,8 @@ name = "httpcore2"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
+    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
@@ -1359,8 +1359,8 @@ name = "uvicorn"
 version = "0.52.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
@@ -1370,7 +1370,7 @@ wheels = [
 
 [[package]]
 name = "yutori"
-version = "0.9.11"
+version = "0.9.12"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1379,14 +1379,14 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/28/5af28edc0680b5f93c1c2f0f78f272aad374279e274921eeb4b106738eea/yutori-0.9.11.tar.gz", hash = "sha256:9f1f5bcb14c112f7ca55123edc672517bde8e469264547f3cb8d3975b532262e", size = 444239, upload-time = "2026-09-03T21:12:12.165Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/18/67f614efb474fa457cf617eb07c8136e9264686c5054b5a7d76aa728e2a6/yutori-0.9.12.tar.gz", hash = "sha256:74675734ddbabbbbea24bcf81a7494cf20c8a51e9cae3e307acb3eaec36c4061", size = 451622, upload-time = "2026-09-03T23:36:20.783Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/b9/d7b78c5c13821c475a37cf946173466f5377cf933e8ac2775f00593f1e18/yutori-0.9.11-py3-none-any.whl", hash = "sha256:5a10b9c5240fc5c859a7e680001cb51ef16bbcc0d1cd5b0ea2e3b9ed8995e261", size = 309491, upload-time = "2026-09-03T21:12:10.479Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/16/3b92b6217ee42c7a2620ce33d95041a01ba1713d762849225eb6186fd212/yutori-0.9.12-py3-none-any.whl", hash = "sha256:c852a9ca61dc7d6d06c6038071322c244380edc76e565c7facf250d428e2c5aa", size = 318089, upload-time = "2026-09-03T23:36:19.008Z" },
 ]
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.9"
+version = "0.5.10"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -1406,6 +1406,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "yutori", specifier = "==0.9.11" },
+    { name = "yutori", specifier = "==0.9.12" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
Pins yutori 0.9.12 ([SDK #370](https://github.com/yutori-ai/yutori-sdk-python/pull/370), [v0.9.12](https://github.com/yutori-ai/yutori-sdk-python/releases/tag/v0.9.12)) and bumps yutori-mcp to 0.5.10.

## What the pin brings

- **The activity window, in both modes.** A floating, non-activating panel carrying the run's conversation with the model — the task, its thinking, every action, and every shell command — opened from *Show activity* in the menu bar item's menu. A background run puts the driven window's live frame above it; a foreground run shows no frame pane and the window is hidden with the overlay for every capture, so the model never sees it.
- **The shell rail for background runs.** The click-through "run command" panels a foreground run already paints under the menu bar, so a command running on the user's Mac is visible without opening anything.

## This PR

- `SDK_VERSION`, `SDK_ARTIFACT_SHA256`, `SDK_INSTALLATION_SHA256` for 0.9.12 (`SDK_PROVENANCE_SHA256` is unchanged — `provenance.json` did not move), the `yutori==` pin, `uv.lock`, and the constants test.
- `format_result` now reports `Activity window: N frame(s) streamed while it was open` instead of naming the menu bar item.
- TOOLS.md, the computer-use skill, and the runner comment describe *Show activity* in both modes.

## Verification

- 423 passed, 1 skipped.
- `computer-use doctor` against the published wheel: PASS on all 14 checks, including `Python runtime: yutori 0.9.12` with the three digests in this PR.

**Existing installs: run `uvx yutori-mcp computer-use setup` once** — the SDK ships new overlay assets, and setup recompiles the host for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly dependency pin, documentation, and result formatting; no changes to run orchestration or security-sensitive paths beyond adopting the published SDK wheel.
> 
> **Overview**
> Pins **yutori 0.9.12** and bumps **yutori-mcp to 0.5.10**, updating `SDK_VERSION`, wheel/install digests, `pyproject.toml`, and `uv.lock` so doctor and preflight enforce the new SDK.
> 
> The pin brings the SDK **activity window** (opened via **Show activity** on the menu bar item): live frame plus the run’s conversation—thinking, actions, and shell commands—in background mode; foreground runs get the same panel without the frame. Docs (`TOOLS.md`, computer-use skill) and runner comments are aligned with that UX.
> 
> **`format_result`** now labels streamed frames as `Activity window: N frame(s) streamed while it was open` instead of referring to the menu bar live view. Tests assert the new SDK pin and output text.
> 
> Existing installs should rerun **`uvx yutori-mcp computer-use setup`** once so overlay assets from the SDK are rebuilt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db579fe32b65ce5ef8a2fed1d853c6e235d1a235. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->