### PR TITLE
refactor(computer-use): extract _discard_stale_pid_file() for stop_active_run()

### DIFF
--- a/src/yutori_mcp/computer_use/supervisor.py
+++ b/src/yutori_mcp/computer_use/supervisor.py
@@ -66,6 +66,13 @@ def _clear_runner_pid(pid: int) -> None:
             path.unlink()
 
 
+def _discard_stale_pid_file(path: Path) -> str:
+    """Remove a pid file that no longer names a live runner, and report that fact."""
+    with suppress(OSError):
+        path.unlink()
+    return "No computer-use run is active (removed a stale pid file)."
+
+
 def _process_command(pid: int) -> str | None:
     try:
         listing = subprocess.run(
@@ -94,15 +101,11 @@ def stop_active_run() -> str:
         return "No computer-use run is active."
     command = _process_command(pid)
     if command is None or RUNNER_MODULE not in command:
-        with suppress(OSError):
-            path.unlink()
-        return "No computer-use run is active (removed a stale pid file)."
+        return _discard_stale_pid_file(path)
     try:
         os.killpg(pid, signal.SIGTERM)
     except ProcessLookupError:
-        with suppress(OSError):
-            path.unlink()
-        return "No computer-use run is active (removed a stale pid file)."
+        return _discard_stale_pid_file(path)
     return f"Asked the computer-use runner (pid {pid}) to stop; the run ends with outcome 'aborted'."
 
 


### PR DESCRIPTION
## What

`computer_use/supervisor.py::stop_active_run()` (part of today's new background-mode `computer-use stop` command) had two branches — an unrecognized process command, and a `ProcessLookupError` on a dead pid — that each independently ran the identical `with suppress(OSError): path.unlink()` cleanup followed by the identical `"No computer-use run is active (removed a stale pid file)."` return string.

Extracted `_discard_stale_pid_file(path: Path) -> str` next to the other pid-file helpers (`_record_runner_pid`/`_clear_runner_pid`); both branches now just `return _discard_stale_pid_file(path)`.

## Why it's safe

- Strictly behavior-preserving: identical unlink call, identical returned message, no signature or call-site changes to `stop_active_run()` itself.
- Existing coverage already exercises both branches end-to-end (`test_stop_active_run_ignores_and_removes_a_stale_pid_file`, parametrized over both trigger conditions) without depending on any internal structure, so no test changes were needed.
- `uv run pytest -q` → 423 passed / 1 skipped (matches the pre-change baseline exactly).
- `uv run ruff check .` → clean. (`ruff format --check` flags pre-existing, unrelated lines in this file — the repo has no `[tool.ruff]` config and CI runs no lint/format step, so that's expected noise, not something this diff introduced.)

1 file changed, +9/-6.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTCgTSGfsYgjNp23ufmSWB

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTCgTSGfsYgjNp23ufmSWB)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with no API changes; existing parametrized tests still cover both stale-pid branches.
> 
> **Overview**
> **`stop_active_run()`** in `supervisor.py` no longer duplicates stale pid-file cleanup in two error paths (non-runner `/bin/ps` command and `ProcessLookupError` on `killpg`).
> 
> Both branches now call a new **`_discard_stale_pid_file(path)`** helper beside the other pid-file utilities. It unlinks the file (errors suppressed) and returns the same *"No computer-use run is active (removed a stale pid file)."* message as before.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d0d57e9102594afc33907834d5d0236735c9ef6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->