### PR TITLE
refactor(computer-use): extract _agent_base_kwargs() for repeated N2ComputerAgent construction

### DIFF
--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -449,18 +449,9 @@ async def _summarize_limit_run(
         {"role": "user", "content": STOP_SUMMARY_PROMPT},
     ]
     async with N2ComputerAgent(
-        computer=computer,
-        tool_set=TOOL_SET,
-        api_key=api_key,
-        base_url=request["api_base_url"],
-        model=request["model"],
+        **_agent_base_kwargs(request, api_key=api_key, computer=computer, deadline=deadline),
         callbacks=[RunGuard(1, deadline)],
-        system_prompt=system_context(request["mode"], request["app"]),
         action_confirmation_callback=deny,
-        presentation=computer.presentation,
-        supports_click_modifiers=True,
-        screenshot_delay=0,
-        execution_deadline=deadline,
     ) as agent:
         summary_items = await _collect_run(agent, messages)
     texts = _texts_from_items(summary_items)
@@ -545,6 +536,31 @@ def _computer_kwargs(
             allow_foreground_fallback=request["allow_foreground_fallback"],
         )
     return kwargs
+
+
+def _agent_base_kwargs(
+    request: dict[str, Any], *, api_key: str, computer: MacOSComputer, deadline: float
+) -> dict[str, Any]:
+    """N2ComputerAgent construction kwargs shared by a real run and its limit-run summary turn.
+
+    `run_request()`'s main agent and `_summarize_limit_run()`'s final "summarize what
+    happened" agent both drive the same computer session against the same backend, model,
+    deadline, and standing `system_prompt` for the run's mode/app, with click-modifier
+    support always on; only `callbacks` and `action_confirmation_callback` differ per call
+    site.
+    """
+    return {
+        "computer": computer,
+        "tool_set": TOOL_SET,
+        "api_key": api_key,
+        "base_url": request["api_base_url"],
+        "model": request["model"],
+        "system_prompt": system_context(request["mode"], request["app"]),
+        "presentation": computer.presentation,
+        "screenshot_delay": 0,
+        "execution_deadline": deadline,
+        "supports_click_modifiers": True,
+    }
 
 
 async def _bind_window_target(computer: MacOSComputer, target: dict[str, Any]) -> None:
@@ -729,17 +745,8 @@ async def run_request(
             computer.recover_target = recover_target
 
         async with N2ComputerAgent(
-            computer=computer,
-            tool_set=TOOL_SET,
-            api_key=api_key,
-            base_url=request["api_base_url"],
-            model=request["model"],
+            **_agent_base_kwargs(request, api_key=api_key, computer=computer, deadline=deadline),
             callbacks=[guard, reporter, api_counter, chat],
-            system_prompt=system_context(mode, request["app"]),
-            presentation=computer.presentation,
-            screenshot_delay=0,
-            execution_deadline=deadline,
-            supports_click_modifiers=True,
         ) as agent:
             items = await _collect_run(agent, request["task"])
         texts = _texts_from_items(items)


### PR DESCRIPTION
## What

`computer_use/runner.py` built `N2ComputerAgent` at two call sites — `run_request()`'s main agent and `_summarize_limit_run()`'s final "summarize what happened" turn — each hand-copying the same kwargs: `computer`, `tool_set`, `api_key`, `base_url`, `model`, `presentation`, `screenshot_delay`, `execution_deadline`, `supports_click_modifiers`, and (as of #252) `system_prompt=system_context(...)` for the same mode/app. Only `callbacks` and `action_confirmation_callback` differ between the two.

Extracted `_agent_base_kwargs(request, *, api_key, computer, deadline) -> dict[str, Any]`, placed next to the existing `_computer_kwargs()` helper in this file (which already does the same "shared construction kwargs" extraction for `MacOSComputer`). Both call sites now spread it (`**_agent_base_kwargs(...)`) and add only their own differing kwargs.

(Rebased onto `main` after #252 landed underneath this branch, which had added the now-shared `system_prompt` kwarg to both call sites independently — folded it into the new helper too rather than leaving a second duplication.)

## Why it's safe

- Strictly behavior-preserving: identical kwargs are passed in the identical order they'd resolve to via keyword arguments; no default values, control flow, or call-site behavior changes.
- Single file touched (`src/yutori_mcp/computer_use/runner.py`), no signature changes to any public function.
- `uv run --extra dev pytest -q` → 424 passed / 1 skipped (matches the current `main` baseline exactly, including #252's new `test_run_request_gives_the_limit_summary_the_runs_system_prompt`).
- `ruff check` on the changed file reports the same 3 pre-existing, unrelated errors as the `main` baseline (confirmed via `git diff origin/main`) — nothing new introduced. The repo has no `[tool.ruff]` config and CI runs no lint/format step.

1 file changed, +27/-20.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F9iAjBxPM94GjhCENMjXP8

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-file refactor with identical agent kwargs; no public API or control-flow changes.
> 
> **Overview**
> **Refactors duplicated `N2ComputerAgent` setup** in `runner.py` by introducing `_agent_base_kwargs()` next to `_computer_kwargs()`, mirroring the existing pattern for shared construction kwargs.
> 
> The helper centralizes the nine kwargs both the main `run_request()` agent and `_summarize_limit_run()`’s summary turn need (computer session, tools, API/model routing, `system_prompt`, presentation, screenshot timing, deadline, click modifiers). Each call site now spreads `**_agent_base_kwargs(...)` and only passes what differs—`callbacks` and, for the limit summary, `action_confirmation_callback`.
> 
> No intended behavior change: same values are passed to `N2ComputerAgent`; only duplication is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e183302b4caa7a7ab768d200caeeb46cf3eb24a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->