### PR TITLE
Optimize computer-use runner lifecycle

### DIFF
--- a/TOOLS.md
+++ b/TOOLS.md
@@ -64,7 +64,7 @@ Delivery mode: foreground
 Run: https://platform.yutori.com/navigator/chats/5d90f532-6c0f-4159-8e46-2ce55e7084c9
 Final text: 17 * 23 = 391
 Elapsed: 18452 ms
-Perf: total 18.5s over 6 steps (3.1s/step)
+Perf: total 18.5s over 6 model turns (3.1s/turn)
 Actions:
 - #1 computer_batch: executed (raw: confirmed; mode: foreground; route: pixel; refusal: None) took 412 ms
 - #2 left_click: executed (raw: confirmed; mode: foreground; route: pixel; refusal: None) took 138 ms
@@ -79,7 +79,7 @@ Window target: Notes (pid 4242, window 71)
 Final text: Created the Standup note with the three agenda items.
 Elapsed: 24107 ms
 Delivery: 0 foreground escalation(s), 1 background refusal(s)
-Perf: total 24.1s over 8 steps (3.0s/step)
+Perf: total 24.1s over 8 model turns (3.0s/turn)
 Actions:
 - #1 left_click: executed (raw: confirmed; mode: background; route: accessibility; refusal: None); effect: unverifiable took 233 ms
 - #2 type: uncertain (raw: unverifiable; mode: background; route: synthetic_events; refusal: None); effect: unverifiable took 610 ms
@@ -96,12 +96,12 @@ before the model was called.
 | `app` | No | Application to target; omit for cross-app tasks |
 | `start_url` | No | URL to open before the task starts; requires `app` |
 | `minutes` | No | Wall-clock deadline in minutes (1-60). Default: 30 |
-| `max_steps` | No | Max desktop actions, 1 or more. Default: 60 |
+| `max_steps` | No | Max model turns, 1 or more. A turn may contain multiple desktop actions. Default: 60 |
 | `mode` | No | `foreground` (default) drives the visible desktop; `background` drives only `app`'s window without taking focus. Background requires `app` |
 | `allow_foreground_fallback` | No | Background only. Retry an action that did not land with the window fronted briefly. Default: false |
 
-`max_steps` has no upper bound. On long runs, compact or summarize older screenshots and tool
-results so the conversation stays within `max_context_len`.
+`max_steps` has no upper bound. The SDK automatically compacts older screenshots and tool
+results on long runs; each step is one model turn, not an individual desktop action.
 
 ## Browsing Tools
 

--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -291,7 +291,7 @@ def register_parser(
         dest="max_steps",
         type=int,
         default=COMPUTER_USE_DEFAULT_MAX_STEPS,
-        help="Maximum actions",
+        help="Maximum model turns (one turn may contain multiple actions)",
     )
     run_parser.add_argument(
         "--mode",

--- a/src/yutori_mcp/computer_use/result.py
+++ b/src/yutori_mcp/computer_use/result.py
@@ -35,9 +35,9 @@ def format_perf(result: dict[str, Any]) -> list[str]:
     steps = result.get("steps")
     if not isinstance(elapsed_ms, (int, float)) or not isinstance(steps, int):
         return []
-    headline = f"Perf: total {_seconds(elapsed_ms)} over {steps} steps"
+    headline = f"Perf: total {_seconds(elapsed_ms)} over {steps} model turns"
     if steps > 0:
-        headline += f" ({elapsed_ms / steps / 1000:.1f}s/step)"
+        headline += f" ({elapsed_ms / steps / 1000:.1f}s/turn)"
     lines = [headline]
     timings = result.get("timings")
     if isinstance(timings, dict):

--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -15,6 +15,7 @@ from dataclasses import asdict
 from importlib import metadata
 from typing import Any, TextIO
 
+from yutori import AsyncYutoriClient
 from yutori.navigator import N2ComputerAgent
 from yutori.navigator.macos import (
     MacOSComputer,
@@ -119,7 +120,9 @@ def system_context(mode: str, app: str | None = None) -> str:
 
 
 SYSTEM_CONTEXT = system_context(DELIVERY_MODE_FOREGROUND)
-STOP_SUMMARY_PROMPT = "Stop here. Briefly summarize what you accomplished and what you found."
+STOP_SUMMARY_PROMPT = (
+    "Stop here. Do not take any more actions. Briefly summarize what you accomplished and what you found."
+)
 FINAL_TEXT_MARKERS = ("[DONE]", "[INFEASIBLE]")
 _SHELL_TOOL_NAMES = frozenset({"bash", "shell_command", "run_command"})
 _BACKGROUND_TASK_PATTERN = re.compile(r"\bStarted background task ([A-Za-z0-9-]+)\b")
@@ -375,7 +378,11 @@ class ChatTracker:
 
 
 class RunGuard:
-    """Bound model turns independently of in-flight SDK cancellation."""
+    """Bound model turns independently of in-flight SDK cancellation.
+
+    ``max_steps`` is the public compatibility name. One step is one model turn;
+    a turn can contain several top-level tool calls or batched desktop actions.
+    """
 
     def __init__(self, max_steps: int, deadline: float) -> None:
         self.max_steps = max_steps
@@ -426,36 +433,101 @@ def _redacted_error_text(error: BaseException, secret: str) -> str:
     return redact(str(error), secret) or type(error).__name__
 
 
-async def _collect_run(agent: Any, messages: Any) -> list[dict[str, Any]]:
-    items: list[dict[str, Any]] = []
+async def _collect_final_text(agent: Any, messages: Any) -> str | None:
+    """Run the agent while retaining only its latest text response.
+
+    The SDK owns and compacts the canonical trajectory. Keeping every streamed
+    item here created a second, unbounded copy of screenshot-bearing tool output.
+    """
+    final_text: str | None = None
     async for response in agent.run(messages):
-        items.extend(response.get("output") or [])
-    return items
+        texts = _texts_from_items(response.get("output") or [])
+        if texts:
+            final_text = texts[-1]
+    return _strip_final_markers(final_text)
+
+
+def _completion_text(response: Any) -> str | None:
+    """Extract assistant text from a chat-completions response."""
+    response = response.model_dump() if hasattr(response, "model_dump") else response
+    if not isinstance(response, dict):
+        return None
+    message = (response.get("choices") or [{}])[0].get("message") or {}
+    if not isinstance(message, dict):
+        return None
+    content = message.get("content")
+    if isinstance(content, str):
+        return _strip_final_markers(content)
+    if not isinstance(content, list):
+        return None
+    texts = [
+        part["text"]
+        for part in content
+        if isinstance(part, dict)
+        and part.get("type") in {"text", "output_text"}
+        and isinstance(part.get("text"), str)
+    ]
+    return _strip_final_markers("\n".join(texts) if texts else None)
+
+
+async def _await_summary_response(agent: Any, awaitable: Any, deadline: float) -> Any:
+    """Await the wrap-up while honoring both the deadline and desktop Stop."""
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        if inspect.iscoroutine(awaitable):
+            awaitable.close()
+        raise asyncio.TimeoutError
+    cancellation = getattr(agent.computer, "cancellation", None)
+    if cancellation is None:
+        return await asyncio.wait_for(awaitable, remaining)
+    if cancellation.cancelled:
+        if inspect.iscoroutine(awaitable):
+            awaitable.close()
+        cancellation.raise_if_cancelled()
+    request_task = asyncio.create_task(awaitable)
+    stopped_task = asyncio.create_task(cancellation.wait())
+    try:
+        done, _ = await asyncio.wait_for(
+            asyncio.wait({request_task, stopped_task}, return_when=asyncio.FIRST_COMPLETED),
+            remaining,
+        )
+        if request_task in done:
+            return request_task.result()
+        raise asyncio.CancelledError(stopped_task.result())
+    finally:
+        for task in (request_task, stopped_task):
+            if not task.done():
+                task.cancel()
+        await asyncio.gather(request_task, stopped_task, return_exceptions=True)
 
 
 async def _summarize_limit_run(
-    request: dict[str, Any],
-    api_key: str,
-    computer: MacOSComputer,
-    items: list[dict[str, Any]],
+    agent: Any,
+    completions: Any,
+    api_counter: ApiCounter,
+    chat: ChatTracker,
     deadline: float,
 ) -> str | None:
-    async def deny(_request: dict[str, Any]) -> bool:
-        return False
+    """Request one text-only wrap-up from the current compacted trajectory.
 
-    messages = [
-        {"role": "user", "content": request["task"]},
-        *items,
-        {"role": "user", "content": STOP_SUMMARY_PROMPT},
-    ]
-    async with N2ComputerAgent(
-        **_agent_base_kwargs(request, api_key=api_key, computer=computer, deadline=deadline),
-        callbacks=[RunGuard(1, deadline)],
-        action_confirmation_callback=deny,
-    ) as agent:
-        summary_items = await _collect_run(agent, messages)
-    texts = _texts_from_items(summary_items)
-    return _strip_final_markers(texts[-1] if texts else None)
+    ``completion_request`` is the SDK's public escape hatch for harness-owned
+    turns. Calling the shared completion surface directly means no tools are
+    executed and the original agent, request chain, and timing record stay live.
+    """
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise asyncio.TimeoutError
+    api_kwargs = agent.completion_request([{"role": "user", "content": STOP_SUMMARY_PROMPT}])
+    await api_counter.on_api_start(api_kwargs)
+    model_started_at = time.monotonic()
+    try:
+        response = await _await_summary_response(agent, completions.create(**api_kwargs), deadline)
+    finally:
+        agent.timings["model_ms"] = agent.timings.get("model_ms", 0) + (
+            time.monotonic() - model_started_at
+        ) * 1000
+    await chat.on_api_end(api_kwargs, response)
+    return _completion_text(response)
 
 
 def _background_counts(events: tuple[ShellPresentationEvent, ...]) -> dict[str, int]:
@@ -539,21 +611,13 @@ def _computer_kwargs(
 
 
 def _agent_base_kwargs(
-    request: dict[str, Any], *, api_key: str, computer: MacOSComputer, deadline: float
+    request: dict[str, Any], *, completions: Any, computer: MacOSComputer, deadline: float
 ) -> dict[str, Any]:
-    """N2ComputerAgent construction kwargs shared by a real run and its limit-run summary turn.
-
-    `run_request()`'s main agent and `_summarize_limit_run()`'s final "summarize what
-    happened" agent both drive the same computer session against the same backend, model,
-    deadline, and standing `system_prompt` for the run's mode/app, with click-modifier
-    support always on; only `callbacks` and `action_confirmation_callback` differ per call
-    site.
-    """
+    """N2ComputerAgent construction kwargs for the run's single agent lifecycle."""
     return {
         "computer": computer,
         "tool_set": TOOL_SET,
-        "api_key": api_key,
-        "base_url": request["api_base_url"],
+        "completions": completions,
         "model": request["model"],
         "system_prompt": system_context(request["mode"], request["app"]),
         "presentation": computer.presentation,
@@ -744,22 +808,30 @@ async def run_request(
 
             computer.recover_target = recover_target
 
-        async with N2ComputerAgent(
-            **_agent_base_kwargs(request, api_key=api_key, computer=computer, deadline=deadline),
-            callbacks=[guard, reporter, api_counter, chat],
-        ) as agent:
-            items = await _collect_run(agent, request["task"])
-        texts = _texts_from_items(items)
-        final_text = _strip_final_markers(texts[-1] if texts else None)
-        if guard.limit_reached or guard.deadline_reached:
-            outcome = "limit"
-            if guard.limit_reached:
-                try:
-                    final_text = await _summarize_limit_run(request, api_key, computer, items, deadline) or final_text
-                except Exception as error:  # noqa: BLE001 - final summary is best effort
-                    print(f"limit summary failed: {error}", file=sys.stderr)
-        else:
-            outcome = "completed"
+        async with AsyncYutoriClient(api_key=api_key, base_url=request["api_base_url"]) as client:
+            completions = client.chat.completions
+            async with N2ComputerAgent(
+                **_agent_base_kwargs(
+                    request,
+                    completions=completions,
+                    computer=computer,
+                    deadline=deadline,
+                ),
+                callbacks=[guard, reporter, api_counter, chat],
+            ) as agent:
+                final_text = await _collect_final_text(agent, request["task"])
+                if guard.limit_reached or guard.deadline_reached:
+                    outcome = "limit"
+                    if guard.limit_reached:
+                        try:
+                            final_text = (
+                                await _summarize_limit_run(agent, completions, api_counter, chat, deadline)
+                                or final_text
+                            )
+                        except Exception as error:  # noqa: BLE001 - final summary is best effort
+                            print(f"limit summary failed: {error}", file=sys.stderr)
+                else:
+                    outcome = "completed"
     except asyncio.CancelledError as error:
         cause = computer.cancellation.cause or (str(error) if str(error) else None)
         outcome, final_text = _cancelled_outcome(cause)
@@ -812,12 +884,33 @@ def _take_api_key() -> str | None:
     return os.environ.pop("YUTORI_API_KEY", None)
 
 
-async def _run_until_terminated(request: dict[str, Any], emitter: Emitter, api_key: str) -> str:
+async def _run_until_terminated(
+    request: dict[str, Any],
+    emitter: Emitter,
+    api_key: str,
+    termination_requested: Callable[[], bool] = lambda: False,
+) -> str:
     """Turn supervisor SIGTERM into SDK cancellation so teardown can reap shells."""
     cancellation = CancellationLatch()
-    task = asyncio.create_task(run_request(request, emitter, api_key, cancellation))
     loop = asyncio.get_running_loop()
     terminating = False
+    task: asyncio.Task[str] | None = None
+    task_started = False
+
+    def emit_early_abort() -> str:
+        emitter.emit(
+            {
+                **_result_event("aborted", "The computer-use run was stopped.", request["mode"]),
+                "elapsed_ms": 0,
+                "steps": 0,
+            }
+        )
+        return "aborted"
+
+    async def execute() -> str:
+        nonlocal task_started
+        task_started = True
+        return await run_request(request, emitter, api_key, cancellation)
 
     def terminate() -> None:
         nonlocal terminating
@@ -825,11 +918,26 @@ async def _run_until_terminated(request: dict[str, Any], emitter: Emitter, api_k
             return
         terminating = True
         cancellation.request("supervisor")
-        task.cancel("supervisor")
+        if task is not None:
+            task.cancel("supervisor")
 
     loop.add_signal_handler(signal.SIGTERM, terminate)
     try:
-        return await task
+        # A synchronous handler is installed before `ready` is emitted. If it
+        # observed SIGTERM while the request was being read or parsed, terminate
+        # cleanly without constructing desktop resources.
+        if termination_requested() or terminating:
+            terminate()
+            return emit_early_abort()
+        task = asyncio.create_task(execute())
+        try:
+            return await task
+        except asyncio.CancelledError:
+            # A signal callback can win the first event-loop tick and cancel the
+            # task before run_request gets a chance to emit its own terminal event.
+            if terminating and not task_started:
+                return emit_early_abort()
+            raise
     finally:
         loop.remove_signal_handler(signal.SIGTERM)
 
@@ -837,46 +945,57 @@ async def _run_until_terminated(request: dict[str, Any], emitter: Emitter, api_k
 def main() -> int:
     api_key = _take_api_key()
     emitter = Emitter(_claim_protocol_stream())
-    emitter.emit(
-        {
-            "type": "ready",
-            "protocol_version": PROTOCOL_VERSION,
-            "package_version": _package_version(),
-            "sdk_version": SDK_VERSION,
-            "sdk_artifact_sha256": SDK_ARTIFACT_SHA256,
-            "sdk_provenance_sha256": SDK_PROVENANCE_SHA256,
-            "driver_version_pinned": DRIVER_VERSION,
-            "observation_format": "webp",
-            "observation_format_fallback": True,
-            "observation_fallback_format": "jpeg",
-            # The request is not parsed yet; the result event carries the truthful value.
-            "reasoning_overlay_requested": True,
-        }
-    )
+    termination = {"requested": False}
+
+    def remember_termination(_signum: int, _frame: Any) -> None:
+        termination["requested"] = True
+
+    previous_sigterm = signal.signal(signal.SIGTERM, remember_termination)
     try:
-        try:
-            payload = json.loads(_read_request_line())
-        except json.JSONDecodeError:
-            raise RequestError("INVALID_JSON", "Request was not valid JSON.") from None
-        request = parse_request(payload)
-    except RequestError as error:
-        emitter.emit(_error_event(error.code, str(error)))
-        return 1
-    if not api_key:
-        emitter.emit(_error_event("MISSING_API_KEY", "YUTORI_API_KEY is not set in the runner environment."))
-        return 1
-    try:
-        outcome = asyncio.run(_run_until_terminated(request, emitter, api_key))
-    except Exception as error:  # noqa: BLE001 - last-resort protocol boundary
-        message = _redacted_error_text(error, api_key)
         emitter.emit(
             {
-                **_result_event("failed", message, request["mode"]),
-                "steps": 0,
+                "type": "ready",
+                "protocol_version": PROTOCOL_VERSION,
+                "package_version": _package_version(),
+                "sdk_version": SDK_VERSION,
+                "sdk_artifact_sha256": SDK_ARTIFACT_SHA256,
+                "sdk_provenance_sha256": SDK_PROVENANCE_SHA256,
+                "driver_version_pinned": DRIVER_VERSION,
+                "observation_format": "webp",
+                "observation_format_fallback": True,
+                "observation_fallback_format": "jpeg",
+                # The request is not parsed yet; the result event carries the truthful value.
+                "reasoning_overlay_requested": True,
             }
         )
-        return 1
-    return 0 if outcome in {"completed", "limit", "aborted"} else 1
+        try:
+            try:
+                payload = json.loads(_read_request_line())
+            except json.JSONDecodeError:
+                raise RequestError("INVALID_JSON", "Request was not valid JSON.") from None
+            request = parse_request(payload)
+        except RequestError as error:
+            emitter.emit(_error_event(error.code, str(error)))
+            return 1
+        if not api_key:
+            emitter.emit(_error_event("MISSING_API_KEY", "YUTORI_API_KEY is not set in the runner environment."))
+            return 1
+        try:
+            outcome = asyncio.run(
+                _run_until_terminated(request, emitter, api_key, lambda: termination["requested"])
+            )
+        except Exception as error:  # noqa: BLE001 - last-resort protocol boundary
+            message = _redacted_error_text(error, api_key)
+            emitter.emit(
+                {
+                    **_result_event("failed", message, request["mode"]),
+                    "steps": 0,
+                }
+            )
+            return 1
+        return 0 if outcome in {"completed", "limit", "aborted"} else 1
+    finally:
+        signal.signal(signal.SIGTERM, previous_sigterm)
 
 
 if __name__ == "__main__":

--- a/src/yutori_mcp/computer_use/supervisor.py
+++ b/src/yutori_mcp/computer_use/supervisor.py
@@ -8,6 +8,7 @@ import signal
 import subprocess
 import sys
 import time
+from collections import deque
 from collections.abc import Awaitable, Callable
 from contextlib import suppress
 from pathlib import Path
@@ -38,6 +39,8 @@ logger = logging.getLogger(__name__)
 EventCallback = Callable[[dict[str, Any]], Awaitable[None]]
 
 EVENT_CALLBACK_TIMEOUT_SECONDS = 5.0
+EVENT_CALLBACK_FLUSH_SECONDS = 0.25
+EVENT_QUEUE_LIMIT = 32
 RUNNER_SHUTDOWN_GRACE_SECONDS = 5.0
 RUNNER_FRAME_LIMIT_BYTES = 8 * 1024 * 1024
 RUNNER_MODULE = "yutori_mcp.computer_use.runner"
@@ -126,6 +129,50 @@ async def _notify(on_event: EventCallback | None, event: dict[str, Any]) -> Even
     return on_event
 
 
+class _EventNotifier:
+    """Deliver presentation events without blocking the runner protocol reader.
+
+    The queue is deliberately bounded. If a host cannot keep up, stale progress
+    is discarded in favor of the latest state while stdout continues draining.
+    """
+
+    def __init__(self, callback: EventCallback) -> None:
+        self._callback: EventCallback | None = callback
+        self._queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=EVENT_QUEUE_LIMIT)
+        self._task = asyncio.create_task(self._run())
+        self._dropped = 0
+
+    def submit(self, event: dict[str, Any]) -> None:
+        if self._callback is None or self._task.done():
+            return
+        if self._queue.full():
+            with suppress(asyncio.QueueEmpty):
+                self._queue.get_nowait()
+                self._queue.task_done()
+                self._dropped += 1
+        self._queue.put_nowait(event)
+
+    async def _run(self) -> None:
+        while self._callback is not None:
+            event = await self._queue.get()
+            try:
+                self._callback = await _notify(self._callback, event)
+            finally:
+                self._queue.task_done()
+        while not self._queue.empty():
+            self._queue.get_nowait()
+            self._queue.task_done()
+
+    async def close(self) -> None:
+        if not self._task.done():
+            with suppress(asyncio.TimeoutError):
+                await asyncio.wait_for(self._queue.join(), EVENT_CALLBACK_FLUSH_SECONDS)
+            self._task.cancel()
+        await asyncio.gather(self._task, return_exceptions=True)
+        if self._dropped:
+            logger.debug("Dropped %d stale computer-use progress event(s)", self._dropped)
+
+
 def _child_environment(api_key: str) -> dict[str, str]:
     # PATH is required because the SDK resolves cua-driver by name and model-run
     # shell commands must retain the host's standard utilities.
@@ -173,10 +220,10 @@ def _remaining_seconds(deadline: float) -> float:
 
 
 async def _drain_stderr(stream: asyncio.StreamReader, secret: str) -> list[str]:
-    diagnostics: list[str] = []
+    diagnostics: deque[str] = deque(maxlen=20)
     while line := await stream.readline():
         diagnostics.append(redact(line.decode(errors="replace"), secret).rstrip())
-    return diagnostics[-20:]
+    return list(diagnostics)
 
 
 def _ready_error(event: dict[str, Any]) -> str | None:
@@ -249,8 +296,8 @@ async def _supervise(
         cwd=os.path.expanduser("~"),
     )
     assert process.stdin and process.stdout and process.stderr
-    _record_runner_pid(process.pid)
     stderr_task = asyncio.create_task(_drain_stderr(process.stderr, api_key))
+    notifier = _EventNotifier(on_event) if on_event is not None else None
     actions: list[dict[str, Any]] = []
     terminal: dict[str, Any] | None = None
     ready = False
@@ -295,14 +342,20 @@ async def _supervise(
                 if not ready:
                     return protocol_failure("emitted an action before ready.")
                 actions.append(event)
-                on_event = await _notify(on_event, event)
+                if notifier is not None:
+                    notifier.submit(event)
             elif event_type == "ready":
                 if ready:
                     return protocol_failure("emitted multiple ready events.")
                 if mismatch := _ready_error(event):
                     return protocol_failure(f"provenance mismatch: {mismatch}")
                 ready = True
-                on_event = await _notify(on_event, event)
+                # Only advertise a process that has emitted ready after installing
+                # its synchronous SIGTERM latch, so `stop` cannot hit the old
+                # startup window where default signal handling killed it abruptly.
+                _record_runner_pid(process.pid)
+                if notifier is not None:
+                    notifier.submit(event)
             elif event_type in {"result", "error"}:
                 if not ready:
                     return protocol_failure("terminated before ready.")
@@ -338,6 +391,8 @@ async def _supervise(
     finally:
         if process.returncode is None:
             await _stop_process_group(process)
+        if notifier is not None:
+            await notifier.close()
         _clear_runner_pid(process.pid)
         if not stderr_task.done():
             stderr_task.cancel()

--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -416,7 +416,9 @@ class ComputerUseTaskInput(ToolInput):
         description=f"Absolute run deadline in minutes (1-{COMPUTER_USE_MAX_MINUTES})",
     )
     max_steps: int = Field(
-        default=COMPUTER_USE_DEFAULT_MAX_STEPS, ge=1, description="Maximum actions before stopping the run"
+        default=COMPUTER_USE_DEFAULT_MAX_STEPS,
+        ge=1,
+        description="Maximum model turns before stopping the run; one turn may contain multiple actions",
     )
     mode: ComputerUseMode = Field(
         default=COMPUTER_USE_DEFAULT_MODE,

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import logging
 import os
 import sys
@@ -597,18 +598,17 @@ def _progress_reporter(
     """Turn runner events into MCP progress + log notifications.
 
     Progress totals are deliberately omitted: an action's `index` is a monotonic
-    per-action counter and a batch step executes several actions, so max_steps is
-    not an upper bound for it — a fabricated total would render a bar that
-    overshoots. The human-readable message carries the step budget instead.
+    per-action counter and a model turn can execute several actions, so max_steps
+    is not an upper bound for it. The human-readable message carries the model-turn
+    budget instead.
     """
     from .computer_use.result import describe_delivery_surface, format_action_line
 
     async def on_event(event: dict[str, Any]) -> None:
         if event.get("type") == "ready":
             surface = describe_delivery_surface(mode, app)
-            message = f"Computer-use runner ready; driving {surface} (up to {max_steps} steps)."
-            await ctx.report_progress(progress=0, message=message)
-            await ctx.info(message)
+            message = f"Computer-use runner ready; driving {surface} (up to {max_steps} model turns)."
+            await asyncio.gather(ctx.report_progress(progress=0, message=message), ctx.info(message))
             return
         index = event.get("index", 0)
         message = format_action_line(event, index_default=0)
@@ -616,8 +616,7 @@ def _progress_reporter(
             message += f" [{event['elapsed_ms']} ms]"
         if event.get("command"):
             message += f" $ {event['command']}"
-        await ctx.report_progress(progress=index, message=message)
-        await ctx.info(message)
+        await asyncio.gather(ctx.report_progress(progress=index, message=message), ctx.info(message))
 
     return on_event
 

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -402,6 +402,48 @@ async def test_supervisor_forwards_ready_and_action_events():
     assert result["actions"] == [events[1]]
 
 
+async def test_supervisor_does_not_let_a_blocked_progress_callback_stall_protocol_drain(monkeypatch):
+    monkeypatch.setattr(supervisor, "EVENT_CALLBACK_FLUSH_SECONDS", 0.01)
+    started = asyncio.Event()
+
+    async def on_event(_event):
+        started.set()
+        await asyncio.Future()
+
+    action = {
+        "type": "action",
+        "index": 0,
+        "tool": "left_click",
+        "status": "executed",
+        "raw_status": "confirmed",
+        "delivery_mode": "foreground",
+        "route": "pixel",
+        "refusal_code": None,
+    }
+    process = _Process(
+        _stream(json.dumps(_ready_event()), json.dumps(action), json.dumps(_result_event())),
+        _stream(""),
+    )
+
+    result = await asyncio.wait_for(_run_supervised(process, on_event=on_event), 0.2)
+
+    assert started.is_set()
+    assert result["outcome"] == "completed"
+    assert result["actions"] == [action]
+
+
+async def test_supervisor_does_not_advertise_the_pid_before_ready(monkeypatch):
+    record = Mock()
+    monkeypatch.setattr(supervisor, "_record_runner_pid", record)
+    monkeypatch.setattr(supervisor, "_clear_runner_pid", Mock())
+    process = _Process(_stream("not-json"), _stream(""))
+
+    result = await _run_supervised(process)
+
+    assert result["outcome"] == "failed"
+    record.assert_not_called()
+
+
 async def test_supervisor_accepts_result_larger_than_default_stream_limit():
     final_text = "x" * 70_000
     stream = asyncio.StreamReader(limit=RUNNER_FRAME_LIMIT_BYTES)
@@ -539,6 +581,12 @@ def test_remaining_seconds_raises_once_deadline_has_passed():
         supervisor._remaining_seconds(time.monotonic() - 1)
 
 
+async def test_stderr_diagnostics_retain_only_the_latest_twenty_lines():
+    diagnostics = await supervisor._drain_stderr(_stream(*(f"line-{index}" for index in range(30))), "secret")
+
+    assert diagnostics == [f"line-{index}" for index in range(10, 30)]
+
+
 async def test_stop_process_group_escalates_to_kill():
     process = SimpleNamespace(pid=123, returncode=None, wait=AsyncMock(return_value=0))
 
@@ -633,6 +681,49 @@ async def test_runner_sigterm_path_cancels_the_sdk_session(monkeypatch):
     handlers[signal.SIGTERM]()
     assert await task == "aborted"
     assert cleaned.is_set()
+
+
+async def test_runner_honors_sigterm_received_before_the_async_loop(monkeypatch):
+    run = AsyncMock()
+    monkeypatch.setattr(runner_module, "run_request", run)
+    stream = _CollectStream()
+
+    outcome = await runner_module._run_until_terminated(
+        _valid_request(),
+        Emitter(stream),
+        "key",
+        lambda: True,
+    )
+
+    assert outcome == "aborted"
+    run.assert_not_awaited()
+    assert json.loads(stream.lines[-1]) == {
+        "type": "result",
+        "outcome": "aborted",
+        "delivery_mode": "foreground",
+        "final_text": "The computer-use run was stopped.",
+        "elapsed_ms": 0,
+        "steps": 0,
+    }
+
+
+async def test_runner_honors_sigterm_during_signal_handler_handoff(monkeypatch):
+    run = AsyncMock()
+    loop = asyncio.get_running_loop()
+    monkeypatch.setattr(runner_module, "run_request", run)
+    monkeypatch.setattr(loop, "add_signal_handler", lambda _sig, callback: callback())
+    monkeypatch.setattr(loop, "remove_signal_handler", lambda _sig: True)
+    stream = _CollectStream()
+
+    outcome = await runner_module._run_until_terminated(
+        _valid_request(),
+        Emitter(stream),
+        "key",
+    )
+
+    assert outcome == "aborted"
+    run.assert_not_awaited()
+    assert json.loads(stream.lines[-1])["outcome"] == "aborted"
 
 
 def test_runner_removes_api_key_before_spawning_a_real_shell(monkeypatch):
@@ -1357,7 +1448,7 @@ class _CollectStream:
 def test_runner_main_unexpected_failure_preserves_the_requested_background_mode(monkeypatch):
     stream = _CollectStream()
 
-    async def fail(_request, _emitter, _api_key):
+    async def fail(_request, _emitter, _api_key, _termination_requested):
         raise RuntimeError("unexpected runner failure")
 
     monkeypatch.setattr(runner_module, "_take_api_key", lambda: "yt-key")
@@ -1430,6 +1521,13 @@ class _FakePresentation:
 
 class _FakeCancellation:
     cause = None
+    cancelled = False
+
+    async def wait(self):
+        await asyncio.Future()
+
+    def raise_if_cancelled(self):
+        return None
 
 
 class _FakeComputer:
@@ -1501,6 +1599,7 @@ class _FakeAgent:
 
     def __init__(self, **kwargs):
         self.kwargs = kwargs
+        self.computer = kwargs.get("computer")
         self.callbacks = kwargs.get("callbacks") or []
         self.timings = {"model_ms": 40}
         self.__class__.instances.append(self)
@@ -1607,20 +1706,105 @@ class _LimitAgent(_FakeAgent):
                     pass
         yield {"output": [{"type": "message", "content": [{"type": "output_text", "text": "Partial"}]}]}
 
+    def completion_request(self, extra_messages):
+        self.summary_extra_messages = extra_messages
+        return {
+            "model": "n2",
+            "messages": [
+                {"role": "user", "content": "compacted trajectory checkpoint"},
+                *extra_messages,
+            ],
+        }
 
-async def test_run_request_gives_the_limit_summary_the_runs_system_prompt(monkeypatch):
+
+async def test_run_request_reuses_the_agent_trajectory_for_the_limit_summary(monkeypatch):
+    class SummaryCompletions:
+        def __init__(self):
+            self.requests = []
+
+        async def create(self, **kwargs):
+            self.requests.append(kwargs)
+            return {
+                "request_id": "req-summary",
+                "choices": [{"message": {"content": "Summary [DONE]"}}],
+            }
+
+    class SummaryClient:
+        instances = []
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.completions = SummaryCompletions()
+            self.chat = SimpleNamespace(completions=self.completions)
+            self.closed = False
+            self.__class__.instances.append(self)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_exc):
+            self.closed = True
+
     _FakeAgent.instances.clear()
     monkeypatch.setattr(runner_module, "MacOSComputer", _FakeComputer)
     monkeypatch.setattr(runner_module, "N2ComputerAgent", _LimitAgent)
+    monkeypatch.setattr(runner_module, "AsyncYutoriClient", SummaryClient)
     stream = _CollectStream()
     request = parse_request(_valid_request(deadline_ms=int((time.time() + 60) * 1000), max_steps=1))
 
     assert await runner_module.run_request(request, Emitter(stream), "yt-secret") == "limit"
 
-    run_agent, summary_agent = _FakeAgent.instances
-    assert summary_agent.kwargs["system_prompt"] == run_agent.kwargs["system_prompt"]
-    assert summary_agent.messages[0] == {"role": "user", "content": "open calculator"}
-    assert summary_agent.messages[-1] == {"role": "user", "content": runner_module.STOP_SUMMARY_PROMPT}
+    (run_agent,) = _FakeAgent.instances
+    (client,) = SummaryClient.instances
+    assert run_agent.kwargs["completions"] is client.completions
+    assert "api_key" not in run_agent.kwargs and "base_url" not in run_agent.kwargs
+    assert run_agent.summary_extra_messages == [
+        {"role": "user", "content": runner_module.STOP_SUMMARY_PROMPT}
+    ]
+    assert client.completions.requests[0]["messages"] == [
+        {"role": "user", "content": "compacted trajectory checkpoint"},
+        {"role": "user", "content": runner_module.STOP_SUMMARY_PROMPT},
+    ]
+    assert client.closed
+    result = json.loads(stream.lines[-1])
+    assert result["final_text"] == "Summary"
+    assert result["timings"]["model_calls"] == 1
+
+
+async def test_limit_summary_stops_with_the_computer_cancellation_latch():
+    from yutori.navigator.macos import CancellationLatch
+
+    completion_cancelled = asyncio.Event()
+
+    class BlockingCompletions:
+        async def create(self, **_kwargs):
+            try:
+                await asyncio.Future()
+            finally:
+                completion_cancelled.set()
+
+    cancellation = CancellationLatch()
+    agent = SimpleNamespace(
+        computer=SimpleNamespace(cancellation=cancellation),
+        timings={"model_ms": 0},
+        completion_request=lambda messages: {"model": "n2", "messages": messages},
+    )
+    task = asyncio.create_task(
+        runner_module._summarize_limit_run(
+            agent,
+            BlockingCompletions(),
+            runner_module.ApiCounter(),
+            runner_module.ChatTracker(),
+            time.monotonic() + 60,
+        )
+    )
+    await asyncio.sleep(0)
+
+    cancellation.request("operator_stop")
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert completion_cancelled.is_set()
 
 
 async def test_run_request_reports_limit_when_the_deadline_has_already_passed():
@@ -1819,6 +2003,33 @@ async def test_server_forwards_mode_and_fallback_to_the_runner(monkeypatch, tmp_
     assert forwarded["mode"] == "background" and forwarded["allow_foreground_fallback"] is True
     assert forwarded["app"] == "Notes"
     assert forwarded["platform_url"] == "https://platform.yutori.com"
+
+
+async def test_progress_reporter_delivers_progress_and_log_notifications_concurrently():
+    from yutori_mcp import server
+
+    progress_started = asyncio.Event()
+    info_started = asyncio.Event()
+    calls = []
+
+    async def report_progress(**kwargs):
+        calls.append(("progress", kwargs))
+        progress_started.set()
+        await info_started.wait()
+
+    async def info(message):
+        calls.append(("info", message))
+        info_started.set()
+        await progress_started.wait()
+
+    ctx = SimpleNamespace(report_progress=report_progress, info=info)
+    on_event = server._progress_reporter(ctx, 12, mode="background", app="Notes")
+
+    await asyncio.wait_for(on_event({"type": "ready"}), 0.2)
+
+    assert {call[0] for call in calls} == {"progress", "info"}
+    progress_call = next(payload for kind, payload in calls if kind == "progress")
+    assert "12 model turns" in progress_call["message"]
 
 
 async def test_server_early_failures_preserve_the_requested_background_mode(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Reuse a single `AsyncYutoriClient`/`N2ComputerAgent` lifecycle and the SDK-compacted trajectory for limit summaries while preserving cancellation, chat chaining, and timing.
- Move progress callbacks behind a bounded queue, deliver MCP progress and log notifications concurrently, retain only recent stderr, and make PID publication plus SIGTERM handoff startup-safe.
- Clarify `max_steps` as model turns across the schema, CLI, output, and docs, with expanded regression coverage for lifecycle edge cases.

## Testing
- `uv run --python 3.10 --extra dev pytest -q` — 431 passed, 1 skipped.
- `uv run --python 3.14 --extra dev pytest -q` — 431 passed, 1 skipped.
- Ruff, lockfile, compilation, and diff checks passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core computer-use runner lifecycle, limit-run summarization, and SIGTERM/stop behavior on a destructive desktop automation path; behavior is well-tested but touches timing and cancellation edge cases.
> 
> **Overview**
> This PR tightens the macOS **computer-use** stack around a single agent lifecycle, clearer **model-turn** semantics for `max_steps`, and safer startup/shutdown around **SIGTERM** and progress callbacks.
> 
> **Runner & limit summaries** reuse one `AsyncYutoriClient` / `N2ComputerAgent` for the whole run. The runner no longer accumulates the full streamed trajectory (only the latest assistant text), and when `max_steps` is hit it requests a text-only wrap-up via the agent’s `completion_request` on the SDK-compacted thread instead of spawning a second agent. Docs, schema, CLI help, perf output, and MCP progress copy now describe **`max_steps` as model turns** (a turn may batch several desktop actions).
> 
> **Supervisor & MCP** deliver `ready` / `action` events through a **bounded async queue** so a slow progress callback cannot stall stdout draining; runner **PID is written only after `ready`**, and stderr diagnostics keep the **last 20 lines**. The runner installs an early **SIGTERM latch** so stop can abort before desktop resources exist. MCP progress and log notifications are sent **concurrently** via `asyncio.gather`.
> 
> Regression tests cover blocked callbacks, PID timing, early SIGTERM, limit-summary trajectory reuse, and cancellation during summary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1439ede7f44dc3ea459ecbc33c629d36b228b653. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->