### PR TITLE
feat(computer-use): serve the eval-exact n2 tool set 20260830

### DIFF
--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -7,7 +7,12 @@ from .. import __version__
 PROTOCOL_VERSION = 2
 MCP_VERSION = __version__
 MODEL = "n2"
-TOOL_SET = "computer_use_tools-20260815"
+# The eval-exact n2 desktop surface, and the SDK's TOOL_SET_COMPUTER_USE_LATEST:
+# computer_batch + bash + read/write/edit, with `screenshot` as a batch member
+# rather than a tool of its own. Pinned by date rather than read from the SDK
+# constant so an SDK bump can never silently move the surface the model is
+# served -- see doctor's tool_set preflight, which sends this exact string.
+TOOL_SET = "computer_use_tools-20260830"
 # The two delivery modes this runtime implements. "foreground" drives the visible desktop
 # (the model sees the whole screen and the user keeps their hands off); "background" drives
 # one target app window through the SDK's window scope without taking the user's focus.

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -826,7 +826,7 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 
 
 def test_runtime_constants_select_latest_python_surface():
-    assert TOOL_SET == "computer_use_tools-20260815"
+    assert TOOL_SET == "computer_use_tools-20260830"
     assert SDK_VERSION == "0.9.12"
     assert all(len(digest) == 64 for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256))
     assert '"yutori==0.9.12"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()


### PR DESCRIPTION
## Why

The runtime pinned `computer_use_tools-20260815`. The API's new default and the SDK's `TOOL_SET_COMPUTER_USE_LATEST` are both `computer_use_tools-20260830`, the set the canonical OSWorld-V2 eval runs — so every Mac run was being served a surface the checkpoint's published numbers were not measured on.

## What changes for the model

20260830 exposes the same five tools (`computer_batch`, `bash`, `read`, `write`, `edit`) and adds the full batch vocabulary:

- `mouse_down` / `mouse_up` / `hold_key` as batch members
- `screenshot` as a batch member rather than a tool of its own
- optional arguments left optional — a `left_click` needs only `coordinates`, where 20260825 marked every argument required

`MacOSComputer` already serves all of it (`left_mouse_down`, `left_mouse_up`, `hold_key` have been on the adapter since the window-scope work), so this is a pin bump rather than a capability change. The standing instructions need no edit: they ask for screenshots without naming the tool that takes one.

## Test plan

- `pytest` — 431 passed, 1 skipped, against the released SDK 0.9.12
- Also run against yutori-ai/yutori-sdk-python#374 (the full-history payload change): 430 passed, with only `test_installed_sdk_matches_the_published_artifact` failing, as an editable SDK install always does

**Wants a live run before merge.** The tool-set change alters the surface the model is served — batch-only GUI, no standalone `screenshot` — and no unit test exercises the model's side of that. A real foreground and a real background task would confirm it.

## Follow-up

The SDK pin bump to whatever release carries yutori-ai/yutori-sdk-python#374 is a separate PR, once that ships — it is what actually restores the full story to a Mac run's replay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the served tool surface alters model behavior (batch-only GUI, no standalone `screenshot`); adapter code is unchanged but live runs should be validated before merge.
> 
> **Overview**
> **Bumps the macOS computer-use runtime** from `computer_use_tools-20260815` to **`computer_use_tools-20260830`**, matching the OSWorld-V2 eval surface and the API/SDK “latest” default.
> 
> That string is still **hard-pinned in `constants.py`** (not read from the SDK) so an SDK upgrade cannot silently change what the model is served; new comments document the eval-exact shape (`computer_batch` + shell/file tools, **`screenshot` only inside batches**). Doctor’s API preflight and the runner’s `N2ComputerAgent` both use this constant unchanged in wiring—only the value moves.
> 
> The unit test **`test_runtime_constants_select_latest_python_surface`** is updated to assert the new pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93b7b272554d927da2052bb23596ee5e75cf4c15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->