### PR TITLE
Extract _run_supervised_with_stop_patched() for the repeated stop-patched supervise call in tests

### DIFF
--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -356,6 +356,27 @@ def _patched_process_group_stop(process):
         yield stopped
 
 
+async def _run_supervised_with_stop_patched(
+    process, *, api_key="yt-key", deadline_seconds=1, **supervise_kwargs
+) -> tuple[dict[str, Any], AsyncMock]:
+    """Like `_run_supervised`, but through `_patched_process_group_stop` for its shared args.
+
+    For the tests below that also need to observe or stub the process-group stop path
+    (`stopped.assert_awaited_once_with(process)`) rather than leaving it unpatched --
+    tests whose control flow diverges further (creating and cancelling their own task)
+    keep their own inline `with _patched_process_group_stop(...)` block.
+    """
+    with _patched_process_group_stop(process) as stopped:
+        result = await _supervise(
+            command=python_runner_command(),
+            request={"type": "run"},
+            api_key=api_key,
+            deadline=time.monotonic() + deadline_seconds,
+            **supervise_kwargs,
+        )
+    return result, stopped
+
+
 async def test_supervisor_redacts_key_and_keeps_it_out_of_argv():
     secret = "yt-super-secret-value"
     process = _Process(
@@ -485,13 +506,7 @@ async def test_supervisor_rejects_runner_provenance_drift():
         _stream(""),
     )
 
-    with _patched_process_group_stop(process):
-        result = await _supervise(
-            command=python_runner_command(),
-            request={"type": "run"},
-            api_key="yt-key",
-            deadline=time.monotonic() + 1,
-        )
+    result, _ = await _run_supervised_with_stop_patched(process)
     assert result["outcome"] == "failed"
     assert "provenance mismatch" in result["final_text"]
 
@@ -609,13 +624,7 @@ async def test_stop_process_group_escalates_to_kill():
 async def test_supervisor_stdout_deadline_returns_limit_and_stops_group():
     process = _Process(asyncio.StreamReader(), asyncio.StreamReader())
 
-    with _patched_process_group_stop(process) as stopped:
-        result = await _supervise(
-            command=python_runner_command(),
-            request={"type": "run"},
-            api_key="secret",
-            deadline=time.monotonic() + 0.01,
-        )
+    result, stopped = await _run_supervised_with_stop_patched(process, api_key="secret", deadline_seconds=0.01)
     assert result["outcome"] == "limit"
     stopped.assert_awaited_once_with(process)
 
@@ -627,13 +636,7 @@ async def test_supervisor_eof_does_not_bypass_the_deadline():
         await asyncio.Future()
 
     process.wait = wait_forever
-    with _patched_process_group_stop(process) as stopped:
-        result = await _supervise(
-            command=python_runner_command(),
-            request={"type": "run"},
-            api_key="secret",
-            deadline=time.monotonic() + 0.01,
-        )
+    result, stopped = await _run_supervised_with_stop_patched(process, api_key="secret", deadline_seconds=0.01)
     assert result["outcome"] == "limit"
     stopped.assert_awaited_once_with(process)
 


### PR DESCRIPTION
## Issue

`tests/test_computer_use.py` already has `_run_supervised()`, a helper that wraps the repeated `_supervise(command=python_runner_command(), request={"type": "run"}, api_key=..., deadline=time.monotonic() + N)` call for the simple case (docstring: "only for tests that don't need to assert on the `create_subprocess_exec` mock itself or patch anything beyond it").

Three tests need the more involved variant — patching `_stop_process_group` too, via the existing `_patched_process_group_stop(process)` context manager — and each independently re-typed the identical `with _patched_process_group_stop(process) as stopped: result = await _supervise(command=python_runner_command(), request={"type": "run"}, api_key=..., deadline=time.monotonic() + N)` block:

- `test_supervisor_rejects_runner_provenance_drift`
- `test_supervisor_stdout_deadline_returns_limit_and_stops_group`
- `test_supervisor_eof_does_not_bypass_the_deadline`

## Fix

Extracted `_run_supervised_with_stop_patched()`, following the exact convention `_run_supervised()`/`_patched_process_group_stop()` already established in this file, and updated the three call sites to use it. The one remaining site with this shape, `test_supervisor_cancellation_is_aborted_and_stops_group`, creates and cancels its own `asyncio.Task` inside the `with` block — genuinely divergent control flow — so it correctly keeps its own inline block, matching how `_run_supervised`'s docstring already documents that split for the simpler helper.

Test-only, 1 file, +24/-21.

## Safety

- No production code touched — `src/` is unchanged.
- `uv run pytest -q`: **431 passed, 1 skipped** both before and after (baseline match exactly; same test count, no coverage change — each test still builds the identical request and makes the identical assertions).
- `ruff check tests/test_computer_use.py`: identical 7 pre-existing findings before and after (only line numbers shifted from the new helper); no new findings introduced. (This repo's CI runs `pytest` only, no `ruff` gate.)
- Reviewable from the diff alone: each replaced block is byte-identical to what the new helper now does internally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DvN8Ceba13sWCcsPbFmBUP

---
_Generated by [Claude Code](https://claude.ai/code/session_01DvN8Ceba13sWCcsPbFmBUP)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only deduplication in one file; no production code changes.
> 
> **Overview**
> Adds **`_run_supervised_with_stop_patched()`** in `tests/test_computer_use.py`, mirroring **`_run_supervised()`** but wrapping **`_patched_process_group_stop`** and returning **`(result, stopped)`** so tests can assert process-group teardown.
> 
> Three supervisor tests now call the helper instead of duplicating the same `with _patched_process_group_stop` + `_supervise(...)` block: provenance drift, stdout deadline/limit, and EOF-not-bypassing-deadline. **`test_supervisor_cancellation_is_aborted_and_stops_group`** still uses an inline patch because it creates and cancels its own **`asyncio.Task`** inside the context manager.
> 
> Test-only refactor; behavior and assertions are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e57005f7aae180f6f54748a64fc9e00a42357ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->