### PR TITLE
chore(computer-use): pin SDK 0.9.13 and release yutori-mcp 0.5.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.10"
+version = "0.5.11"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"
@@ -30,8 +30,10 @@ dependencies = [
     # breaks the install as soon as 2.x resolves.
     "mcp>=1.0.0,<2.0.0",
     "pydantic>=2.0.0",
-    # SDK 0.9.12 adds the activity window: the run's conversation with the model, in both modes.
-    "yutori==0.9.12",
+    # SDK 0.9.13 sends the whole screenshot history: a run's replay shows every
+    # step again, instead of stopping after the two frames the old client-side
+    # image window left in the request the replay is logged from.
+    "yutori==0.9.13",
 ]
 
 [project.optional-dependencies]

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -22,11 +22,11 @@ TOOL_SET = "computer_use_tools-20260830"
 DELIVERY_MODE_FOREGROUND = "foreground"
 DELIVERY_MODE_BACKGROUND = "background"
 DELIVERY_MODES = (DELIVERY_MODE_FOREGROUND, DELIVERY_MODE_BACKGROUND)
-SDK_VERSION = "0.9.12"
+SDK_VERSION = "0.9.13"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.
-SDK_ARTIFACT_SHA256 = "c852a9ca61dc7d6d06c6038071322c244380edc76e565c7facf250d428e2c5aa"
-SDK_INSTALLATION_SHA256 = "0bfc0789fcb7f258b6306e332378215acda71824281c53b84742e6ad17b81b17"
+SDK_ARTIFACT_SHA256 = "d3d8b252332cfcd87d6d2e33ebb4b4c54e5ab51a07dc790f0e5e3906de628d14"
+SDK_INSTALLATION_SHA256 = "92bb44226b462858bdb1d6d39c9a33e2509813b3f6812046b0e4c213d8177666"
 SDK_PROVENANCE_SHA256 = "7cab595d2f00e1a9ab5cd121204fbd6dd4c24163ead3eb76f76eef7fba495fc4"
 
 # The cua-driver release that implements this tool contract, and the checksum

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -830,9 +830,9 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 
 def test_runtime_constants_select_latest_python_surface():
     assert TOOL_SET == "computer_use_tools-20260830"
-    assert SDK_VERSION == "0.9.12"
+    assert SDK_VERSION == "0.9.13"
     assert all(len(digest) == 64 for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256))
-    assert '"yutori==0.9.12"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
+    assert '"yutori==0.9.13"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
 
 
 def test_installed_sdk_matches_the_published_artifact():

--- a/uv.lock
+++ b/uv.lock
@@ -1370,7 +1370,7 @@ wheels = [
 
 [[package]]
 name = "yutori"
-version = "0.9.12"
+version = "0.9.13"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1379,14 +1379,14 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/18/67f614efb474fa457cf617eb07c8136e9264686c5054b5a7d76aa728e2a6/yutori-0.9.12.tar.gz", hash = "sha256:74675734ddbabbbbea24bcf81a7494cf20c8a51e9cae3e307acb3eaec36c4061", size = 451622, upload-time = "2026-09-03T23:36:20.783Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/6b/41d856a07ec97b7471370f97b406fe5147340366428bea86b84a31a53270/yutori-0.9.13.tar.gz", hash = "sha256:7f3e2bcae7746c697d44830191b8138c1542823cfda87ad31ec94b619f241918", size = 454267, upload-time = "2026-09-04T06:57:37.746Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fd/16/3b92b6217ee42c7a2620ce33d95041a01ba1713d762849225eb6186fd212/yutori-0.9.12-py3-none-any.whl", hash = "sha256:c852a9ca61dc7d6d06c6038071322c244380edc76e565c7facf250d428e2c5aa", size = 318089, upload-time = "2026-09-03T23:36:19.008Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/74/0bb1ec7bd4e3687a9a48329758795ebaf1f143257d4dac5480ad1de44a67/yutori-0.9.13-py3-none-any.whl", hash = "sha256:d3d8b252332cfcd87d6d2e33ebb4b4c54e5ab51a07dc790f0e5e3906de628d14", size = 320338, upload-time = "2026-09-04T06:57:36.03Z" },
 ]
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.10"
+version = "0.5.11"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -1406,6 +1406,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "yutori", specifier = "==0.9.12" },
+    { name = "yutori", specifier = "==0.9.13" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
## What ships

yutori 0.9.13 ([yutori-ai/yutori-sdk-python#374](https://github.com/yutori-ai/yutori-sdk-python/pull/374), released via #375) sends the whole screenshot history on every n2 request instead of windowing it down to the two newest image-bearing messages.

The window bought the model nothing — the API's n2 handler applies exactly that window itself before serving the model — while the request log a run's replay is built from records what the client sent. That is why a Mac run's page on platform.yutori.com stopped after two frames and showed `[older image omitted]` in place of its story, and why a playground run of the same length showed every step.

Frames are now dropped only when a request would exceed the 10 MB wire cap, oldest first, and a dropped frame leaves no marker.

**Expect larger uploads.** A run past roughly 50 steps sends several MB per request where it used to send two frames' worth. That is the cost of the replay it buys back; the playground pays the same cost in-datacenter.

## Pins

| | |
|---|---|
| `SDK_VERSION` | 0.9.13 |
| `SDK_ARTIFACT_SHA256` | the PyPI wheel digest for `yutori-0.9.13-py3-none-any.whl` |
| `SDK_INSTALLATION_SHA256` | recomputed from a clean install |
| `SDK_PROVENANCE_SHA256` | unchanged — `provenance.json` did not move |

Digest method validated by reproducing the pinned 0.9.12 values from the 0.9.12 install before recomputing for 0.9.13. `uv.lock` refreshed.

## Test plan

- `pytest` — 431 passed, 1 skipped, against a real 0.9.13 install, so `test_installed_sdk_matches_the_published_artifact` is exercising the new digests rather than being skipped

**Still wants a live run.** Neither this nor #255 (the 20260830 tool set, already on main) has been exercised against a real Mac task. Worth one foreground and one background run before cutting the GitHub release that publishes 0.5.11 — the replay on the run's platform page is the thing to look at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Bumps a core SDK dependency and changes request payload size (larger uploads on long runs) while behavior shifts in screenshot/replay handling; digest mismatches will block runs until installs match.
> 
> **Overview**
> **Releases `yutori-mcp` 0.5.11** with the **`yutori` Python SDK pinned to 0.9.13** (was 0.9.12). Dependency comments note that 0.9.13 sends **full screenshot history** on n2 requests so platform run replays can show every step, instead of the prior client-side two-frame window that truncated logged replays.
> 
> **Runtime gates stay aligned:** `SDK_VERSION`, `SDK_ARTIFACT_SHA256`, and `SDK_INSTALLATION_SHA256` in `constants.py` are updated for the new wheel; `SDK_PROVENANCE_SHA256` is unchanged. **`uv.lock`** is refreshed, and computer-use tests assert the new version strings match `pyproject.toml`.
> 
> No MCP server or runner logic changes in this diff—only version pins, checksums, and lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c59f69be08f0f2b9fc762a3c00644d5fc868393. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->