### PR TITLE
refactor(computer-use): extract _as_dict() for repeated SDK-response normalization

### DIFF
--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -240,6 +240,19 @@ def classify_result(outputs: list[dict[str, Any]] | None) -> str:
     return "confirmed"
 
 
+def _as_dict(response: Any) -> dict[str, Any] | None:
+    """Normalize an SDK response to a plain dict, or None if it isn't one.
+
+    SDK call sites hand back either a pydantic-like model (with a `model_dump()`
+    method) or an already-plain dict, depending on the client path exercised;
+    `ChatTracker.on_api_end` and `_completion_text` below both need "whichever
+    one this is, as a dict" before reading fields off it.
+    """
+    if hasattr(response, "model_dump"):
+        response = response.model_dump()
+    return response if isinstance(response, dict) else None
+
+
 def _status_for(raw_status: str) -> str:
     if raw_status == "confirmed":
         return "executed"
@@ -370,9 +383,8 @@ class ChatTracker:
     async def on_api_end(self, _kwargs: dict[str, Any], response: Any) -> None:
         if self.chat_id is not None:
             return
-        if hasattr(response, "model_dump"):
-            response = response.model_dump()
-        request_id = response.get("request_id") if isinstance(response, dict) else None
+        response = _as_dict(response)
+        request_id = response.get("request_id") if response is not None else None
         if isinstance(request_id, str) and request_id:
             self.chat_id = request_id
 
@@ -449,8 +461,8 @@ async def _collect_final_text(agent: Any, messages: Any) -> str | None:
 
 def _completion_text(response: Any) -> str | None:
     """Extract assistant text from a chat-completions response."""
-    response = response.model_dump() if hasattr(response, "model_dump") else response
-    if not isinstance(response, dict):
+    response = _as_dict(response)
+    if response is None:
         return None
     message = (response.get("choices") or [{}])[0].get("message") or {}
     if not isinstance(message, dict):


### PR DESCRIPTION
## What

`src/yutori_mcp/computer_use/runner.py` had the same SDK-response normalization pattern hand-rolled in two places:

- `ChatTracker.on_api_end()`
- `_completion_text()`

Both needed "call `.model_dump()` if the response is a pydantic-like object, otherwise use it as-is if it's already a dict, otherwise `None`" before reading fields off the response. This PR extracts that into one `_as_dict()` helper and has both call sites use it.

## Why it's safe

- Purely internal implementation detail inside a single module — no change to any MCP tool name, schema, or behavior.
- Byte-for-byte equivalent logic (same `hasattr(response, "model_dump")` check, same dict-or-None fallback), just deduplicated.
- Full test suite passes unchanged: `uv run --extra dev pytest -q` → 431 passed, 1 skipped (pre-existing skip, unrelated).
- Touches 1 file.

## Testing

```
uv run --extra dev pytest -q
```
431 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WeFdmW4VRjG8gc9mLyjyML

---
_Generated by [Claude Code](https://claude.ai/code/session_01WeFdmW4VRjG8gc9mLyjyML)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor in one module with equivalent logic and no protocol or MCP surface changes.
> 
> **Overview**
> This PR **deduplicates** SDK response handling in `runner.py` by introducing `_as_dict()`, which turns pydantic-like responses (via `model_dump()`) or plain dicts into a dict, and returns `None` otherwise.
> 
> **`ChatTracker.on_api_end`** and **`_completion_text`** now call this helper instead of repeating the same inline normalization before reading `request_id` or chat completion fields. Behavior is unchanged; only the shared logic is centralized with a short docstring explaining why both sites need it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 998faad180242adb6ec1244c9cea396e9b832946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->