### PR TITLE
refactor(computer-use): extract _require_field() for the repeated request-validator shape

### DIFF
--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -134,39 +134,51 @@ class RequestError(ValueError):
         self.code = code
 
 
-def _require_string(request: dict[str, Any], field: str) -> str:
+def _require_field(request: dict[str, Any], field: str, *, valid: Callable[[Any], bool], expected: str) -> Any:
+    """Read ``field`` from ``request``, or raise ``INVALID_REQUEST`` when ``valid`` rejects it.
+
+    Single source of truth for the "get the field, check it, raise a uniform
+    `{field} must be {expected}.` message" shape every ``_require_*`` helper below shared before
+    this existed; only the predicate and the expected-type phrase differ per field.
+    """
     value = request.get(field)
-    if not isinstance(value, str) or not value:
-        raise RequestError("INVALID_REQUEST", f"{field} must be a non-empty string.")
+    if not valid(value):
+        raise RequestError("INVALID_REQUEST", f"{field} must be {expected}.")
     return value
+
+
+def _require_string(request: dict[str, Any], field: str) -> str:
+    return _require_field(
+        request, field, valid=lambda v: isinstance(v, str) and bool(v), expected="a non-empty string"
+    )
 
 
 def _require_optional_string(request: dict[str, Any], field: str) -> str | None:
-    value = request.get(field)
-    if value is not None and (not isinstance(value, str) or not value):
-        raise RequestError("INVALID_REQUEST", f"{field} must be a non-empty string or null.")
-    return value
+    return _require_field(
+        request,
+        field,
+        valid=lambda v: v is None or (isinstance(v, str) and bool(v)),
+        expected="a non-empty string or null",
+    )
 
 
 def _require_positive_int(request: dict[str, Any], field: str) -> int:
-    value = request.get(field)
-    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
-        raise RequestError("INVALID_REQUEST", f"{field} must be a positive integer.")
-    return value
+    return _require_field(
+        request,
+        field,
+        valid=lambda v: isinstance(v, int) and not isinstance(v, bool) and v > 0,
+        expected="a positive integer",
+    )
 
 
 def _require_mode(request: dict[str, Any]) -> str:
-    value = request.get("mode")
-    if value not in DELIVERY_MODES:
-        raise RequestError("INVALID_REQUEST", f"mode must be one of {', '.join(DELIVERY_MODES)}.")
-    return str(value)
+    return _require_field(
+        request, "mode", valid=lambda v: v in DELIVERY_MODES, expected=f"one of {', '.join(DELIVERY_MODES)}"
+    )
 
 
 def _require_bool(request: dict[str, Any], field: str) -> bool:
-    value = request.get(field)
-    if not isinstance(value, bool):
-        raise RequestError("INVALID_REQUEST", f"{field} must be a boolean.")
-    return value
+    return _require_field(request, field, valid=lambda v: isinstance(v, bool), expected="a boolean")
 
 
 def parse_request(payload: Any) -> dict[str, Any]:


### PR DESCRIPTION
## What

`computer_use/runner.py`'s `parse_request()` validated each incoming protocol field through
five separate helpers — `_require_string`, `_require_optional_string`, `_require_positive_int`,
`_require_mode`, `_require_bool` — that all repeated the identical shape:

```python
value = request.get(field)
if <field-specific condition>:
    raise RequestError("INVALID_REQUEST", f"{field} must be <expected>.")
return value
```

This extracts that shape into one `_require_field(request, field, *, valid, expected)` helper;
each of the five validators now supplies only its predicate and expected-type phrase.

## Why it's an improvement

The "get, validate, raise a uniformly-worded INVALID_REQUEST" boilerplate was duplicated five
times with only the type check and message wording differing. A single source of truth for that
shape means a future change to the error-raising pattern (e.g. adding more context to the
message) only needs to happen once, and a new validator is a one-line predicate instead of a
full copy-pasted function.

## Why it's safe

- **No behavior change.** Every validator produces the exact same `RequestError` code and
  message text as before — verified by diffing the error text for every rejection case
  (`task=''`, `app=123`, `deadline_ms=0`, `mode='sideways'`, `allow_foreground_fallback='yes'`,
  etc.) against the pre-refactor implementation.
- **Existing tests cover this path untouched.** `tests/test_computer_use.py`'s parametrized
  `test_parse_request_rejects_malformed_requests` (12 cases) and
  `test_parse_request_accepts_python_only_shape`/`test_parse_request_accepts_background_with_app`
  all pass unmodified.
- Single file touched (`src/yutori_mcp/computer_use/runner.py`), no public API, MCP tool schema,
  or wire-protocol change — this is a supervisor/runner-internal request parser.
- `uv run ruff check src/ tests/` is clean and `uv run pytest tests/` passes (431 passed, 1
  skipped, same as before the change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WbB5r3PopVvfyidraXtmk9

---
_Generated by [Claude Code](https://claude.ai/code/session_01WbB5r3PopVvfyidraXtmk9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor in `runner.py` with no intended change to error codes, messages, or the public protocol; existing `parse_request` tests cover the validation path.
> 
> **Overview**
> Introduces **`_require_field(request, field, *, valid, expected)`** as the shared implementation for the repeated “read field → validate → raise uniform `INVALID_REQUEST`” pattern in the computer-use runner’s request parser.
> 
> The five helpers **`_require_string`**, **`_require_optional_string`**, **`_require_positive_int`**, **`_require_mode`**, and **`_require_bool`** now delegate to that helper with field-specific predicates and expected-type phrases only; **`parse_request`** and wire behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d780dc752208a81376210a4bd6f3121a0684a804. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->