### PR TITLE
feat(computer-use): colorize the CLI, show batch actions, and mark the final output

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,23 +348,68 @@ uvx yutori-mcp computer-use setup    # installs CuaDriver.app, requests Screen R
 `setup` finishes by running the readiness checks and reports anything still missing. Re-run
 those checks any time with `uvx yutori-mcp computer-use doctor`.
 
-<details>
-<summary>Run a task from the terminal</summary>
+#### Prompting a task from the terminal
+
+The task is one quoted positional argument — plain English, in the imperative, as if you
+were handing the Mac to someone else:
 
 ```bash
-uvx yutori-mcp computer-use smoke
-uvx yutori-mcp computer-use run "In Calculator, compute 17 * 23 and report the result." --app Calculator
-uvx yutori-mcp computer-use run "Add a note titled Standup." --app Notes --mode background
+uvx yutori-mcp computer-use run "<what to do, and what to report back>"
 ```
 
-`smoke` is an end-to-end check: it types into Calculator to confirm the permissions took
-effect, then has the agent compute 9 * 9 in Calculator. `run` does whatever task you
-give it, printing each action as the agent takes it. `--mode background` drives only the
-target app's window without taking focus, so you can keep working; add
-`--allow-foreground-fallback` to let an action that did not land in the background briefly
-front the window. `uvx yutori-mcp computer-use stop` ends the active run from another terminal
-(background runs have no on-screen Stop button).
-</details>
+Everything else is optional. The three that matter most:
+
+```bash
+# Name the app you want driven, so the run starts in the right place
+uvx yutori-mcp computer-use run "Compute 17 * 23 and report the result." --app Calculator
+
+# Start a browser task on a specific page (--start-url requires --app)
+uvx yutori-mcp computer-use run "List every person on the team page and save them to ~/Desktop/team.txt." \
+  --app Safari --start-url https://yutori.com/company
+
+# Drive one window in the background and keep working (--mode background requires --app)
+uvx yutori-mcp computer-use run "Add a note titled Standup with today's three agenda items." \
+  --app Notes --mode background
+```
+
+Write the prompt so the run has a finish line:
+
+- **Say what "done" looks like.** "…and report the list" or "…and save it to
+  `~/Desktop/team.txt`" gives the model something to stop at; "look at the team page" does not.
+- **Name the app and the starting page** with `--app` / `--start-url` instead of describing
+  them in the prompt. The runner opens them before the model's first screenshot, which saves
+  turns and avoids the model guessing at which window to use.
+- **Spell out the constraints you care about** — which account to use, which folder to write
+  to, what to do when something is ambiguous ("if the page asks to log in, stop and say so").
+- **Keep it one task.** One run holds a machine-wide lock; chain separate runs rather than
+  packing five errands into one prompt.
+- **Don't put secrets in the prompt.** Have the model use an already-signed-in app or an
+  entry in Keychain; typed text shows up (scrubbed and truncated) in the action log.
+
+| Flag | Default | What it does |
+|------|---------|--------------|
+| `--app NAME` | none | App to target; opened and readied before the first screenshot |
+| `--start-url URL` | none | Page to open in `--app` first. Requires `--app` |
+| `--minutes N` | `30` | Absolute deadline, 1–60. The run stops here regardless of progress |
+| `--max-steps N` | `60` | Model turns before stopping; one turn can take several actions |
+| `--mode background` | `foreground` | Drives only `--app`'s window, without taking focus. Requires `--app` |
+| `--allow-foreground-fallback` | off | Background only: retry a missed action with the window briefly fronted |
+| `--env dev` | production | Runs against `platform.dev.yutori.com`. Goes before the subcommand: `yutori-mcp --env dev computer-use run "…"` |
+
+**Foreground** (the default) drives the whole visible desktop — don't touch the Mac while it
+runs. **Background** drives one app's window and captures only that window, so you can keep
+working; leave that window alone. Some apps accept background clicks but not typed keys
+(Calculator, for one), and the run reports the refusal rather than typing blind — add
+`--allow-foreground-fallback` for typing-heavy background tasks.
+
+`uvx yutori-mcp computer-use stop` ends the active run from another terminal (background runs
+have no on-screen Stop button). `uvx yutori-mcp computer-use smoke` is an end-to-end check: it
+types into Calculator to confirm the permissions took effect, then has the agent compute 9 * 9.
+
+While a task runs, `run` prints each action as the agent takes it — including the individual
+clicks, keystrokes, and scrolls inside each `computer_batch` — and closes with the model's
+answer in a labeled `FINAL OUTPUT` block. Output is colorized when stdout is a terminal; set
+`NO_COLOR=1` to turn that off, or `FORCE_COLOR=1` to keep it through a pipe.
 
 The harness in this repository is minimal: one task at a time (a machine-wide lock), either on
 the visible desktop or targeting one app window in the background, with no multiplexing. For

--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -20,7 +20,6 @@ from ..schemas import (
 )
 from .constants import (
     DELIVERY_MODE_BACKGROUND,
-    DELIVERY_MODE_FOREGROUND,
     DELIVERY_MODES,
     DRIVER_INSTALLER_SHA256,
     DRIVER_VERSION,
@@ -35,7 +34,7 @@ from .preflight import (
     first_blocker,
     run_checks,
 )
-from .result import describe_delivery_surface, format_action_line, format_result
+from .result import Terminal, describe_delivery_surface, format_terminal_action, format_terminal_result
 from .supervisor import run_task_with_resolved_credentials, stop_active_run
 
 
@@ -108,9 +107,13 @@ def _blocked() -> bool:
     return True
 
 
-def _report(result: dict[str, Any]) -> int:
-    """Print the formatted run result and derive the process exit code from its outcome."""
-    print(format_result(result))
+def _report(result: dict[str, Any], *, include_actions: bool = True) -> int:
+    """Print the formatted run result and derive the process exit code from its outcome.
+
+    ``include_actions`` stays on for commands that streamed nothing while the run was
+    in progress; `run` turns it off, having already printed each action as it landed.
+    """
+    print(format_terminal_result(result, Terminal.detect(), include_actions=include_actions))
     return 0 if result.get("outcome") == "completed" else 1
 
 
@@ -196,24 +199,37 @@ def hands_off_notice(mode: str) -> str:
     return "The model takes over this Mac's desktop now; do not touch it during the run."
 
 
-def _event_printer(mode: str, app: str | None):
+def _event_printer(mode: str, app: str | None, paint: Terminal | None = None):
     surface = describe_delivery_surface(mode, app)
+    paint = Terminal.detect() if paint is None else paint
 
     async def print_event(event: dict) -> None:
         if event.get("type") == "ready":
-            print(f"runner ready; driving {surface}")
+            print(f"{paint(paint.glyph('bullet'), 'green')} runner ready, driving {surface}\n", flush=True)
             return
-        line = format_action_line(event)
-        if event.get("elapsed_ms") is not None:
-            line += f" [at {event['elapsed_ms']} ms]"
-        if event.get("command"):
-            line += f"\n  $ {event['command']}"
-        print(line, flush=True)
+        print("\n".join(format_terminal_action(event, paint)), flush=True)
 
     return print_event
 
 
-_print_event = _event_printer(DELIVERY_MODE_FOREGROUND, None)
+def format_run_header(params: ComputerUseTaskInput, paint: Terminal) -> str:
+    """The block a `run` opens with: what was asked, where it lands, and the limits."""
+    target = params.app or "the visible desktop"
+    if params.start_url:
+        target += f"  {params.start_url}"
+    limits = f"{params.mode}  {paint.glyph('separator')}  {params.minutes:g} min  "
+    limits += f"{paint.glyph('separator')}  {params.max_steps} model turns"
+    return "\n".join(
+        [
+            paint.rule("YUTORI COMPUTER USE"),
+            paint.row("task", params.task),
+            paint.row("target", target),
+            paint.row("limits", limits),
+            "",
+            paint(f"{paint.glyph('warn')} {hands_off_notice(params.mode)}", "yellow", "bold"),
+            "",
+        ]
+    )
 
 
 async def _run_custom(args: argparse.Namespace) -> int:
@@ -232,12 +248,13 @@ async def _run_custom(args: argparse.Namespace) -> int:
     )
     if _blocked():
         return 1
-    print(hands_off_notice(params.mode))
+    paint = Terminal.detect()
+    print(format_run_header(params, paint))
     result = await run_task_with_resolved_credentials(
         **params.model_dump(),
-        on_event=_event_printer(params.mode, params.app),
+        on_event=_event_printer(params.mode, params.app, paint),
     )
-    return _report(result)
+    return _report(result, include_actions=False)
 
 
 def apply_computer_use_environment(env: str | None) -> None:

--- a/src/yutori_mcp/computer_use/result.py
+++ b/src/yutori_mcp/computer_use/result.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
-from typing import Any
+import os
+import shutil
+import sys
+from typing import Any, TextIO
 
 from .constants import DELIVERY_MODE_BACKGROUND, DELIVERY_MODE_FOREGROUND
 
@@ -101,11 +104,254 @@ def format_action_line(event: dict[str, Any], *, index_default: Any = None) -> s
     return line
 
 
-def _window_target_line(target: Any) -> str | None:
+_ANSI_CODES = {
+    "bold": "1",
+    "dim": "2",
+    "red": "31",
+    "green": "32",
+    "yellow": "33",
+    "cyan": "36",
+}
+# Each glyph as (preferred, ASCII fallback), so a stream whose encoding cannot carry the
+# preferred form degrades to plain text instead of raising UnicodeEncodeError at the very
+# end of a run that already did its work.
+_GLYPHS = {
+    "check": ("\u2713", "v"),
+    "cross": ("\u2717", "x"),
+    "tilde": ("~", "~"),
+    "dash": ("\u2014", "-"),
+    "clock": ("\u23f1", "!"),
+    "warn": ("\u26a0", "!"),
+    "bullet": ("\u25cf", "*"),
+    "separator": ("\u00b7", "|"),
+    "rule": ("\u2500", "-"),
+    "detail": ("\u21b3", ">"),
+    "prompt": ("$", "$"),
+}
+# Every action status `runner._status_for` can emit, plus the "interrupted" one
+# `ActionReporter.flush_interrupted` emits for a call cut short by a stop.
+_ACTION_STYLES = {
+    "executed": ("check", "green"),
+    "refused": ("cross", "red"),
+    "uncertain": ("tilde", "yellow"),
+    "interrupted": ("dash", "yellow"),
+}
+# Every outcome `runner._cancelled_outcome`, `runner.run_request`, and `terminal_result` produce.
+_OUTCOME_STYLES = {
+    "completed": ("check", "green"),
+    "limit": ("clock", "yellow"),
+    "aborted": ("dash", "yellow"),
+    "target_crashed": ("cross", "red"),
+    "failed": ("cross", "red"),
+}
+FINAL_OUTPUT_HEADING = "FINAL OUTPUT"
+_MAX_RULE_WIDTH = 88
+_LABEL_WIDTH = 10
+_DETAIL_INDENT = "     "
+
+
+def supports_color(stream: TextIO | None = None) -> bool:
+    """Whether ANSI styling is safe to write to ``stream``.
+
+    NO_COLOR and FORCE_COLOR come first so a piped run (`| tee`, CI logs) stays plain
+    text, and a deliberately colored one stays colored, whatever the TTY check says.
+    """
+    if os.environ.get("NO_COLOR"):
+        return False
+    if os.environ.get("FORCE_COLOR"):
+        return True
+    if os.environ.get("TERM") == "dumb":
+        return False
+    stream = sys.stdout if stream is None else stream
+    try:
+        return bool(stream.isatty())
+    except (AttributeError, ValueError):
+        # A closed or non-file-like stdout is not a terminal, and never a reason to fail a run.
+        return False
+
+
+def supports_glyphs(stream: TextIO | None = None) -> bool:
+    """Whether ``stream``'s encoding can carry the non-ASCII glyphs in ``_GLYPHS``."""
+    stream = sys.stdout if stream is None else stream
+    encoding = getattr(stream, "encoding", None) or "ascii"
+    try:
+        "".join(preferred for preferred, _ in _GLYPHS.values()).encode(encoding)
+    except (LookupError, UnicodeEncodeError):
+        return False
+    return True
+
+
+class Terminal:
+    """How one output stream renders: ANSI styles on or off, rich glyphs or ASCII.
+
+    Callable, so painting reads as ``paint(text, "green")`` at the call sites. Painted
+    spans are never nested: the trailing reset would end the outer style early.
+    """
+
+    def __init__(self, *, color: bool = False, glyphs: bool = True) -> None:
+        self.color = color
+        self.glyphs = glyphs
+
+    @classmethod
+    def detect(cls, stream: TextIO | None = None) -> "Terminal":
+        """The capabilities of ``stream`` (stdout by default)."""
+        return cls(color=supports_color(stream), glyphs=supports_glyphs(stream))
+
+    def __call__(self, text: str, *styles: str) -> str:
+        if not self.color or not styles or not text:
+            return text
+        codes = ";".join(_ANSI_CODES[style] for style in styles)
+        return f"\033[{codes}m{text}\033[0m"
+
+    def glyph(self, name: str) -> str:
+        preferred, fallback = _GLYPHS[name]
+        return preferred if self.glyphs else fallback
+
+    def width(self) -> int:
+        return min(_MAX_RULE_WIDTH, max(24, shutil.get_terminal_size((80, 24)).columns))
+
+    def rule(self, label: str | None = None) -> str:
+        """A full-width horizontal rule, optionally naming the block it opens."""
+        bar = self.glyph("rule")
+        if not label:
+            return self(bar * self.width(), "dim")
+        head = f"{bar * 2} {label} "
+        return self(head, "bold") + self(bar * max(0, self.width() - len(head)), "dim")
+
+    def row(self, label: str, value: str) -> str:
+        """One ``label   value`` metadata row, aligned under the run's headline."""
+        return "  " + self(label.ljust(_LABEL_WIDTH), "dim") + value
+
+
+def _clock(ms: Any) -> str:
+    """A duration scaled for reading: milliseconds under a second, minutes past sixty."""
+    if not isinstance(ms, (int, float)):
+        return "?"
+    if ms < 1000:
+        return f"{ms:.0f}ms"
+    seconds = ms / 1000
+    if seconds < 60:
+        return f"{seconds:.1f}s"
+    return f"{int(seconds // 60)}m {seconds % 60:04.1f}s"
+
+
+def format_terminal_action(event: dict[str, Any], paint: Terminal) -> list[str]:
+    """One action as a status line plus its indented detail lines.
+
+    The detail lines carry what a flat status line cannot: the members of a
+    `computer_batch` and the command of a shell call. Deliberately separate from
+    :func:`format_action_line`, which stays one plain line for MCP progress
+    notifications, where a host renders each message on its own.
+    """
+    status = str(event.get("status") or "")
+    glyph, color = _ACTION_STYLES.get(status, ("bullet", "yellow"))
+    line = f"{paint(paint.glyph(glyph), color, 'bold')} {paint('#' + str(event.get('index', 0)), 'dim')} "
+    line += paint(str(event.get("tool") or "unknown"), "cyan", "bold")
+    if status not in {"", "executed"}:
+        line += " " + paint(status, color)
+    if event.get("refusal_code"):
+        line += " " + paint(f"({event['refusal_code']})", color)
+    if event.get("escalated"):
+        line += " " + paint("[fronted]", "yellow")
+    if event.get("run_in_background"):
+        line += " " + paint("[background]", "yellow")
+    timings = [_clock(event["duration_ms"])] if event.get("duration_ms") is not None else []
+    if event.get("elapsed_ms") is not None:
+        timings.append(f"at {_clock(event['elapsed_ms'])}")
+    if timings:
+        line += "  " + paint(f" {paint.glyph('separator')} ".join(timings), "dim")
+    lines = [line]
+    for detail in event.get("details") or []:
+        lines.append(f"{_DETAIL_INDENT}{paint(paint.glyph('detail'), 'dim')} {paint(str(detail), 'dim')}")
+    if event.get("command"):
+        lines.append(f"{_DETAIL_INDENT}{paint(paint.glyph('prompt'), 'dim')} {event['command']}")
+    return lines
+
+
+def format_terminal_result(
+    result: dict[str, Any],
+    paint: Terminal,
+    *,
+    include_actions: bool = False,
+) -> str:
+    """A finished run for a terminal: the model's answer first, then the run's facts.
+
+    The answer is what the operator ran the command for, so it leads, inside a labeled
+    block that separates it from the progress lines above and the metadata below.
+    ``include_actions`` is for callers that streamed nothing while the run was going
+    (`smoke`); `run` leaves it off, since its actions already scrolled past live.
+    """
+    lines: list[str] = []
+    if include_actions and (actions := result.get("actions")):
+        for action in actions:
+            lines.extend(format_terminal_action(action, paint))
+        lines.append("")
+    if result.get("final_text"):
+        lines.extend(["", paint.rule(FINAL_OUTPUT_HEADING), str(result["final_text"]).strip(), paint.rule(), ""])
+    outcome = str(result.get("outcome") or "failed")
+    glyph, color = _OUTCOME_STYLES.get(outcome, ("bullet", "yellow"))
+    facts = []
+    if result.get("elapsed_ms") is not None:
+        facts.append(_clock(result["elapsed_ms"]))
+    if isinstance(result.get("steps"), int):
+        facts.append(f"{result['steps']} model turns")
+    facts.append(str(result.get("delivery_mode") or DELIVERY_MODE_FOREGROUND))
+    separator = f"  {paint.glyph('separator')}  "
+    lines.append(
+        f"{paint(paint.glyph(glyph), color, 'bold')} "
+        + paint(outcome, color, "bold")
+        + paint(separator + separator.join(facts), "dim")
+    )
+    if result.get("run_url"):
+        lines.append(paint.row("run", str(result["run_url"])))
+    if (window_target := _window_target(result.get("window_target"))) is not None:
+        lines.append(paint.row("window", window_target))
+    if (state := _presentation_state(result)) is not None:
+        surface = "menu bar" if result.get("delivery_mode") == DELIVERY_MODE_BACKGROUND else "overlay"
+        lines.append(paint.row(surface, state))
+    if (delivery := _delivery_counts(result)) is not None:
+        lines.append(paint.row("delivery", delivery))
+    if result.get("preview_frames"):
+        lines.append(paint.row("activity", f"{result['preview_frames']} frame(s) streamed while the window was open"))
+    perf = format_perf(result)
+    if perf:
+        lines.append(paint.row("perf", perf[0].removeprefix("Perf: ")))
+        lines.extend(paint.row("", paint(line.strip(), "dim")) for line in perf[1:])
+    return "\n".join(lines)
+
+
+def _window_target(target: Any) -> str | None:
+    """The background window a run was scoped to, or None when it drove the desktop."""
     if not isinstance(target, dict) or target.get("pid") is None:
         return None
     label = target.get("app_name") or target.get("title") or "window"
-    return f"Window target: {label} (pid {target['pid']}, window {target.get('window_id')})"
+    return f"{label} (pid {target['pid']}, window {target.get('window_id')})"
+
+
+def _presentation_state(result: dict[str, Any]) -> str | None:
+    """Whether the requested presentation surface came up, or None if none was asked for."""
+    if not result.get("reasoning_overlay_requested"):
+        return None
+    state = "active" if result.get("reasoning_overlay_effective") else "unavailable"
+    return f"{state}; codec: {result.get('codec') or 'unknown'}"
+
+
+def _delivery_counts(result: dict[str, Any]) -> str | None:
+    """How often background delivery had to escalate or gave up; None when uninteresting.
+
+    Always reported for a background run, even at zero -- that a run needed no
+    escalation is the result the operator is looking for.
+    """
+    escalations = result.get("fallback_escalations") or 0
+    skips = result.get("fallback_skips") or 0
+    refusals = result.get("background_refusals") or 0
+    if not (result.get("delivery_mode") == DELIVERY_MODE_BACKGROUND or escalations or skips or refusals):
+        return None
+    line = f"{escalations} foreground escalation(s), {refusals} background refusal(s)"
+    if skips:
+        # Foreground retries the SDK withheld because the window had already changed.
+        line += f", {skips} retry(ies) skipped after the window changed"
+    return line
 
 
 def format_result(result: dict[str, Any]) -> str:
@@ -115,27 +361,19 @@ def format_result(result: dict[str, Any]) -> str:
     ]
     if result.get("run_url"):
         lines.append(f"Run: {result['run_url']}")
-    if (window_target := _window_target_line(result.get("window_target"))) is not None:
-        lines.append(window_target)
+    if (window_target := _window_target(result.get("window_target"))) is not None:
+        lines.append(f"Window target: {window_target}")
     if result.get("final_text"):
         lines.append(f"Final text: {result['final_text']}")
     if result.get("elapsed_ms") is not None:
         lines.append(f"Elapsed: {result['elapsed_ms']} ms")
-    if result.get("reasoning_overlay_requested"):
-        state = "active" if result.get("reasoning_overlay_effective") else "unavailable"
+    if (state := _presentation_state(result)) is not None:
         # Background runs show a menu bar item (latest frame + Stop) instead of the overlay.
         # Either way the run also offers the activity window, opened from that menu.
         surface = "Menu bar status" if result.get("delivery_mode") == DELIVERY_MODE_BACKGROUND else "Reasoning overlay"
-        lines.append(f"{surface}: {state}; codec: {result.get('codec') or 'unknown'}")
-    escalations = result.get("fallback_escalations") or 0
-    skips = result.get("fallback_skips") or 0
-    refusals = result.get("background_refusals") or 0
-    if result.get("delivery_mode") == DELIVERY_MODE_BACKGROUND or escalations or skips or refusals:
-        line = f"Delivery: {escalations} foreground escalation(s), {refusals} background refusal(s)"
-        if skips:
-            # Foreground retries the SDK withheld because the window had already changed.
-            line += f", {skips} retry(ies) skipped after the window changed"
-        lines.append(line)
+        lines.append(f"{surface}: {state}")
+    if (delivery := _delivery_counts(result)) is not None:
+        lines.append(f"Delivery: {delivery}")
     if result.get("preview_frames"):
         lines.append(f"Activity window: {result['preview_frames']} frame(s) streamed while it was open")
     lines.extend(format_perf(result))

--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -16,7 +16,7 @@ from importlib import metadata
 from typing import Any, TextIO
 
 from yutori import AsyncYutoriClient
-from yutori.navigator import N2ComputerAgent
+from yutori.navigator import N2ComputerAgent, flatten_batch_member
 from yutori.navigator.macos import (
     MacOSComputer,
     MacOSPresentationStatus,
@@ -125,6 +125,10 @@ STOP_SUMMARY_PROMPT = (
 )
 FINAL_TEXT_MARKERS = ("[DONE]", "[INFEASIBLE]")
 _SHELL_TOOL_NAMES = frozenset({"bash", "shell_command", "run_command"})
+BATCH_TOOL_NAME = "computer_batch"
+# Long enough to identify what was typed into which field, short enough that a typed
+# paragraph does not push the action line off the terminal (or into a host's logs).
+TYPED_TEXT_PREVIEW_CHARACTERS = 48
 _BACKGROUND_TASK_PATTERN = re.compile(r"\bStarted background task ([A-Za-z0-9-]+)\b")
 
 
@@ -290,6 +294,67 @@ def shell_command_preview(item: dict[str, Any]) -> str | None:
     return sanitize_command_preview(command) if isinstance(command, str) and command.strip() else None
 
 
+def _is_number(value: Any) -> bool:
+    """True for a real int/float. `bool` is an int subclass, so it is excluded."""
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def _point(value: Any) -> str | None:
+    """Render a model coordinate pair, or None when the field is absent or malformed."""
+    if isinstance(value, (list, tuple)) and len(value) == 2 and all(_is_number(part) for part in value):
+        return f"({value[0]:g},{value[1]:g})"
+    return None
+
+
+def _batch_member_preview(member: dict[str, Any]) -> str:
+    """One human-readable phrase for a single flattened `computer_batch` member.
+
+    Field-driven rather than a per-action branch: every n2 action is some subset of
+    coordinates/direction/amount/key/duration/modifier/text (see the SDK's
+    `_ACTION_FIELDS`), so reading the fields that are present covers a new action
+    name without a code change here.
+    """
+    parts = [str(member.get("action") or "action")]
+    start = _point(member.get("start_coordinates"))
+    point = _point(member.get("coordinates"))
+    if start is not None and point is not None:
+        parts.append(f"{start} -> {point}")
+    elif point is not None:
+        parts.append(point)
+    if isinstance(member.get("direction"), str) and member["direction"].strip():
+        parts.append(member["direction"].strip())
+    if _is_number(member.get("amount")):
+        parts.append(f"x{member['amount']:g}")
+    if isinstance(member.get("key"), str) and member["key"].strip():
+        parts.append(member["key"].strip())
+    if _is_number(member.get("duration")):
+        parts.append(f"{member['duration']:g}s")
+    if isinstance(member.get("modifier"), str) and member["modifier"].strip():
+        parts.append(f"+{member['modifier'].strip()}")
+    if isinstance(member.get("text"), str):
+        # Typed text is the one batch field that can carry a secret the model was
+        # handed, so it goes through the same scrubbing as a shell command preview.
+        parts.append(f'"{sanitize_command_preview(member["text"], max_characters=TYPED_TEXT_PREVIEW_CHARACTERS)}"')
+    return " ".join(parts)
+
+
+def batch_action_previews(item: dict[str, Any]) -> list[str] | None:
+    """Per-member previews for a `computer_batch` call; None for every other tool.
+
+    A batch is where all the clicking, typing, and scrolling happens, so
+    "computer_batch -> executed" on its own says nothing about what the model did on
+    screen. Both progress renderers show these underneath the action line, the way
+    they already show a shell call's command.
+    """
+    if str(item.get("name") or "").lower() != BATCH_TOOL_NAME:
+        return None
+    actions = _arguments(item).get("actions")
+    if not isinstance(actions, list):
+        return None
+    previews = [_batch_member_preview(flatten_batch_member(member)) for member in actions if isinstance(member, dict)]
+    return previews or None
+
+
 def _background_task_id(outputs: list[dict[str, Any]] | None) -> str | None:
     for frame in outputs or []:
         output = frame.get("output")
@@ -362,6 +427,7 @@ class ActionReporter:
                 "elapsed_ms": max(0, round((self._clock() - self._run_start) * 1000)),
                 "duration_ms": duration_ms,
                 "command": shell_command_preview(item),
+                "details": batch_action_previews(item),
                 "run_in_background": run_in_background,
                 "background_task_id": _background_task_id(result) if run_in_background else None,
                 # Carried on every action so the supervisor can still link the run when it

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -614,6 +614,10 @@ def _progress_reporter(
         message = format_action_line(event, index_default=0)
         if event.get("elapsed_ms") is not None:
             message += f" [{event['elapsed_ms']} ms]"
+        if event.get("details"):
+            # One line, not the CLI's indented block: a host renders each notification
+            # as a single message.
+            message += " " + "; ".join(str(detail) for detail in event["details"])
         if event.get("command"):
             message += f" $ {event['command']}"
         await asyncio.gather(ctx.report_progress(progress=index, message=message), ctx.info(message))

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -42,13 +42,25 @@ from yutori_mcp.computer_use.constants import (
     TOOL_SET,
 )
 from yutori_mcp.computer_use.lock import ComputerUseBusyError, DesktopLock
-from yutori_mcp.computer_use.result import failure, format_result, redact, terminal_result
+from yutori_mcp.computer_use.result import (
+    FINAL_OUTPUT_HEADING,
+    Terminal,
+    failure,
+    format_result,
+    format_terminal_action,
+    format_terminal_result,
+    redact,
+    supports_color,
+    supports_glyphs,
+    terminal_result,
+)
 from yutori_mcp.computer_use.supervisor import attach_run_link, run_chat_id
 from yutori_mcp.computer_use.runner import (
     ActionReporter,
     Emitter,
     RequestError,
     RunGuard,
+    batch_action_previews,
     classify_result,
     parse_request,
 )
@@ -1209,7 +1221,7 @@ async def test_smoke_allows_two_minutes_for_live_check(monkeypatch, tmp_path):
     _patch_smoke_preflight(monkeypatch, cli, tmp_path / "desktop.lock")
     monkeypatch.setattr(cli, "_mechanical_calculator_check", AsyncMock(return_value="42"))
     monkeypatch.setattr(supervisor, "run_task", run)
-    monkeypatch.setattr(cli, "format_result", lambda _result: "complete")
+    monkeypatch.setattr(cli, "format_terminal_result", lambda *_args, **_kwargs: "complete")
     monkeypatch.setattr(
         "yutori_mcp.adapter.resolve_run_credentials_and_platform_url",
         lambda: ("dev-key", "https://api.yutori.com/v1", "https://platform.yutori.com"),
@@ -2119,7 +2131,7 @@ async def test_cli_run_forwards_the_mode_and_prints_the_matching_notice(monkeypa
     assert run.await_args.kwargs["platform_url"] == "https://platform.yutori.com"
     out = capsys.readouterr().out
     assert cli.hands_off_notice("background") in out
-    assert "Delivery mode: background" in out
+    assert "completed" in out and "background" in out
     with pytest.raises(ValidationError, match="requires app"):
         await cli._run_custom(SimpleNamespace(**{**vars(args), "app": None}))
 
@@ -2588,3 +2600,198 @@ def test_cli_stop_prints_the_stop_outcome(monkeypatch, capsys):
     args = parser.parse_args(["computer-use", "stop"])
     assert cli.dispatch(args.computer_use_command, args) == 0
     assert capsys.readouterr().out == "No computer-use run is active.\n"
+
+
+def _batch(*members: dict[str, Any]) -> dict[str, Any]:
+    return {"name": "computer_batch", "arguments": {"actions": list(members)}}
+
+
+def test_batch_action_previews_describe_each_member_of_the_batch():
+    previews = batch_action_previews(
+        _batch(
+            {"action": "screenshot"},
+            {"action": "left_click", "coordinates": [412, 318], "modifier": "ctrl"},
+            {"action": "type", "text": "yutori.com/company"},
+            {"action": "key_press", "key": "cmd+l"},
+            {"action": "scroll", "coordinates": [500, 500], "direction": "down", "amount": 3},
+            {"action": "wait", "duration": 1.5},
+            # The nested envelope tool sets 20260812/20260815 advertise, which
+            # flatten_batch_member() folds into the flat shape before rendering.
+            {"name": "drag", "arguments": {"start_coordinates": [10, 20], "coordinates": [30, 40]}},
+        )
+    )
+    assert previews == [
+        "screenshot",
+        "left_click (412,318) +ctrl",
+        'type "yutori.com/company"',
+        "key_press cmd+l",
+        "scroll (500,500) down x3",
+        "wait 1.5s",
+        "drag (10,20) -> (30,40)",
+    ]
+
+
+def test_batch_action_previews_only_apply_to_batches_and_survive_junk_members():
+    assert batch_action_previews({"name": "bash", "arguments": {"command": "ls"}}) is None
+    assert batch_action_previews(_batch()) is None
+    assert batch_action_previews({"name": "computer_batch", "arguments": {"actions": "nope"}}) is None
+    # A malformed coordinate pair is dropped rather than rendered or raised on.
+    assert batch_action_previews(_batch({"action": "left_click", "coordinates": [1]}, "junk")) == ["left_click"]
+
+
+def test_batch_action_previews_redact_a_secret_the_model_typed(monkeypatch):
+    monkeypatch.setenv("DEMO_API_KEY", "super-secret-value")
+    (preview,) = batch_action_previews(_batch({"action": "type", "text": "super-secret-value"}))
+    assert "super-secret-value" not in preview
+    (long_preview,) = batch_action_previews(_batch({"action": "type", "text": "y" * 200}))
+    typed = long_preview.removeprefix('type "').removesuffix('"')
+    assert len(typed) == runner_module.TYPED_TEXT_PREVIEW_CHARACTERS and typed.endswith("\u2026")
+
+
+async def test_action_events_carry_the_batch_detail_and_no_detail_for_other_tools():
+    stream = _CollectStream()
+    reporter = ActionReporter(Emitter(stream), time.monotonic())
+    batch = _batch({"action": "left_click", "coordinates": [1, 2]})
+    await reporter.on_computer_call_start(batch)
+    await reporter.on_computer_call_end(batch, [{"output": "ok"}])
+    shell = {"name": "bash", "arguments": {"command": "ls"}}
+    await reporter.on_computer_call_start(shell)
+    await reporter.on_computer_call_end(shell, [{"output": "ok"}])
+    first, second = (json.loads(line) for line in stream.lines)
+    assert first["details"] == ["left_click (1,2)"]
+    assert second["details"] is None
+
+
+def test_supports_color_honors_the_environment_and_the_tty(monkeypatch):
+    monkeypatch.delenv("NO_COLOR", raising=False)
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+    monkeypatch.setenv("TERM", "xterm-256color")
+    assert supports_color(SimpleNamespace(isatty=lambda: True)) is True
+    assert supports_color(SimpleNamespace(isatty=lambda: False)) is False
+    monkeypatch.setenv("FORCE_COLOR", "1")
+    assert supports_color(SimpleNamespace(isatty=lambda: False)) is True
+    monkeypatch.setenv("NO_COLOR", "1")
+    assert supports_color(SimpleNamespace(isatty=lambda: True)) is False
+
+
+def test_supports_glyphs_falls_back_for_an_ascii_stream():
+    assert supports_glyphs(SimpleNamespace(encoding="utf-8")) is True
+    assert supports_glyphs(SimpleNamespace(encoding="ascii")) is False
+    ascii_only = Terminal(color=False, glyphs=False)
+    assert ascii_only.glyph("check").isascii() and ascii_only.rule("X").isascii()
+
+
+def test_terminal_paints_only_when_color_is_on():
+    assert Terminal(color=False)("ok", "green") == "ok"
+    assert Terminal(color=True)("ok", "green") == "\033[32mok\033[0m"
+
+
+def test_format_terminal_action_shows_the_batch_members_and_the_shell_command():
+    plain = Terminal(color=False, glyphs=False)
+    lines = format_terminal_action(
+        {
+            "index": 4,
+            "tool": "computer_batch",
+            "status": "executed",
+            "duration_ms": 1630,
+            "elapsed_ms": 14691,
+            "details": ["left_click (1,2)", 'type "hi"'],
+        },
+        plain,
+    )
+    assert lines[0] == "v #4 computer_batch  1.6s | at 14.7s"
+    assert [line.strip() for line in lines[1:]] == ["> left_click (1,2)", '> type "hi"']
+    refused = format_terminal_action(
+        {"index": 0, "tool": "bash", "status": "refused", "refusal_code": "driver_refused", "command": "ls"},
+        plain,
+    )
+    assert refused[0] == "x #0 bash refused (driver_refused)"
+    assert refused[1].strip() == "$ ls"
+
+
+def test_format_terminal_result_leads_with_a_labeled_final_output_block():
+    text = format_terminal_result(
+        {
+            "outcome": "completed",
+            "delivery_mode": "foreground",
+            "final_text": "  Here are the 14 employees.  ",
+            "elapsed_ms": 292147,
+            "steps": 35,
+            "run_url": "https://platform.yutori.com/navigator/chats/abc",
+        },
+        Terminal(color=False, glyphs=False),
+    )
+    lines = [line for line in text.split("\n") if line.strip()]
+    assert FINAL_OUTPUT_HEADING in lines[0]
+    assert lines[1] == "Here are the 14 employees."
+    assert lines[3].startswith("v completed") and "4m 52.1s" in lines[3] and "35 model turns" in lines[3]
+    assert lines[4].split() == ["run", "https://platform.yutori.com/navigator/chats/abc"]
+
+
+def test_format_terminal_result_omits_the_action_list_unless_asked():
+    result = {
+        "outcome": "failed",
+        "delivery_mode": "foreground",
+        "actions": [{"index": 0, "tool": "bash", "status": "executed", "command": "ls"}],
+    }
+    plain = Terminal(color=False, glyphs=False)
+    assert "bash" not in format_terminal_result(result, plain)
+    assert "bash" in format_terminal_result(result, plain, include_actions=True)
+
+
+def test_format_terminal_result_reports_the_background_surfaces():
+    text = format_terminal_result(
+        {
+            "outcome": "limit",
+            "delivery_mode": "background",
+            "window_target": {"pid": 42, "app_name": "Notes", "window_id": 7},
+            "reasoning_overlay_requested": True,
+            "reasoning_overlay_effective": True,
+            "codec": "jpeg",
+            "fallback_escalations": 1,
+            "fallback_skips": 2,
+            "preview_frames": 7,
+        },
+        Terminal(color=False, glyphs=False),
+    )
+    assert "! limit" in text
+    assert "window    Notes (pid 42, window 7)" in text
+    assert "menu bar  active; codec: jpeg" in text
+    assert "delivery  1 foreground escalation(s), 0 background refusal(s)" in text
+    assert "retry(ies) skipped after the window changed" in text
+    assert "activity  7 frame(s) streamed while the window was open" in text
+
+
+def test_cli_run_header_states_the_task_target_and_limits():
+    from yutori_mcp.computer_use import cli
+
+    params = ComputerUseTaskInput(task="list the team", app="Safari", start_url="https://yutori.com", minutes=5)
+    text = cli.format_run_header(params, Terminal(color=False, glyphs=False))
+    assert "task      list the team" in text
+    assert "target    Safari  https://yutori.com" in text
+    assert "limits    foreground  |  5 min  |  60 model turns" in text
+    assert cli.hands_off_notice("foreground") in text
+
+
+async def test_progress_reporter_folds_the_batch_detail_into_one_message():
+    from yutori_mcp import server
+
+    messages: list[str] = []
+    ctx = SimpleNamespace(
+        report_progress=AsyncMock(),
+        info=lambda message: messages.append(message) or asyncio.sleep(0),
+    )
+    on_event = server._progress_reporter(ctx, 12)
+    await on_event(
+        {
+            "type": "action",
+            "index": 3,
+            "tool": "computer_batch",
+            "status": "executed",
+            "elapsed_ms": 900,
+            "details": ["left_click (1,2)", 'type "hi"'],
+        }
+    )
+    (message,) = messages
+    assert message.count("\n") == 0
+    assert message.endswith('left_click (1,2); type "hi"')


### PR DESCRIPTION
`computer-use run` now opens with a header block (task, target, limits, hands-off notice), streams each action with a colored status glyph and scaled timings, and closes with the model's answer inside a labeled `FINAL OUTPUT` rule block followed by an aligned run summary. Each `computer_batch` event now carries a `details` list — one privacy-safe phrase per member (`left_click (412,318)`, `type "…"`, `scroll (500,500) down x3`) built off the SDK's flattened batch shape, with typed text run through `sanitize_command_preview` so secrets and long strings never reach the terminal; the trailing `Actions:` dump is gone from the CLI, since those lines already streamed live. Styling lives in a new `Terminal` capability object with no new dependencies, honoring `NO_COLOR`/`FORCE_COLOR`/`TERM=dumb`/non-TTY and degrading to ASCII glyphs when stdout's encoding can't carry them. The MCP tool response is unchanged — `format_result` still emits the same plain text (shared fragments were factored into `_window_target`/`_presentation_state`/`_delivery_counts`) — and MCP progress notifications gained the batch detail folded onto one line. README also replaces the collapsed CLI blurb with a full "Prompting a task from the terminal" section: command shape, worked examples, prompt-writing rules, and a flag table with verified defaults and constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are mostly CLI presentation and observability; MCP final tool output shape is preserved, with new detail only on progress notifications.
> 
> **Overview**
> **`computer-use run`** now prints a structured header (task, target, limits, hands-off warning), streams **colorized** per-action lines with glyphs and readable timings, and ends with the model answer in a **`FINAL OUTPUT`** rule block plus a compact outcome summary. Live runs no longer repeat the full **`Actions:`** dump at the end.
> 
> **`computer_batch`** actions emit a **`details`** list (clicks, scrolls, typed text previews) from the runner; the CLI shows them indented under each action, and **MCP progress** folds them onto one line. Typed text in previews is **scrubbed and truncated** like shell commands.
> 
> A new **`Terminal`** helper (no extra deps) drives styling via **`NO_COLOR`**, **`FORCE_COLOR`**, TTY detection, and ASCII glyph fallback. **`format_result`** for MCP tool text is unchanged; shared metadata helpers were refactored only.
> 
> **README** replaces the short collapsed CLI note with a full **“Prompting a task from the terminal”** section: examples, prompt tips, flag table, and notes on foreground vs background and terminal color.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit baeeef40ac7f7e8bdec722b1940c6794cbb00944. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->