### PR TITLE
test(computer-use): extract _patched_run_task_supervise() for the repeated run_task() driver/supervise stub

### DIFF
--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -759,14 +759,28 @@ def _run_task_kwargs(tmp_path, **overrides):
     return kwargs
 
 
-async def test_run_task_uses_only_python_runner_and_sdk_driver_discovery(tmp_path):
+@contextmanager
+def _patched_run_task_supervise(tmp_path, *, result=None):
+    """Patch driver discovery and `_supervise()` so `run_task()` sees a fake driver.
+
+    Shared by the tests below that call `run_task()` directly and need its two
+    module-level dependencies stubbed identically -- a driver file `find_cua_driver()`
+    can resolve, and `_supervise()` returning ``result`` (default: a bare completed
+    outcome) instead of actually spawning the runner subprocess. Yields the `_supervise`
+    AsyncMock so callers can inspect its `await_args`.
+    """
     driver = tmp_path / "cua-driver"
     driver.write_text("")
-    supervise = AsyncMock(return_value={"outcome": "completed"})
+    supervise = AsyncMock(return_value=result if result is not None else {"outcome": "completed"})
     with (
         patch.object(supervisor, "_supervise", supervise),
         patch.object(supervisor, "find_cua_driver", return_value=driver),
     ):
+        yield supervise
+
+
+async def test_run_task_uses_only_python_runner_and_sdk_driver_discovery(tmp_path):
+    with _patched_run_task_supervise(tmp_path) as supervise:
         result = await run_task(**_run_task_kwargs(tmp_path))
     assert result["outcome"] == "completed"
     assert supervise.await_args.kwargs["command"] == python_runner_command()
@@ -776,8 +790,6 @@ async def test_run_task_uses_only_python_runner_and_sdk_driver_discovery(tmp_pat
 
 
 async def test_run_task_links_the_run_to_the_platform_chat_page(tmp_path):
-    driver = tmp_path / "cua-driver"
-    driver.write_text("")
     action = {
         "index": 0,
         "tool": "screenshot",
@@ -789,10 +801,7 @@ async def test_run_task_links_the_run_to_the_platform_chat_page(tmp_path):
         "chat_id": "chat-1",
     }
     supervised = terminal_result("limit", "deadline", actions=[action])
-    with (
-        patch.object(supervisor, "_supervise", AsyncMock(return_value=supervised)),
-        patch.object(supervisor, "find_cua_driver", return_value=driver),
-    ):
+    with _patched_run_task_supervise(tmp_path, result=supervised):
         result = await run_task(**_run_task_kwargs(tmp_path, platform_url="https://platform.dev.yutori.com"))
     assert result["chat_id"] == "chat-1"
     assert result["run_url"] == "https://platform.dev.yutori.com/navigator/chats/chat-1"
@@ -2125,13 +2134,7 @@ async def test_cli_run_forwards_the_mode_and_prints_the_matching_notice(monkeypa
 
 
 async def test_run_task_request_carries_mode_and_fallback(tmp_path):
-    driver = tmp_path / "cua-driver"
-    driver.write_text("")
-    supervise = AsyncMock(return_value={"outcome": "completed"})
-    with (
-        patch.object(supervisor, "_supervise", supervise),
-        patch.object(supervisor, "find_cua_driver", return_value=driver),
-    ):
+    with _patched_run_task_supervise(tmp_path) as supervise:
         await run_task(**_run_task_kwargs(tmp_path, app="Notes", mode="background", allow_foreground_fallback=True))
     request = supervise.await_args.kwargs["request"]
     assert request["protocol_version"] == PROTOCOL_VERSION == 2


### PR DESCRIPTION
## Structural issue

Three tests in `tests/test_computer_use.py` — `test_run_task_uses_only_python_runner_and_sdk_driver_discovery`, `test_run_task_links_the_run_to_the_platform_chat_page`, and `test_run_task_request_carries_mode_and_fallback` — each independently wrote out the same five-line setup before calling `run_task()` directly:

```python
driver = tmp_path / "cua-driver"
driver.write_text("")
supervise = AsyncMock(return_value=...)
with (
    patch.object(supervisor, "_supervise", supervise),
    patch.object(supervisor, "find_cua_driver", return_value=driver),
):
    ...
```

The only thing that varied between the three call sites was `_supervise`'s return value.

## Why it's an improvement

This is exactly the "repeated test-setup closure" pattern this file's own test suite has already extracted for elsewhere (`_run_supervised`, `_patched_process_group_stop`, `_recording_dispatch`, `_patch_smoke_preflight`, `_run_supervised_with_stop_patched`, etc.) — three independent hand-written copies of the same fake-driver + double-patch shape, discovered via a mechanical duplicate-block scan of the file. Extracting `_patched_run_task_supervise(tmp_path, *, result=None)` as a context manager (yielding the `_supervise` AsyncMock so callers can still inspect `await_args`) gives the pattern one named, docstring-explained home, matching this file's established convention.

## Why it's safe

- Test-only change; no production code touched.
- Strictly mechanical: same patches applied in the same order, same default return value, same assertions at every call site — no behavior or coverage change.
- Full suite: 431 passed / 1 skipped (matches the pre-change baseline exactly).
- `ruff check` clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MEHBV5oknBGzMA31U25sUE

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MEHBV5oknBGzMA31U25sUE

---
_Generated by [Claude Code](https://claude.ai/code/session_01MEHBV5oknBGzMA31U25sUE)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with identical patch behavior and assertions; no production code changes.
> 
> **Overview**
> Introduces **`_patched_run_task_supervise(tmp_path, *, result=None)`**, a context manager that centralizes the fake CUA driver file plus patches on `supervisor._supervise` and `find_cua_driver` for tests that invoke **`run_task()`** directly. It yields the `_supervise` **AsyncMock** so tests can still assert on **`await_args`**, with an optional **`result`** override (default completed outcome).
> 
> **`test_run_task_uses_only_python_runner_and_sdk_driver_discovery`**, **`test_run_task_links_the_run_to_the_platform_chat_page`**, and **`test_run_task_request_carries_mode_and_fallback`** now use this helper instead of copying the same five-line setup block.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f62f38611de0168dbec950caabe9e8e1f28783d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->