### PR TITLE
chore(computer-use): pin SDK 0.9.14 and release yutori-mcp 0.5.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.11"
+version = "0.5.12"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"
@@ -30,10 +30,9 @@ dependencies = [
     # breaks the install as soon as 2.x resolves.
     "mcp>=1.0.0,<2.0.0",
     "pydantic>=2.0.0",
-    # SDK 0.9.13 sends the whole screenshot history: a run's replay shows every
-    # step again, instead of stopping after the two frames the old client-side
-    # image window left in the request the replay is logged from.
-    "yutori==0.9.13",
+    # SDK 0.9.14 makes the native reasoning overlay compile across supported
+    # Swift/CoreFoundation combinations by disambiguating CGFloat arithmetic.
+    "yutori==0.9.14",
 ]
 
 [project.optional-dependencies]

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -22,11 +22,11 @@ TOOL_SET = "computer_use_tools-20260830"
 DELIVERY_MODE_FOREGROUND = "foreground"
 DELIVERY_MODE_BACKGROUND = "background"
 DELIVERY_MODES = (DELIVERY_MODE_FOREGROUND, DELIVERY_MODE_BACKGROUND)
-SDK_VERSION = "0.9.13"
+SDK_VERSION = "0.9.14"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.
-SDK_ARTIFACT_SHA256 = "d3d8b252332cfcd87d6d2e33ebb4b4c54e5ab51a07dc790f0e5e3906de628d14"
-SDK_INSTALLATION_SHA256 = "92bb44226b462858bdb1d6d39c9a33e2509813b3f6812046b0e4c213d8177666"
+SDK_ARTIFACT_SHA256 = "81f2b7e124eaba0501e23142a9a83f145ddb69d9e46ace9955e12a794b02aca7"
+SDK_INSTALLATION_SHA256 = "629893d1286a8893db1538c216d6d077c1ff20515f9e5b4b0708e9a503cbe35f"
 SDK_PROVENANCE_SHA256 = "7cab595d2f00e1a9ab5cd121204fbd6dd4c24163ead3eb76f76eef7fba495fc4"
 
 # The cua-driver release that implements this tool contract, and the checksum

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -830,9 +830,9 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 
 def test_runtime_constants_select_latest_python_surface():
     assert TOOL_SET == "computer_use_tools-20260830"
-    assert SDK_VERSION == "0.9.13"
+    assert SDK_VERSION == "0.9.14"
     assert all(len(digest) == 64 for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256))
-    assert '"yutori==0.9.13"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
+    assert '"yutori==0.9.14"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
 
 
 def test_installed_sdk_matches_the_published_artifact():

--- a/uv.lock
+++ b/uv.lock
@@ -1370,7 +1370,7 @@ wheels = [
 
 [[package]]
 name = "yutori"
-version = "0.9.13"
+version = "0.9.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1379,14 +1379,14 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7c/6b/41d856a07ec97b7471370f97b406fe5147340366428bea86b84a31a53270/yutori-0.9.13.tar.gz", hash = "sha256:7f3e2bcae7746c697d44830191b8138c1542823cfda87ad31ec94b619f241918", size = 454267, upload-time = "2026-09-04T06:57:37.746Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/1f/84808f2bc9b5d7be18f5dc8e9cf460e701be646e65fbaf5a5d094be8db87/yutori-0.9.14.tar.gz", hash = "sha256:94563eed7c85b8e34c72fc1bcf58966a8d99563aa073f62473efc7945f5909eb", size = 458539, upload-time = "2026-09-04T19:04:12.815Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/74/0bb1ec7bd4e3687a9a48329758795ebaf1f143257d4dac5480ad1de44a67/yutori-0.9.13-py3-none-any.whl", hash = "sha256:d3d8b252332cfcd87d6d2e33ebb4b4c54e5ab51a07dc790f0e5e3906de628d14", size = 320338, upload-time = "2026-09-04T06:57:36.03Z" },
+    { url = "https://files.pythonhosted.org/packages/90/7a/5227a12eb3c2b390744d29abb2e6b34392e3b3a2341d04891907b25bf730/yutori-0.9.14-py3-none-any.whl", hash = "sha256:81f2b7e124eaba0501e23142a9a83f145ddb69d9e46ace9955e12a794b02aca7", size = 322204, upload-time = "2026-09-04T19:04:10.222Z" },
 ]
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.11"
+version = "0.5.12"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -1406,6 +1406,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "yutori", specifier = "==0.9.13" },
+    { name = "yutori", specifier = "==0.9.14" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
## What ships

Pins [yutori 0.9.14](https://github.com/yutori-ai/yutori-sdk-python/releases/tag/v0.9.14), which fixes the native macOS reasoning overlay build on Swift/CoreFoundation combinations that report ambiguous `CGFloat`/`Double` multiplication.

The SDK now explicitly converts normalized Stop-region coordinate ratios to `Double` before scaling. The SDK change landed in [yutori-sdk-python#380](https://github.com/yutori-ai/yutori-sdk-python/pull/380) and was released through [#382](https://github.com/yutori-ai/yutori-sdk-python/pull/382).

## Pins

| | |
|---|---|
| `SDK_VERSION` | 0.9.14 |
| `SDK_ARTIFACT_SHA256` | published PyPI wheel digest |
| `SDK_INSTALLATION_SHA256` | recomputed from a clean registry install |
| `SDK_PROVENANCE_SHA256` | unchanged |

Also bumps `yutori-mcp` to 0.5.12 and refreshes `uv.lock`.

## Verification

- `uv run pytest -q` — 431 passed, 1 skipped
- published SDK artifact hash test passes
- Doctor accepts a clean registry installation of yutori 0.9.14
- overlay compiles and self-tests with Swift 6.3.3 / macOS SDK 26.5
- overlay compiles and self-tests with Swift 6.4 / macOS SDK 27.0

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and checksum pin only—no MCP runtime logic changes beyond accepting yutori 0.9.14 at install/preflight gates.
> 
> **Overview**
> Releases **yutori-mcp 0.5.12** by pinning **`yutori==0.9.14`** in `pyproject.toml` and aligning computer-use runtime constants (`SDK_VERSION`, wheel/installation SHA256 digests) so doctor/preflight still reject mismatched SDK installs.
> 
> The dependency comment now points at SDK **0.9.14** fixing native macOS **reasoning overlay** builds where `CGFloat`/`Double` math was ambiguous across Swift/CoreFoundation toolchains. **`SDK_PROVENANCE_SHA256`** is unchanged; **`uv.lock`** and **`test_computer_use`** expectations are updated to match the new pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c07a5b71deb4e8c7d31ec30109f0ab393c2820db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->