### PR TITLE
Stream computer-use CLI progress in Claude

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,8 @@
   "mcpServers": {
     "yutori": {
       "command": "uvx",
-      "args": ["yutori-mcp"]
+      "args": ["yutori-mcp"],
+      "request_timeout_ms": 3660000
     }
   }
 }

--- a/skills/06-computer-use/SKILL.md
+++ b/skills/06-computer-use/SKILL.md
@@ -33,7 +33,42 @@ The optional native reasoning overlay may require Xcode Command Line Tools.
 
 ## Run a Task
 
-Prefer the MCP tool when it is available:
+In Claude Code, including Claude sessions hosted by Conductor, run the CLI through the Bash
+tool with stdout attached. This makes `runner ready`, each `action #...` line, shell-command
+previews, and the final result appear in the agent's live progress. Do not redirect the command
+to a file or call the MCP `run_computer_use_task` tool from these sessions: Claude's headless
+Agent SDK does not expose MCP progress or log notifications to its host.
+
+For a foreground run:
+
+```bash
+uvx yutori-mcp computer-use run "$ARGUMENTS" --minutes 9 --max-steps 60
+```
+
+Run that as a foreground Bash call and set the Bash tool timeout slightly longer than the CLI's
+`--minutes` limit (Claude's foreground Bash timeout is capped at 10 minutes). Pass the task as
+one safely quoted argument and do not use `eval`.
+
+For a longer run, start the same CLI command as a background Bash task without redirecting its
+output, then wait on it with `TaskOutput` in blocking intervals. Relay meaningful new action
+lines in progress updates between waits. The computer-use `--minutes` value remains the absolute
+run deadline.
+
+For an app-specific task:
+
+```bash
+uvx yutori-mcp computer-use run "$ARGUMENTS" --app Safari --start-url https://example.com --minutes 9
+```
+
+For a background window-delivery run (the CLI process itself can still be a foreground Bash
+call):
+
+```bash
+uvx yutori-mcp computer-use run "$ARGUMENTS" --app Notes --mode background --minutes 9
+```
+
+In another MCP host that visibly renders MCP progress notifications, prefer the MCP tool when it
+is available:
 
 ```json
 {
@@ -71,22 +106,10 @@ target before calling the tool. "In the foreground" or no mention means the defa
 Add `"allow_foreground_fallback": true` only if the user accepts the target window briefly
 flashing to the front when an action cannot be delivered in the background.
 
-If the MCP tool is unavailable, ask the user to run the CLI task runner:
+If neither the CLI nor the MCP tool is available, ask the user to run the CLI task runner:
 
 ```bash
 uvx yutori-mcp computer-use run "$ARGUMENTS" --minutes 30 --max-steps 60
-```
-
-For an app-specific task:
-
-```bash
-uvx yutori-mcp computer-use run "$ARGUMENTS" --app Safari --start-url https://example.com
-```
-
-For a background run:
-
-```bash
-uvx yutori-mcp computer-use run "$ARGUMENTS" --app Notes --mode background
 ```
 
 To stop the active run from the Mac (background runs have no on-screen Stop button):

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -2544,6 +2544,17 @@ def test_docs_describe_background_mode():
     skill = " ".join((root / "skills/06-computer-use/SKILL.md").read_text().split())
     assert "--mode background" in skill
     assert '"in the background"' in skill and "ask which app to target" in skill
+    assert "Claude Code, including Claude sessions hosted by Conductor" in skill
+    assert "run the CLI through the Bash tool with stdout attached" in skill
+    assert "does not expose MCP progress or log notifications" in skill
+    assert "TaskOutput" in skill
+
+
+def test_claude_mcp_config_allows_the_full_computer_use_deadline():
+    config = json.loads((Path(__file__).parents[1] / ".mcp.json").read_text())
+    # The tool accepts a 60-minute deadline; leave one minute for startup and
+    # final result delivery so Claude does not abandon a still-running child.
+    assert config["mcpServers"]["yutori"]["request_timeout_ms"] == 61 * 60 * 1000
 
 
 # --- computer-use stop --------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Route Claude Code and Conductor computer-use workflows through the attached CLI so live action output is visible.
- Document background polling for longer runs while retaining the MCP path for hosts that render progress notifications.
- Raise the direct MCP request timeout to 61 minutes and add regression coverage.

## Testing
- `uv run --extra dev python -m pytest -q` (445 passed, 1 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and MCP client configuration only; no changes to computer-use execution logic.
> 
> **Overview**
> **Claude Code and Conductor** are now told to run computer-use via **`uvx yutori-mcp computer-use run`** in foreground Bash (stdout attached), not **`run_computer_use_task`**, because the headless Agent SDK does not surface MCP progress. The skill adds examples for foreground runs, Bash timeout vs `--minutes`, and longer runs via background Bash plus **`TaskOutput`** polling; the MCP JSON tool path is reserved for hosts that show progress notifications.
> 
> **`.mcp.json`** sets **`request_timeout_ms`** to **3,660,000** (~61 minutes) so direct MCP calls can outlast the tool’s 60-minute deadline with a minute of slack. Tests assert the new skill wording and the timeout value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f88bd56cfd7b558f8f23ddb1aec97e1c5279eb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->