### PR TITLE
test(computer-use): extract _action_event() for the repeated action-event fixture

### DIFF
--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -320,6 +320,21 @@ def _result_event(**overrides):
     return event
 
 
+def _action_event(**overrides):
+    event = {
+        "type": "action",
+        "index": 0,
+        "tool": "left_click",
+        "status": "executed",
+        "raw_status": "confirmed",
+        "delivery_mode": "foreground",
+        "route": "pixel",
+        "refusal_code": None,
+    }
+    event.update(overrides)
+    return event
+
+
 async def _run_supervised(process, *, api_key="yt-key", deadline_seconds=1, **supervise_kwargs):
     """Patch the child process and call `_supervise` with the shared fixed args this file's tests repeat.
 
@@ -411,17 +426,7 @@ async def test_supervisor_redacts_key_and_keeps_it_out_of_argv():
 async def test_supervisor_forwards_ready_and_action_events():
     events = [
         _ready_event(reasoning_overlay_requested=True),
-        {
-            "type": "action",
-            "index": 1,
-            "tool": "computer_batch",
-            "status": "executed",
-            "raw_status": "confirmed",
-            "delivery_mode": "foreground",
-            "route": "pixel",
-            "refusal_code": None,
-            "elapsed_ms": 42,
-        },
+        _action_event(index=1, tool="computer_batch", elapsed_ms=42),
         _result_event(),
     ]
     process = _Process(_stream(*(json.dumps(event) for event in events)), _stream(""))
@@ -560,16 +565,7 @@ async def test_supervisor_rejects_invalid_utf8_in_an_otherwise_valid_event():
 
 
 async def test_supervisor_overwrites_child_supplied_actions():
-    action = {
-        "type": "action",
-        "index": 0,
-        "tool": "left_click",
-        "status": "executed",
-        "raw_status": "confirmed",
-        "delivery_mode": "foreground",
-        "route": "pixel",
-        "refusal_code": None,
-    }
+    action = _action_event()
     process = _Process(
         _stream(
             json.dumps(_ready_event()),
@@ -2175,18 +2171,7 @@ async def test_supervisor_synthesized_results_carry_the_requested_mode():
 
 
 def test_event_shape_checks_delivery_modes_and_accepts_the_new_action_fields():
-    action = {
-        "type": "action",
-        "index": 0,
-        "tool": "left_click",
-        "status": "executed",
-        "raw_status": "confirmed",
-        "delivery_mode": "background",
-        "route": "accessibility",
-        "refusal_code": None,
-        "effect": "confirmed",
-        "escalated": True,
-    }
+    action = _action_event(delivery_mode="background", route="accessibility", effect="confirmed", escalated=True)
     assert supervisor._event_shape_error(action) is None
     assert supervisor._event_shape_error({**action, "delivery_mode": "sideways"}) == (
         "invalid or missing fields: delivery_mode"


### PR DESCRIPTION
## What

`tests/test_computer_use.py` already has `_ready_event(**overrides)` and `_result_event(**overrides)` helper functions that build the shared literal shape for the runner's `"ready"`/`"result"` protocol events, letting each test only spell out the fields it varies. The parallel `"action"` event shape (`type`/`index`/`tool`/`status`/`raw_status`/`delivery_mode`/`route`/`refusal_code`) had no such helper: three tests each independently hand-built the identical 8-key dict literal:

- `test_supervisor_forwards_ready_and_action_events`
- `test_supervisor_overwrites_child_supplied_actions`
- `test_event_shape_checks_delivery_modes_and_accepts_the_new_action_fields`

## Why this is an improvement

Same duplication mechanism this repo has repeatedly consolidated for the sibling `_ready_event`/`_result_event` builders (and for other repeated test-fixture shapes) — a hand-copied literal that has to be kept in sync by eye across call sites whenever the protocol shape changes. Extracting `_action_event(**overrides)` right next to the two existing builders, following their exact convention, gives the "action" event the same single source of truth.

## Why this is safe

- Test-only change, zero production code touched, and the extraction changes no MCP tool name, schema, or CLI flag.
- Purely mechanical: `_action_event()` with no overrides reproduces the exact dict `test_supervisor_overwrites_child_supplied_actions` built by hand; the other two call sites pass only the fields that differed from that shape (`index`/`tool`/`elapsed_ms` for one, `delivery_mode`/`route`/`effect`/`escalated` for the other) and produce byte-identical dicts to what was there before.
- Full suite: `uv run pytest -q` → 445 passed / 1 skipped, unchanged from the pre-change baseline (same test count, same pass/skip split — no coverage change).
- `uv run ruff check .` clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKTEXhBJZ5HnbekxrBA7oV

---
_Generated by [Claude Code](https://claude.ai/code/session_01LKTEXhBJZ5HnbekxrBA7oV)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with identical fixture data; no runtime or API surface touched.
> 
> **Overview**
> Adds **`_action_event(**overrides)`** beside the existing `_ready_event` / `_result_event` helpers in `tests/test_computer_use.py`, giving supervisor protocol **action** events a single default shape (`type`, `index`, `tool`, `status`, `raw_status`, `delivery_mode`, `route`, `refusal_code`).
> 
> Three tests that previously inlined the same dict are switched to the helper, passing only overrides (`index`/`tool`/`elapsed_ms`, or background delivery fields). **No production or protocol behavior changes**—mechanical deduplication only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13424fe09ebb5860554730a74f65b2296a5d9694. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->