### PR TITLE
docs: name Yutori in add-mcp setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Use https://yutori.com/api/llms.txt and set up Yutori for me.
 
 2. Install MCP using [add-mcp](https://neon.com/blog/add-mcp) (requires Node.js):
    ```
-   npx add-mcp "uvx yutori-mcp"
+   npx -y add-mcp -n yutori "uvx yutori-mcp"
    ```
 
     Pick the clients you want to configure.


### PR DESCRIPTION
## Summary
- explicitly name the server `yutori` in the cross-client `add-mcp` command
- run `npx` noninteractively to avoid the redundant package-install prompt

## Validation
- `npx -y add-mcp --help`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the install command; no runtime or config code is modified.
> 
> **Overview**
> Updates the **manual quick install** `add-mcp` example so copy-paste setup matches the rest of the README’s **`yutori`** server name.
> 
> The command now uses **`npx -y`** (non-interactive) and **`-n yutori`** when registering **`uvx yutori-mcp`**, instead of the bare `npx add-mcp "uvx yutori-mcp"` line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0513dba48acb0231753a4102c6f2b5cfc5230f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->