### PR TITLE
test(computer-use): finish the _action_event() consolidation to 3 more call sites

### DIFF
--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -448,16 +448,7 @@ async def test_supervisor_does_not_let_a_blocked_progress_callback_stall_protoco
         started.set()
         await asyncio.Future()
 
-    action = {
-        "type": "action",
-        "index": 0,
-        "tool": "left_click",
-        "status": "executed",
-        "raw_status": "confirmed",
-        "delivery_mode": "foreground",
-        "route": "pixel",
-        "refusal_code": None,
-    }
+    action = _action_event()
     process = _Process(
         _stream(json.dumps(_ready_event()), json.dumps(action), json.dumps(_result_event())),
         _stream(""),
@@ -798,16 +789,7 @@ async def test_run_task_uses_only_python_runner_and_sdk_driver_discovery(tmp_pat
 
 
 async def test_run_task_links_the_run_to_the_platform_chat_page(tmp_path):
-    action = {
-        "index": 0,
-        "tool": "screenshot",
-        "status": "executed",
-        "raw_status": "confirmed",
-        "delivery_mode": "foreground",
-        "route": "pixel",
-        "refusal_code": None,
-        "chat_id": "chat-1",
-    }
+    action = _action_event(tool="screenshot", chat_id="chat-1")
     supervised = terminal_result("limit", "deadline", actions=[action])
     with _patched_run_task_supervise(tmp_path, result=supervised):
         result = await run_task(**_run_task_kwargs(tmp_path, platform_url="https://platform.dev.yutori.com"))
@@ -1905,20 +1887,14 @@ def test_format_result_handles_python_runtime_action_fields():
         {
             "outcome": "completed",
             "actions": [
-                {
-                    "index": 0,
-                    "tool": "bash",
-                    "status": "executed",
-                    "raw_status": "confirmed",
-                    "delivery_mode": "foreground",
-                    "route": "pixel",
-                    "refusal_code": None,
-                    "elapsed_ms": 10,
-                    "duration_ms": 5,
-                    "command": "echo safe",
-                    "run_in_background": True,
-                    "background_task_id": "bash-1",
-                }
+                _action_event(
+                    tool="bash",
+                    elapsed_ms=10,
+                    duration_ms=5,
+                    command="echo safe",
+                    run_in_background=True,
+                    background_task_id="bash-1",
+                )
             ],
         }
     )
@@ -2475,18 +2451,7 @@ def test_format_result_renders_background_fields():
             "background_refusals": 2,
             "window_target": {"pid": 42, "window_id": 7, "app_name": "Notes"},
             "actions": [
-                {
-                    "index": 0,
-                    "tool": "left_click",
-                    "status": "executed",
-                    "raw_status": "confirmed",
-                    "delivery_mode": "foreground",
-                    "route": "accessibility",
-                    "refusal_code": None,
-                    "effect": "confirmed",
-                    "escalated": True,
-                    "duration_ms": 5,
-                }
+                _action_event(route="accessibility", effect="confirmed", escalated=True, duration_ms=5)
             ],
         }
     )


### PR DESCRIPTION
## What
`_action_event()` was extracted in #264 as the shared fixture builder for this file's repeated runner-action-event dict shape (`type`/`index`/`tool`/`status`/`raw_status`/`delivery_mode`/`route`/`refusal_code`), but that PR converted only 3 of its call sites. This PR finishes the consolidation for 4 more:

- `test_supervisor_does_not_let_a_blocked_progress_callback_stall_protocol_drain` hand-built the exact default shape byte-for-byte, with zero differences.
- `test_run_task_links_the_run_to_the_platform_chat_page`, `test_format_result_handles_python_runtime_action_fields`, and `test_format_result_renders_background_fields` each varied only a few fields (`tool`/`route`/`effect`/etc.) from the same default — the identical override pattern `test_event_shape_checks_delivery_modes_and_accepts_the_new_action_fields` already uses for this exact helper.

## Why it's safe
- Test-only change, one file, +11/-46.
- None of these tests assert on the literal dict's exact key set — only on `format_result`/protocol-shape-error output derived from specific named fields — so the single extra key (`type`) the shared default happens to carry is inert everywhere it's added.
- Each converted call site is a place the event shape could silently drift from what `_action_event()` encodes and what `supervisor._event_shape_error()` validates on the wire; consolidating removes that risk.
- No production code touched, no MCP tool schema/behavior change.

## Verification
- `uv run pytest -q` → 445 passed, 1 skipped (matches the documented baseline exactly).
- `uv run ruff check .` → clean.
- (`ruff format --check` flags the same 13 files before and after this change — pre-existing drift unrelated to this diff; not enforced in CI, which only runs `pytest -q`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TuJ4mUjLAbHvHwwdEeo1Ro

---
_Generated by [Claude Code](https://claude.ai/code/session_01TuJ4mUjLAbHvHwwdEeo1Ro)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes in one file with no production or API impact.
> 
> **Overview**
> **Test-only refactor** in `tests/test_computer_use.py` that replaces four hand-built runner action-event dicts with the shared `_action_event(**overrides)` helper (follow-up to #264).
> 
> Supervisor stall test now uses the default `_action_event()` instead of duplicating the full wire shape. `test_run_task_links_the_run_to_the_platform_chat_page`, `test_format_result_handles_python_runtime_action_fields`, and `test_format_result_renders_background_fields` pass only the fields they need (`tool`, `chat_id`, bash/background metadata, etc.) via overrides.
> 
> **Net −35 lines**; behavior unchanged—assertions still target outcomes, URLs, and formatted text, not raw dict equality. Keeps test fixtures aligned with the canonical action event shape the supervisor validates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3362999676347cd290355b552d1a0084a2bd51a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->