### PR TITLE
refactor(server): split _invoke's two error-handling contracts

### DIFF
--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -152,6 +152,33 @@ def _format_api_error(e: YutoriAPIError) -> str:
     return f"API Error ({e.status_code}): {e.message}"
 
 
+async def _invoke_computer_use(args: dict[str, Any]) -> str:
+    """Invoke the run_computer_use_task handler and return the formatted result text.
+
+    This tool follows a different error-handling contract than the rest of
+    _invoke: it always returns a terminal result dict (a failure() result
+    stands in for an unclassified error) rather than converting failures into
+    a raised RuntimeError, so it gets its own function instead of sharing
+    _invoke's outer try/except.
+    """
+    from .computer_use.constants import DELIVERY_MODES
+    from .computer_use.result import failure, format_result
+
+    handler = _TOOL_HANDLERS["run_computer_use_task"]
+    try:
+        result, _ = await handler(None, args)  # type: ignore[arg-type]
+    except ValidationError:
+        raise
+    # MCP callers need the same actionable result shape even when a
+    # platform integration raises an error we cannot classify here.
+    except Exception as error:  # noqa: BLE001
+        logger.error("Computer-use task failed before the runner returned a result")
+        requested_mode = args.get("mode")
+        delivery_mode = str(requested_mode) if requested_mode in DELIVERY_MODES else COMPUTER_USE_DEFAULT_MODE
+        result = failure(str(error), delivery_mode=delivery_mode)
+    return format_result(result)
+
+
 async def _invoke(tool_name: str, args: dict[str, Any]) -> str:
     """Invoke a tool handler and return the formatted response text.
 
@@ -159,28 +186,10 @@ async def _invoke(tool_name: str, args: dict[str, Any]) -> str:
     framework marks the result isError=True; ValidationError re-raised as-is;
     unexpected exceptions logged and re-raised.
     """
+    if tool_name == "run_computer_use_task":
+        return await _invoke_computer_use(args)
     handler = _TOOL_HANDLERS[tool_name]
     try:
-        if tool_name == "run_computer_use_task":
-            from .computer_use.constants import DELIVERY_MODES
-            from .computer_use.result import failure, format_result
-
-            try:
-                result, _ = await handler(None, args)  # type: ignore[arg-type]
-            except ValidationError:
-                raise
-            # MCP callers need the same actionable result shape even when a
-            # platform integration raises an error we cannot classify here.
-            except Exception as error:  # noqa: BLE001
-                logger.error(
-                    "Computer-use task failed before the runner returned a result"
-                )
-                requested_mode = args.get("mode")
-                delivery_mode = (
-                    str(requested_mode) if requested_mode in DELIVERY_MODES else COMPUTER_USE_DEFAULT_MODE
-                )
-                result = failure(str(error), delivery_mode=delivery_mode)
-            return format_result(result)
         client = get_adapter()
         result, context = await handler(client, args)
         return format_response(tool_name, result, **context)


### PR DESCRIPTION
## What

`_invoke()` in `src/yutori_mcp/server.py` special-cased `run_computer_use_task` inline, mixing two unrelated error-handling contracts in one function:

- The generic path: convert `YutoriAPIError` → `RuntimeError`, re-raise `ValidationError`, log-and-re-raise everything else.
- The `run_computer_use_task` path: its own inner `try/except` already converts every non-`ValidationError` failure into a `failure()` result dict and returns — so the outer `except YutoriAPIError`/`except Exception` clauses were dead code for that branch (only a re-raised `ValidationError` could ever reach them, and it was just re-raised again).

This PR extracts the `run_computer_use_task` branch into its own `_invoke_computer_use()` function, so each contract lives in its own function instead of one function silently carrying both.

## Why this is safe

- No behavior change: the extracted function keeps the exact same inner `try/except` logic, same handler call, same `failure()`/`format_result()` calls. `_invoke()`'s remaining code path for every other tool is untouched.
- Single file, ~20-line diff (mostly code motion).
- No call sites change — `_invoke("run_computer_use_task", locals())` still works identically.
- Full test suite passes locally (445 passed, 1 skipped), including `tests/test_computer_use.py` (175 passed, 1 skipped), which exercises `_invoke`'s computer-use error handling directly.

This is a structural cleanup surfaced by an automated review pass looking for safe, scoped refactors (not the trivial-cleanup category already handled by a separate bot).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELGR8HoGxvNYtnFaWd7LSy

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELGR8HoGxvNYtnFaWd7LSy)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Structural refactor in one file with preserved control flow; no call-site or API changes.
> 
> **Overview**
> **`_invoke()` no longer embeds a special-case branch for `run_computer_use_task`.** That logic moves into a dedicated **`_invoke_computer_use()`**, which keeps the computer-use contract: re-raise **`ValidationError`**, turn other pre-result failures into a **`failure()`** dict (with delivery mode from args or default), and return **`format_result()`** text instead of raising through the generic **`YutoriAPIError` → RuntimeError** path.
> 
> **`_invoke()`** now only early-returns to **`_invoke_computer_use(args)`** for that tool name; all other tools still use the adapter client, **`format_response`**, and the existing outer exception handling unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d52f66b637bd2ed5803f81f02358157e3686b62c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->