### PR TITLE
test(formatters): extract shared _scout_list_response() builder

### DIFF
--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -167,22 +167,31 @@ class TestFormatUsage:
         assert "Active Scouts: 3" in result
 
 
+def _scout_list_response(scouts=None, total=0, summary=None, **overrides):
+    """Build a list_scouts response payload for tests, following the _ready_event/_action_event convention."""
+    if summary is None:
+        summary = {"active": 0, "paused": 0, "done": 0}
+    response = {
+        "scouts": scouts if scouts is not None else [],
+        "total": total,
+        "summary": summary,
+    }
+    response.update(overrides)
+    return response
+
+
 class TestFormatListScouts:
     def test_empty_list(self):
         """Empty scouts list shows appropriate message."""
-        response = {
-            "scouts": [],
-            "total": 0,
-            "summary": {"active": 0, "paused": 0, "done": 0},
-        }
+        response = _scout_list_response()
         result = format_list_scouts(response)
         assert "Found 0 scouts" in result
         assert "No scouts to display" in result
 
     def test_with_scouts(self):
         """Scouts are listed with key details."""
-        response = {
-            "scouts": [
+        response = _scout_list_response(
+            scouts=[
                 {
                     "id": "abc-123",
                     "display_name": "Test Scout",
@@ -192,10 +201,10 @@ class TestFormatListScouts:
                     "next_output_timestamp": "2026-01-21T05:00:00Z",
                 }
             ],
-            "total": 1,
-            "summary": {"active": 1, "paused": 0, "done": 0},
-            "has_more": False,
-        }
+            total=1,
+            summary={"active": 1, "paused": 0, "done": 0},
+            has_more=False,
+        )
         result = format_list_scouts(response)
         assert "Found 1 scouts" in result
         assert "Test Scout" in result
@@ -204,11 +213,11 @@ class TestFormatListScouts:
 
     def test_summary_breakdown_line_exact(self):
         """Pin the exact 'Found N scouts: a active, b paused, c done.' summary line."""
-        response = {
-            "scouts": [{"id": "abc", "query": "test", "status": "active"}],
-            "total": 6,
-            "summary": {"active": 3, "paused": 2, "done": 1},
-        }
+        response = _scout_list_response(
+            scouts=[{"id": "abc", "query": "test", "status": "active"}],
+            total=6,
+            summary={"active": 3, "paused": 2, "done": 1},
+        )
         result = format_list_scouts(response)
         assert "Found 6 scouts: 3 active, 2 paused, 1 done." in result
 
@@ -223,31 +232,31 @@ class TestFormatListScouts:
 
     def test_has_more_hint(self):
         """When has_more is true, shows hint to increase limit."""
-        response = {
-            "scouts": [{"id": "abc", "query": "test", "status": "active"}],
-            "total": 50,
-            "summary": {"active": 50, "paused": 0, "done": 0},
-            "has_more": True,
-        }
+        response = _scout_list_response(
+            scouts=[{"id": "abc", "query": "test", "status": "active"}],
+            total=50,
+            summary={"active": 50, "paused": 0, "done": 0},
+            has_more=True,
+        )
         result = format_list_scouts(response)
         assert "limit=50" in result
 
     def test_cursor_hint_when_next_cursor_present(self):
         """has_more with a next_cursor surfaces a cursor-pagination hint."""
-        response = {
-            "scouts": [{"id": "abc", "query": "test", "status": "active"}],
-            "total": 50,
-            "summary": {"active": 50, "paused": 0, "done": 0},
-            "has_more": True,
-            "next_cursor": "scout-cur-2",
-        }
+        response = _scout_list_response(
+            scouts=[{"id": "abc", "query": "test", "status": "active"}],
+            total=50,
+            summary={"active": 50, "paused": 0, "done": 0},
+            has_more=True,
+            next_cursor="scout-cur-2",
+        )
         result = format_list_scouts(response)
         assert 'list_scouts(cursor="scout-cur-2")' in result
 
     def test_shows_rejection_reason(self):
         """Scout list includes rejection reason when present."""
-        response = {
-            "scouts": [
+        response = _scout_list_response(
+            scouts=[
                 {
                     "id": "abc-123",
                     "query": "monitor something",
@@ -255,9 +264,9 @@ class TestFormatListScouts:
                     "rejection_reason": "invalid_query",
                 }
             ],
-            "total": 1,
-            "summary": {"active": 0, "paused": 1, "done": 0},
-        }
+            total=1,
+            summary={"active": 0, "paused": 1, "done": 0},
+        )
         result = format_list_scouts(response)
         assert "Rejection reason: invalid_query" in result
 
@@ -620,11 +629,7 @@ class TestFormatResponse:
     def test_routes_to_correct_formatter(self):
         """format_response routes to the right formatter."""
         # Test list_scouts routing
-        response = {
-            "scouts": [],
-            "total": 0,
-            "summary": {"active": 0, "paused": 0, "done": 0},
-        }
+        response = _scout_list_response()
         result = format_response("list_scouts", response)
         assert "Found 0 scouts" in result
 
@@ -750,11 +755,11 @@ class TestFormatterNullSafety:
     """Regression tests for present-but-null fields in API responses."""
 
     def test_list_scouts_with_explicit_null_query(self):
-        response = {
-            "scouts": [{"id": "abc", "query": None, "status": "active"}],
-            "total": 1,
-            "summary": {"active": 1, "paused": 0, "done": 0},
-        }
+        response = _scout_list_response(
+            scouts=[{"id": "abc", "query": None, "status": "active"}],
+            total=1,
+            summary={"active": 1, "paused": 0, "done": 0},
+        )
         result = format_list_scouts(response)
         assert "Untitled" in result
 
@@ -769,8 +774,8 @@ class TestTimestampFormatting:
 
     def test_list_scouts_with_unix_ms_next_run(self):
         assert _format_date(1769997854699) == "2026-02-02"
-        response = {
-            "scouts": [
+        response = _scout_list_response(
+            scouts=[
                 {
                     "id": "abc",
                     "query": "q",
@@ -778,9 +783,9 @@ class TestTimestampFormatting:
                     "next_output_timestamp": 1769997854699,
                 }
             ],
-            "total": 1,
-            "summary": {"active": 1, "paused": 0, "done": 0},
-        }
+            total=1,
+            summary={"active": 1, "paused": 0, "done": 0},
+        )
         result = format_list_scouts(response)
         assert "Next: 2026-02-02" in result
 


### PR DESCRIPTION
## Summary
- Nine test methods across `TestFormatListScouts`, `TestFormatResponse`, `TestFormatterNullSafety`, and `TestTimestampFormatting` in `tests/test_formatters.py` each hand-built the same `list_scouts` response shape (`scouts`/`total`/`summary`, plus per-test overrides like `has_more`/`next_cursor`).
- Extracted `_scout_list_response(scouts=None, total=0, summary=None, **overrides)`, following the same `**overrides` convention as the existing `_ready_event`/`_action_event` test builders in `test_computer_use.py`, and updated all nine call sites.
- `test_summary_breakdown_shown_even_when_summary_missing` deliberately omits the `"summary"` key to test `format_list_scouts`'s fallback behavior, so it intentionally keeps its inline dict rather than using the helper (which always includes a `summary` key).

## Why it's safe
- Test-only change, zero production code touched.
- Each call site's constructed dict is unchanged byte-for-byte; only the construction mechanism changed.
- Scoped to a single file.

## Test plan
- [x] `uv run pytest tests/test_formatters.py -q` — 71 passed
- [x] `uv run ruff check tests/test_formatters.py` — clean
- [x] `uv run ruff format --check tests/test_formatters.py` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSSiBRB2ApxZFcuBwL6rrT

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSSiBRB2ApxZFcuBwL6rrT)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor in one file; no production code or runtime behavior changes.
> 
> **Overview**
> Adds a **`_scout_list_response()`** test helper in `tests/test_formatters.py` that builds the standard `list_scouts` payload (`scouts`, `total`, `summary`, plus optional `**overrides` like `has_more` / `next_cursor`), mirroring the `**overrides` pattern used by `_ready_event` / `_action_event` in `test_computer_use.py`.
> 
> **Nine** formatter tests that previously inlined the same dict shape now call the helper; assertions and effective payloads stay the same. **`test_summary_breakdown_shown_even_when_summary_missing`** still uses a hand-built dict **without** a `summary` key so it can exercise the missing-summary fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 020ab8ab9f77538bce686a322a7f16ba798437ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->