### PR TITLE
test(computer-use): extract _PLAIN_TERMINAL for the repeated plain-Terminal fixture

### DIFF
--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -2638,11 +2638,15 @@ def test_supports_color_honors_the_environment_and_the_tty(monkeypatch):
     assert supports_color(SimpleNamespace(isatty=lambda: True)) is False
 
 
+# The Terminal every rendering test below wants: no ANSI codes and no non-ASCII glyphs, so
+# assertions can pin exact byte-for-byte output instead of the color/glyph-detecting default.
+_PLAIN_TERMINAL = Terminal(color=False, glyphs=False)
+
+
 def test_supports_glyphs_falls_back_for_an_ascii_stream():
     assert supports_glyphs(SimpleNamespace(encoding="utf-8")) is True
     assert supports_glyphs(SimpleNamespace(encoding="ascii")) is False
-    ascii_only = Terminal(color=False, glyphs=False)
-    assert ascii_only.glyph("check").isascii() and ascii_only.rule("X").isascii()
+    assert _PLAIN_TERMINAL.glyph("check").isascii() and _PLAIN_TERMINAL.rule("X").isascii()
 
 
 def test_terminal_paints_only_when_color_is_on():
@@ -2651,7 +2655,6 @@ def test_terminal_paints_only_when_color_is_on():
 
 
 def test_format_terminal_action_shows_the_batch_members_and_the_shell_command():
-    plain = Terminal(color=False, glyphs=False)
     lines = format_terminal_action(
         {
             "index": 4,
@@ -2661,13 +2664,13 @@ def test_format_terminal_action_shows_the_batch_members_and_the_shell_command():
             "elapsed_ms": 14691,
             "details": ["left_click (1,2)", 'type "hi"'],
         },
-        plain,
+        _PLAIN_TERMINAL,
     )
     assert lines[0] == "v #4 computer_batch  1.6s | at 14.7s"
     assert [line.strip() for line in lines[1:]] == ["> left_click (1,2)", '> type "hi"']
     refused = format_terminal_action(
         {"index": 0, "tool": "bash", "status": "refused", "refusal_code": "driver_refused", "command": "ls"},
-        plain,
+        _PLAIN_TERMINAL,
     )
     assert refused[0] == "x #0 bash refused (driver_refused)"
     assert refused[1].strip() == "$ ls"
@@ -2683,7 +2686,7 @@ def test_format_terminal_result_leads_with_a_labeled_final_output_block():
             "steps": 35,
             "run_url": "https://platform.yutori.com/navigator/chats/abc",
         },
-        Terminal(color=False, glyphs=False),
+        _PLAIN_TERMINAL,
     )
     lines = [line for line in text.split("\n") if line.strip()]
     assert FINAL_OUTPUT_HEADING in lines[0]
@@ -2698,9 +2701,8 @@ def test_format_terminal_result_omits_the_action_list_unless_asked():
         "delivery_mode": "foreground",
         "actions": [{"index": 0, "tool": "bash", "status": "executed", "command": "ls"}],
     }
-    plain = Terminal(color=False, glyphs=False)
-    assert "bash" not in format_terminal_result(result, plain)
-    assert "bash" in format_terminal_result(result, plain, include_actions=True)
+    assert "bash" not in format_terminal_result(result, _PLAIN_TERMINAL)
+    assert "bash" in format_terminal_result(result, _PLAIN_TERMINAL, include_actions=True)
 
 
 def test_format_terminal_result_reports_the_background_surfaces():
@@ -2716,7 +2718,7 @@ def test_format_terminal_result_reports_the_background_surfaces():
             "fallback_skips": 2,
             "preview_frames": 7,
         },
-        Terminal(color=False, glyphs=False),
+        _PLAIN_TERMINAL,
     )
     assert "! limit" in text
     assert "window    Notes (pid 42, window 7)" in text
@@ -2730,7 +2732,7 @@ def test_cli_run_header_states_the_task_target_and_limits():
     from yutori_mcp.computer_use import cli
 
     params = ComputerUseTaskInput(task="list the team", app="Safari", start_url="https://yutori.com", minutes=5)
-    text = cli.format_run_header(params, Terminal(color=False, glyphs=False))
+    text = cli.format_run_header(params, _PLAIN_TERMINAL)
     assert "task      list the team" in text
     assert "target    Safari  https://yutori.com" in text
     assert "limits    foreground  |  5 min  |  60 model turns" in text


### PR DESCRIPTION
## What

Six tests in `tests/test_computer_use.py`'s colorized-CLI rendering section (`test_supports_glyphs_falls_back_for_an_ascii_stream`, `test_format_terminal_action_shows_the_batch_members_and_the_shell_command`, `test_format_terminal_result_leads_with_a_labeled_final_output_block`, `test_format_terminal_result_omits_the_action_list_unless_asked`, `test_format_terminal_result_reports_the_background_surfaces`, `test_cli_run_header_states_the_task_target_and_limits`) each independently constructed the identical `Terminal(color=False, glyphs=False)` — the "no ANSI codes, no non-ASCII glyphs" instance every byte-exact rendering assertion in this section needs so it can pin exact output instead of going through the color/glyph-detecting `Terminal.detect()` default.

Extracted a module-level `_PLAIN_TERMINAL` constant, following the same duplicate-fixture-extraction convention already established in this file for `_ready_event()`/`_result_event()`/`_action_event()`. All 6 call sites now share it instead of re-constructing their own copy.

## Why it's safe

- Test-only change, single file, no production code touched.
- No coverage change: the same `Terminal` configuration is constructed and passed to the same functions at every call site — just once instead of six times.
- `uv run pytest -q` → 445 passed / 1 skipped (unchanged from baseline).
- `uv run ruff check .` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0128gofQaPgAfPffCzxY3xLZ

---
_Generated by [Claude Code](https://claude.ai/code/session_0128gofQaPgAfPffCzxY3xLZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor in one file; no production code or assertion logic changes.
> 
> **Overview**
> Introduces a module-level **`_PLAIN_TERMINAL`** (`Terminal(color=False, glyphs=False)`) in `tests/test_computer_use.py`, with a short comment explaining it pins byte-exact CLI rendering assertions without color or Unicode glyphs.
> 
> Six terminal-formatting tests in that section now pass **`_PLAIN_TERMINAL`** instead of constructing the same instance locally (including the inline `ascii_only` name in the glyphs fallback test). Behavior and coverage are unchanged—only duplicate setup is centralized, matching existing helpers like `_ready_event()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a028f5affb91c7157ba09bb3920db6e77d65c605. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->