### PR TITLE
test: share _scout_list_response() between test_formatters.py and test_server.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,23 @@
 
 Import paths are configured in pyproject.toml via
 ``tool.pytest.ini_options.pythonpath = ["src"]``, so the suite runs from a
-source checkout without installing the package. This file is kept as a
-placeholder for future shared fixtures.
+source checkout without installing the package.
 """
+
+
+def _scout_list_response(scouts=None, total=0, summary=None, **overrides):
+    """Build a ``list_scouts``-shaped response payload for tests.
+
+    Shared by test_formatters.py (formatting a real payload) and test_server.py
+    (mocking the adapter's return value), which had each independently written
+    out the same ``{"scouts": [...], "total": ..., "summary": {...}}`` shape.
+    """
+    if summary is None:
+        summary = {"active": 0, "paused": 0, "done": 0}
+    response = {
+        "scouts": scouts if scouts is not None else [],
+        "total": total,
+        "summary": summary,
+    }
+    response.update(overrides)
+    return response

--- a/tests/test_formatters.py
+++ b/tests/test_formatters.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from tests.conftest import _scout_list_response
 from yutori_mcp.formatters import (
     _EXTERNAL_CONTENT_END,
     _EXTERNAL_CONTENT_START,
@@ -165,19 +166,6 @@ class TestFormatUsage:
         """format_response correctly routes list_api_usage."""
         result = format_response("list_api_usage", self.USAGE_RESPONSE)
         assert "Active Scouts: 3" in result
-
-
-def _scout_list_response(scouts=None, total=0, summary=None, **overrides):
-    """Build a list_scouts response payload for tests, following the _ready_event/_action_event convention."""
-    if summary is None:
-        summary = {"active": 0, "paused": 0, "done": 0}
-    response = {
-        "scouts": scouts if scouts is not None else [],
-        "total": total,
-        "summary": summary,
-    }
-    response.update(overrides)
-    return response
 
 
 class TestFormatListScouts:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from mcp.types import CallToolRequest, CallToolRequestParams
 
+from tests.conftest import _scout_list_response
 from yutori.auth.types import AuthStatus, LoginResult
 from yutori_mcp import __version__
 from yutori_mcp.adapter import YutoriAPIError
@@ -392,11 +393,7 @@ class TestCallToolErrorContract:
 
     async def test_success_returns_formatted_text_without_error_flag(self):
         with _patched_adapter() as client:
-            client.list_scouts.return_value = {
-                "scouts": [],
-                "total": 0,
-                "summary": {"active": 0, "paused": 0, "done": 0},
-            }
+            client.list_scouts.return_value = _scout_list_response()
             result = await _call_tool("list_scouts", {})
 
         assert result.root.isError is False
@@ -463,11 +460,7 @@ class TestCallToolErrorContract:
 
     async def test_known_arguments_still_accepted(self):
         with _patched_adapter() as client:
-            client.list_scouts.return_value = {
-                "scouts": [],
-                "total": 0,
-                "summary": {"active": 0, "paused": 0, "done": 0},
-            }
+            client.list_scouts.return_value = _scout_list_response()
             result = await _call_tool("list_scouts", {"limit": 5})
 
         assert result.root.isError is False


### PR DESCRIPTION
## What

`tests/test_formatters.py` already had a private `_scout_list_response(scouts=None, total=0, summary=None, **overrides)` builder for the `list_scouts` response shape (added in a prior refactor). `tests/test_server.py` independently hand-wrote the identical `{"scouts": [], "total": 0, "summary": {"active": 0, "paused": 0, "done": 0}}` literal in two tests (`test_success_returns_formatted_text_without_error_flag`, `test_known_arguments_still_accepted`) that mock the adapter's `list_scouts` return value for the same all-empty case.

Moved the builder into `tests/conftest.py` — previously just a placeholder docstring inviting future shared fixtures — and updated both test files to import it from there instead of test_formatters.py defining its own private copy. Both files now share one source of truth for this response shape instead of it being able to drift between a "real" formatter-facing payload and a mocked adapter response.

## Why it's safe

- Test-only change, 3 files, no production code touched.
- No coverage change: `_scout_list_response()` with no arguments returns the exact same dict the two `test_server.py` sites previously wrote by hand.
- `uv run pytest -q` → 445 passed / 1 skipped (unchanged from baseline).
- `uv run ruff check .` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAUJ6QNJjaj3hqXqWiCJXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01EAUJ6QNJjaj3hqXqWiCJXj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactor with no production code changes; default `_scout_list_response()` matches the literals it replaced.
> 
> **Overview**
> Centralizes the **`list_scouts`** test payload builder in **`tests/conftest.py`** so formatter and server tests use one shape for `scouts`, `total`, and `summary` (with optional `**overrides`).
> 
> **`test_formatters.py`** drops its local `_scout_list_response` and imports the shared helper. **`test_server.py`** replaces two hand-written empty-response dicts in `list_scouts` success mocks with `_scout_list_response()`. **`conftest.py`** is no longer documented as a fixtures placeholder—it now hosts this helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0db3165c229b51db8d543ee82b1fd30e333842a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->