### PR TITLE
refactor(computer_use): extract shared _elapsed_ms helper in runner.py

### DIFF
--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -364,6 +364,11 @@ def _background_task_id(outputs: list[dict[str, Any]] | None) -> str | None:
     return None
 
 
+def _elapsed_ms(start: float, *, clock: Callable[[], float] = time.monotonic) -> int:
+    """Milliseconds elapsed since `start`, floor-clamped at zero."""
+    return max(0, round((clock() - start) * 1000))
+
+
 class ActionReporter:
     """Emit one privacy-safe action event for each attempted top-level tool call."""
 
@@ -404,7 +409,7 @@ class ActionReporter:
     def _emit(self, item: dict[str, Any], raw_status: str, result: list[dict[str, Any]]) -> None:
         duration_ms = None
         if self._call_start is not None:
-            duration_ms = max(0, round((self._clock() - self._call_start) * 1000))
+            duration_ms = _elapsed_ms(self._call_start, clock=self._clock)
         self._call_start = None
         self._pending_item = None
         arguments = _arguments(item)
@@ -424,7 +429,7 @@ class ActionReporter:
                 "refusal_code": delivery.get("refusal_code") or ("driver_refused" if raw_status == "refused" else None),
                 "effect": delivery.get("effect"),
                 "escalated": bool(delivery.get("escalated")),
-                "elapsed_ms": max(0, round((self._clock() - self._run_start) * 1000)),
+                "elapsed_ms": _elapsed_ms(self._run_start, clock=self._clock),
                 "duration_ms": duration_ms,
                 "command": shell_command_preview(item),
                 "details": batch_action_previews(item),
@@ -940,7 +945,7 @@ async def run_request(
                 final_text = _redacted_error_text(error, api_key)
 
     reporter.flush_interrupted()
-    elapsed_ms = max(0, round((time.monotonic() - run_start) * 1000))
+    elapsed_ms = _elapsed_ms(run_start)
     emitter.emit(
         {
             **_result_event(outcome, final_text, mode),


### PR DESCRIPTION
## What

`ActionReporter._emit` and `run_request` in `src/yutori_mcp/computer_use/runner.py` each hand-rolled the same "milliseconds elapsed since a start time, floor-clamped at zero" formula:

```python
max(0, round((self._clock() - self._call_start) * 1000))
```

three separate times. Consolidated into one helper:

```python
def _elapsed_ms(start: float, *, clock: Callable[[], float] = time.monotonic) -> int:
    """Milliseconds elapsed since `start`, floor-clamped at zero."""
    return max(0, round((clock() - start) * 1000))
```

## Why it's safe

Pure arithmetic extraction — same clock, same rounding, same clamp at every call site. No behavior change.

- `ruff check` / `ruff format --check`: clean
- `pytest tests/test_computer_use.py`: 175 passed, 1 skipped (unchanged)
- Full suite: 445 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LX8bJDAC5eesH2du4M6tBj

---
_Generated by [Claude Code](https://claude.ai/code/session_01LX8bJDAC5eesH2du4M6tBj)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure arithmetic extraction with identical clock, rounding, and clamping; telemetry fields only.
> 
> **Overview**
> Consolidates duplicated **elapsed-time** math in the computer-use runner into a single `_elapsed_ms` helper that returns **floor-clamped milliseconds** since a start timestamp, using an injectable clock (default `time.monotonic`).
> 
> **ActionReporter** now uses the helper for per-call `duration_ms` and run-level `elapsed_ms` on action events; **`run_request`** uses it for `elapsed_ms` on the terminal result event. Behavior is unchanged—same rounding and zero floor at every site.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e683e5d4d9bf8938de0426200273f6825997b582. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->