### PR TITLE
refactor(computer-use): extract shared preflight remediation constants

### DIFF
--- a/src/yutori_mcp/computer_use/preflight.py
+++ b/src/yutori_mcp/computer_use/preflight.py
@@ -53,6 +53,14 @@ TOOL_SEARCH_DIRECTORIES = (
 _EDITABLE_SDK_OVERRIDE = "YUTORI_MCP_ALLOW_EDITABLE_SDK"
 _INSTALLER_GENERATED_FILES = {"INSTALLER", "RECORD", "REQUESTED", "direct_url.json"}
 _SDK_PROVENANCE_PATH = Path("yutori/navigator/macos/assets/provenance.json")
+# Shared remediation text for checks whose fix is "(re)install the pinned CuaDriver setup":
+# check_driver_app, check_driver_binary, check_driver_contract, check_overlay, and
+# check_capture's driver-not-found branch all point here, so the wording can't drift
+# across five call sites if it's ever revised.
+_SETUP_REMEDIATION = "Run: yutori-mcp computer-use setup"
+# Shared remediation text for checks whose fix is granting the driver's TCC permissions:
+# check_permissions and check_capture's driver-capture-failed branch both point here.
+_PERMISSIONS_GRANT_REMEDIATION = "Run: cua-driver permissions grant"
 
 
 def _login_remediation(environment: str) -> str:
@@ -260,7 +268,7 @@ def check_overlay() -> CheckResult:
         "reasoning overlay",
         ok,
         detail,
-        "Run: yutori-mcp computer-use setup",
+        _SETUP_REMEDIATION,
         blocking=False,
     )
 
@@ -270,7 +278,7 @@ def check_driver_app() -> CheckResult:
         "driver app",
         DRIVER_APP.is_dir(),
         str(DRIVER_APP),
-        "Run: yutori-mcp computer-use setup",
+        _SETUP_REMEDIATION,
     )
 
 
@@ -280,7 +288,7 @@ def check_driver_binary() -> CheckResult:
         "cua-driver binary",
         driver is not None,
         str(driver or "not found"),
-        "Run: yutori-mcp computer-use setup",
+        _SETUP_REMEDIATION,
     )
 
 
@@ -323,7 +331,7 @@ def check_driver_contract() -> CheckResult:
             "driver contract",
             False,
             "driver did not report a version",
-            "Run: yutori-mcp computer-use setup",
+            _SETUP_REMEDIATION,
         )
     return _result(
         "driver contract",
@@ -353,7 +361,7 @@ def check_permissions() -> CheckResult:
         "permissions",
         ok,
         "Accessibility and Screen Recording",
-        "Run: cua-driver permissions grant",
+        _PERMISSIONS_GRANT_REMEDIATION,
     )
 
 
@@ -414,7 +422,7 @@ def check_capture() -> CheckResult:
             "desktop capture",
             False,
             "cua-driver not found",
-            "Run: yutori-mcp computer-use setup",
+            _SETUP_REMEDIATION,
             blocking=False,
         )
     with tempfile.TemporaryDirectory(prefix="cua-capture-check-") as directory:
@@ -431,7 +439,7 @@ def check_capture() -> CheckResult:
                 "desktop capture",
                 False,
                 "driver capture failed",
-                "Run: cua-driver permissions grant",
+                _PERMISSIONS_GRANT_REMEDIATION,
                 blocking=False,
             )
         ok = target.is_file() and target.stat().st_size > 0


### PR DESCRIPTION
## What

`preflight.py`'s doctor checks repeat two literal remediation strings by hand:

- `"Run: yutori-mcp computer-use setup"` — copied across `check_overlay`, `check_driver_app`, `check_driver_binary`, `check_driver_contract`'s no-version branch, and `check_capture`'s driver-not-found branch (5 call sites).
- `"Run: cua-driver permissions grant"` — copied across `check_permissions` and `check_capture`'s driver-capture-failed branch (2 call sites).

This extracts each into a module-level constant (`_SETUP_REMEDIATION`, `_PERMISSIONS_GRANT_REMEDIATION`) and updates all 7 call sites to reference them.

## Why this is an improvement

Structurally these are the same "single source of truth" pattern the file already uses for other repeated remediation text (e.g. `_login_remediation()`, `_api_access_remediation()`), and that the wider repo has a long history of applying to repeated strings (`_GET_SCOUT_DETAIL_HINT`, `_login_remediation`, etc.). Centralizing the two constants means the wording can't silently drift out of sync across the 5 and 2 call sites respectively if it's ever revised again (the setup wording has changed before — see the doctor-facing docs commit that touched this exact phrase).

## Why it's safe — no behavior change

- Every call site passes the exact same string value as before; this is a pure literal → named-constant substitution, nothing else changed.
- No tool schema, tool surface, or public API is touched — this is internal to the macOS computer-use doctor/preflight checks.
- Confirmed no test hardcodes these exact strings (`grep` for both phrases across `tests/` found no matches to update).
- Full test suite: `uv run pytest -q` → **445 passed, 1 skipped** (same as on `main`).
- `uv run ruff check` → clean.
- Diff is a single file (`src/yutori_mcp/computer_use/preflight.py`), 15 insertions / 7 deletions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4X8gs69kSrP7HuoE9DBGU


---
_Generated by [Claude Code](https://claude.ai/code/session_01N4X8gs69kSrP7HuoE9DBGU)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal copy-only refactor in macOS preflight messaging; no API, check logic, or user-facing command text changes beyond deduplication.
> 
> **Overview**
> **Preflight doctor checks** now use two module-level constants for repeated failure hints instead of copying the same strings at seven call sites.
> 
> `_SETUP_REMEDIATION` (`Run: yutori-mcp computer-use setup`) replaces inline text in overlay, driver app/binary/contract (no-version path), and capture when `cua-driver` is missing. `_PERMISSIONS_GRANT_REMEDIATION` (`Run: cua-driver permissions grant`) is shared by the permissions check and capture when the driver probe fails. Comments document which checks use each constant. **String values are unchanged**—this is a single-source-of-truth refactor aligned with existing patterns like `_login_remediation()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5a11c38512c9533f1c3b55d082ff6eef0c80a5e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->