### PR TITLE
refactor(computer-use): share remaining_seconds() across supervisor/runner

### DIFF
--- a/src/yutori_mcp/computer_use/result.py
+++ b/src/yutori_mcp/computer_use/result.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import os
 import shutil
 import sys
+import time
 from typing import Any, TextIO
 
 from .constants import DELIVERY_MODE_BACKGROUND, DELIVERY_MODE_FOREGROUND
@@ -17,6 +19,24 @@ def redact(text: str, secret: str) -> str:
     protocol stdout lines) so the child's API key never survives past this one point.
     """
     return text.replace(secret, REDACTED)
+
+
+def remaining_seconds(deadline: float) -> float:
+    """Seconds left before ``deadline`` (a ``time.monotonic()`` value).
+
+    Raises ``asyncio.TimeoutError`` if none remain, rather than returning a
+    zero/negative value a caller could pass straight into ``asyncio.wait_for``.
+    Shared by the supervisor (guarding both its child-process read loop and the
+    final ``process.wait()`` after EOF) and the runner (guarding the
+    deadline-aware summary request it makes when a run hits its step limit),
+    so an expired absolute deadline is caught the same way on both sides of
+    the runner/supervisor protocol boundary instead of two independently
+    hand-rolled checks.
+    """
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        raise asyncio.TimeoutError
+    return remaining
 
 
 def _seconds(ms: Any) -> str:

--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -38,7 +38,7 @@ from .constants import (
     SDK_VERSION,
     TOOL_SET,
 )
-from .result import redact
+from .result import redact, remaining_seconds
 
 _FOREGROUND_OPENING = "You control the entire macOS screen. "
 _SHARED_CONTEXT = (
@@ -567,11 +567,12 @@ def _completion_text(response: Any) -> str | None:
 
 async def _await_summary_response(agent: Any, awaitable: Any, deadline: float) -> Any:
     """Await the wrap-up while honoring both the deadline and desktop Stop."""
-    remaining = deadline - time.monotonic()
-    if remaining <= 0:
+    try:
+        remaining = remaining_seconds(deadline)
+    except asyncio.TimeoutError:
         if inspect.iscoroutine(awaitable):
             awaitable.close()
-        raise asyncio.TimeoutError
+        raise
     cancellation = getattr(agent.computer, "cancellation", None)
     if cancellation is None:
         return await asyncio.wait_for(awaitable, remaining)
@@ -609,9 +610,7 @@ async def _summarize_limit_run(
     turns. Calling the shared completion surface directly means no tools are
     executed and the original agent, request chain, and timing record stay live.
     """
-    remaining = deadline - time.monotonic()
-    if remaining <= 0:
-        raise asyncio.TimeoutError
+    remaining_seconds(deadline)  # raises asyncio.TimeoutError once the deadline has passed
     api_kwargs = agent.completion_request([{"role": "user", "content": STOP_SUMMARY_PROMPT}])
     await api_counter.on_api_start(api_kwargs)
     model_started_at = time.monotonic()

--- a/src/yutori_mcp/computer_use/supervisor.py
+++ b/src/yutori_mcp/computer_use/supervisor.py
@@ -27,7 +27,9 @@ from .constants import (
 )
 from .lock import ComputerUseBusyError, DesktopLock
 from .preflight import child_search_path, find_cua_driver
-from .result import failure, redact, terminal_result
+from .result import failure, redact
+from .result import remaining_seconds as _remaining_seconds
+from .result import terminal_result
 
 logger = logging.getLogger(__name__)
 
@@ -203,20 +205,6 @@ async def _stop_process_group(process: asyncio.subprocess.Process) -> None:
         except ProcessLookupError:
             pass
         await process.wait()
-
-
-def _remaining_seconds(deadline: float) -> float:
-    """Seconds left before ``deadline``, or raise ``asyncio.TimeoutError`` if none remain.
-
-    ``_supervise`` checks this before both of its waits on the child process -- the
-    per-line read loop and the final ``process.wait()`` after EOF -- so an expired
-    absolute deadline is caught the same way in both places instead of one of them
-    risking a zero/negative timeout reaching ``asyncio.wait_for``.
-    """
-    remaining = deadline - time.monotonic()
-    if remaining <= 0:
-        raise asyncio.TimeoutError
-    return remaining
 
 
 async def _drain_stderr(stream: asyncio.StreamReader, secret: str) -> list[str]:


### PR DESCRIPTION
## What

The "seconds left before an absolute deadline, or raise `asyncio.TimeoutError`" check was hand-rolled three times:

1. `supervisor._remaining_seconds()` — guards the child-process read loop and the final `process.wait()`.
2. Inline in `runner._await_summary_response()` — guards the deadline-aware summary wrap-up wait.
3. Inline in `runner._summarize_limit_run()` — guards the summary request before it's issued.

All three were the exact same three-line `deadline - time.monotonic(); if <= 0: raise asyncio.TimeoutError` shape.

## Why this is safe

`computer_use/result.py` is already the module both `supervisor.py` and `runner.py` import shared protocol helpers from (`redact`, `terminal_result`, `failure`), so it's the natural home for one more. I moved the logic there as `remaining_seconds()` and pointed both runner call sites at it.

`supervisor.py` imports it aliased as `remaining_seconds as _remaining_seconds`, so:
- its existing call sites (`_remaining_seconds(deadline)`) are unchanged,
- and `tests/test_computer_use.py`'s direct `supervisor._remaining_seconds(...)` references still resolve to the same function object, unchanged.

No tool schema, tool name, or response shape is touched — this is purely internal control-flow deduplication inside the computer-use runner/supervisor pair. Behavior (the `TimeoutError`-on-expiry contract and its callers) is identical.

## Testing

- `uv run --extra dev pytest -q` — 445 passed, 1 skipped (unchanged from before the change).
- `uv run --extra dev ruff check` on the three touched files — clean.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LbhdZh7YggdY4XFd4XWwRs

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbhdZh7YggdY4XFd4XWwRs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure internal refactor with identical timeout semantics; no auth, protocol, or external API surface changes.
> 
> **Overview**
> Consolidates the repeated **deadline − monotonic clock → raise `asyncio.TimeoutError` if expired** logic into a shared **`remaining_seconds()`** in `result.py`, alongside existing runner/supervisor helpers like `redact`.
> 
> The **runner** now uses that helper for limit-run summary timing (`_summarize_limit_run`, `_await_summary_response`) instead of inline checks. The **supervisor** drops its local `_remaining_seconds` and imports the same function as `_remaining_seconds`, so existing `_supervise` call sites and tests that reference `supervisor._remaining_seconds` keep the same API and behavior.
> 
> No protocol, tool, or user-visible output changes—only internal deadline handling is deduplicated so zero/negative timeouts cannot reach `asyncio.wait_for` inconsistently across the runner/supervisor boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43cf514af5a9346a45d1e89ae80b14e7658004f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->