### PR TITLE
Send macOS screenshots as WebP

### DIFF
--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -13,6 +13,10 @@ MODEL = "n2"
 # constant so an SDK bump can never silently move the surface the model is
 # served -- see doctor's tool_set preflight, which sends this exact string.
 TOOL_SET = "computer_use_tools-20260830"
+# Request frames are always sent as WebP. Keep this explicit instead of relying on
+# N2ComputerAgent's default so an SDK upgrade cannot silently move high-resolution
+# macOS screenshots back to a larger wire encoding.
+OBSERVATION_FORMAT = "webp"
 # The two delivery modes this runtime implements. "foreground" drives the visible desktop
 # (the model sees the whole screen and the user keeps their hands off); "background" drives
 # one target app window through the SDK's window scope without taking the user's focus.

--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -32,6 +32,7 @@ from .constants import (
     DELIVERY_MODE_FOREGROUND,
     DELIVERY_MODES,
     DRIVER_VERSION,
+    OBSERVATION_FORMAT,
     PROTOCOL_VERSION,
     SDK_ARTIFACT_SHA256,
     SDK_PROVENANCE_SHA256,
@@ -716,6 +717,7 @@ def _agent_base_kwargs(
         "system_prompt": system_context(request["mode"], request["app"]),
         "presentation": computer.presentation,
         "screenshot_delay": 0,
+        "image_format": OBSERVATION_FORMAT,
         "execution_deadline": deadline,
         "supports_click_modifiers": True,
     }
@@ -1055,7 +1057,7 @@ def main() -> int:
                 "sdk_artifact_sha256": SDK_ARTIFACT_SHA256,
                 "sdk_provenance_sha256": SDK_PROVENANCE_SHA256,
                 "driver_version_pinned": DRIVER_VERSION,
-                "observation_format": "webp",
+                "observation_format": OBSERVATION_FORMAT,
                 "observation_format_fallback": True,
                 "observation_fallback_format": "jpeg",
                 # The request is not parsed yet; the result event carries the truthful value.

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -34,6 +34,7 @@ from yutori_mcp.computer_use.constants import (
     DELIVERY_MODES,
     DRIVER_VERSION,
     MCP_VERSION,
+    OBSERVATION_FORMAT,
     PROTOCOL_VERSION,
     SDK_ARTIFACT_SHA256,
     SDK_INSTALLATION_SHA256,
@@ -1677,6 +1678,7 @@ async def test_run_request_wires_sdk_runtime_and_reports_effective_state(monkeyp
     }
     assert agent.kwargs["tool_set"] == TOOL_SET
     assert agent.kwargs["presentation"] is computer.presentation
+    assert agent.kwargs["image_format"] == OBSERVATION_FORMAT == "webp"
     assert agent.kwargs["supports_click_modifiers"] is True
     assert "Shell commands run headlessly" in agent.kwargs["system_prompt"]
     assert "Do not use osascript" in agent.kwargs["system_prompt"]


### PR DESCRIPTION
## Summary

- Pin macOS N2 request images to WebP instead of relying on the SDK default.
- Reuse the shared format constant in runner readiness metadata.
- Add regression coverage for the explicit image format.

## Testing

- `uv run --extra dev python -m pytest -q` (445 passed, 1 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small configuration pin with no auth or data-path changes; behavior is explicitly WebP, which was already advertised in the ready handshake.
> 
> **Overview**
> **Pins macOS N2 screenshot/request frames to WebP** instead of inheriting `N2ComputerAgent`'s default `image_format`, so a future SDK bump cannot silently switch high-resolution captures to a heavier on-the-wire encoding.
> 
> Adds `OBSERVATION_FORMAT = "webp"` in `constants.py` (same pinning pattern as `TOOL_SET`), passes it into agent construction via `image_format`, and uses it in the runner `ready` event's `observation_format` field. A test asserts the agent is wired with that constant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a6ea9fd9df43d075cf25eeee207b95734dbca6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->