### PR TITLE
Release yutori-mcp 0.5.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.13"
+version = "0.5.14"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"
@@ -30,9 +30,8 @@ dependencies = [
     # breaks the install as soon as 2.x resolves.
     "mcp>=1.0.0,<2.0.0",
     "pydantic>=2.0.0",
-    # SDK 0.9.14 makes the native reasoning overlay compile across supported
-    # Swift/CoreFoundation combinations by disambiguating CGFloat arithmetic.
-    "yutori==0.9.14",
+    # SDK 0.9.15 keeps terminal commands legible in the native activity dialog.
+    "yutori==0.9.15",
 ]
 
 [project.optional-dependencies]

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -26,11 +26,11 @@ OBSERVATION_FORMAT = "webp"
 DELIVERY_MODE_FOREGROUND = "foreground"
 DELIVERY_MODE_BACKGROUND = "background"
 DELIVERY_MODES = (DELIVERY_MODE_FOREGROUND, DELIVERY_MODE_BACKGROUND)
-SDK_VERSION = "0.9.14"
+SDK_VERSION = "0.9.15"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.
-SDK_ARTIFACT_SHA256 = "81f2b7e124eaba0501e23142a9a83f145ddb69d9e46ace9955e12a794b02aca7"
-SDK_INSTALLATION_SHA256 = "629893d1286a8893db1538c216d6d077c1ff20515f9e5b4b0708e9a503cbe35f"
+SDK_ARTIFACT_SHA256 = "e4e4ea2fd0bf9715e60b08442a452f72c44a8ee63c0d3323f483e492a328d04f"
+SDK_INSTALLATION_SHA256 = "5ea4aca7de1f169b90bf3f9faa43deed8f20e5736cd21f8f923e16b1fdd11b79"
 SDK_PROVENANCE_SHA256 = "7cab595d2f00e1a9ab5cd121204fbd6dd4c24163ead3eb76f76eef7fba495fc4"
 
 # The cua-driver release that implements this tool contract, and the checksum

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -850,9 +850,9 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 
 def test_runtime_constants_select_latest_python_surface():
     assert TOOL_SET == "computer_use_tools-20260830"
-    assert SDK_VERSION == "0.9.14"
+    assert SDK_VERSION == "0.9.15"
     assert all(len(digest) == 64 for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256))
-    assert '"yutori==0.9.14"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
+    assert '"yutori==0.9.15"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
 
 
 def test_installed_sdk_matches_the_published_artifact():

--- a/uv.lock
+++ b/uv.lock
@@ -1370,7 +1370,7 @@ wheels = [
 
 [[package]]
 name = "yutori"
-version = "0.9.14"
+version = "0.9.15"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1379,14 +1379,14 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/1f/84808f2bc9b5d7be18f5dc8e9cf460e701be646e65fbaf5a5d094be8db87/yutori-0.9.14.tar.gz", hash = "sha256:94563eed7c85b8e34c72fc1bcf58966a8d99563aa073f62473efc7945f5909eb", size = 458539, upload-time = "2026-09-04T19:04:12.815Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/72/476abf8d5308b5b15f3abbbed28533ca3bd8a81591e90ed05fac52cd5ba0/yutori-0.9.15.tar.gz", hash = "sha256:e93c8866d62eabafdd57ca86c616012746f9dcd7bae15c22e9e75add5ff6a8d0", size = 459835, upload-time = "2026-09-08T17:15:41.501Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/7a/5227a12eb3c2b390744d29abb2e6b34392e3b3a2341d04891907b25bf730/yutori-0.9.14-py3-none-any.whl", hash = "sha256:81f2b7e124eaba0501e23142a9a83f145ddb69d9e46ace9955e12a794b02aca7", size = 322204, upload-time = "2026-09-04T19:04:10.222Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/7d/10ffc0fb9087660cc3762f2f6cb6ca156ee881e16e7cf01a9ae045da6fb0/yutori-0.9.15-py3-none-any.whl", hash = "sha256:e4e4ea2fd0bf9715e60b08442a452f72c44a8ee63c0d3323f483e492a328d04f", size = 323135, upload-time = "2026-09-08T17:15:39.797Z" },
 ]
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.13"
+version = "0.5.14"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -1406,6 +1406,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "yutori", specifier = "==0.9.14" },
+    { name = "yutori", specifier = "==0.9.15" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
Bump yutori-mcp to 0.5.14 and pin the newly published yutori SDK 0.9.15 so macOS activity-dialog terminal commands remain legible. Refresh the SDK wheel, installed-file, and provenance digests together with the lockfile and runtime regression assertions.

Tested with the published-artifact check and full suite (446 passed), plus package build and twine validation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and checksum pin bump only; no application logic changes beyond version gates and tests.
> 
> **Overview**
> **Releases `yutori-mcp` 0.5.14** and pins the **`yutori` SDK to 0.9.15** (from 0.9.14), motivated by clearer terminal command display in the native macOS activity dialog.
> 
> The bump is wired through **`pyproject.toml`**, **`uv.lock`**, and **`SDK_VERSION`** plus refreshed **`SDK_ARTIFACT_SHA256`** / **`SDK_INSTALLATION_SHA256`** in `constants.py` so doctor/preflight still reject mismatched installs. **`test_runtime_constants_select_latest_python_surface`** expectations move to **0.9.15** to stay aligned with the dependency pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c396154e30677c3f7c218d4554fa76a911dad6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->