### PR TITLE
Release yutori-mcp 0.5.15

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.14"
+version = "0.5.15"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1386,7 +1386,7 @@ wheels = [
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.14"
+version = "0.5.15"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
Bump yutori-mcp from 0.5.14 to 0.5.15 in the package metadata and lockfile. This release publishes the codec-reporting correction and CLI runtime-version display merged in #281.

Tested with the full suite (446 passed, 1 skipped), lock validation, package build, and twine checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version bump with no runtime code changes in the diff.
> 
> **Overview**
> **Release cut** that bumps `yutori-mcp` from **0.5.14** to **0.5.15** in `pyproject.toml` and the editable `yutori-mcp` entry in `uv.lock`.
> 
> There are no source changes in this PR; it tags the package for publish after **#281** (codec reporting fixes and CLI runtime version display).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 393993890d601370403333e3eb806cee4e691f4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->