### PR TITLE
chore(release): 0.5.16

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.15"
+version = "0.5.16"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"
@@ -30,8 +30,10 @@ dependencies = [
     # breaks the install as soon as 2.x resolves.
     "mcp>=1.0.0,<2.0.0",
     "pydantic>=2.0.0",
-    # SDK 0.9.15 keeps terminal commands legible in the native activity dialog.
-    "yutori==0.9.15",
+    # SDK 0.9.16 keeps the activity dialog's run-command panels at their text's
+    # height instead of letting the transcript squeeze them flat, and stands the
+    # desktop shell rail down while that dialog is open.
+    "yutori==0.9.16",
 ]
 
 [project.optional-dependencies]

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -26,11 +26,11 @@ OBSERVATION_FORMAT = "webp"
 DELIVERY_MODE_FOREGROUND = "foreground"
 DELIVERY_MODE_BACKGROUND = "background"
 DELIVERY_MODES = (DELIVERY_MODE_FOREGROUND, DELIVERY_MODE_BACKGROUND)
-SDK_VERSION = "0.9.15"
+SDK_VERSION = "0.9.16"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.
-SDK_ARTIFACT_SHA256 = "e4e4ea2fd0bf9715e60b08442a452f72c44a8ee63c0d3323f483e492a328d04f"
-SDK_INSTALLATION_SHA256 = "5ea4aca7de1f169b90bf3f9faa43deed8f20e5736cd21f8f923e16b1fdd11b79"
+SDK_ARTIFACT_SHA256 = "b3ee9349476b9536088721af1b899fcf9f29b18465bf73ebeed774796d705793"
+SDK_INSTALLATION_SHA256 = "ed219d19147568d99b68db9eb58ab0dc504a9388b9ce5ffe096e8c8acb6fa146"
 SDK_PROVENANCE_SHA256 = "7cab595d2f00e1a9ab5cd121204fbd6dd4c24163ead3eb76f76eef7fba495fc4"
 
 # The cua-driver release that implements this tool contract, and the checksum

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -850,9 +850,9 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 
 def test_runtime_constants_select_latest_python_surface():
     assert TOOL_SET == "computer_use_tools-20260830"
-    assert SDK_VERSION == "0.9.15"
+    assert SDK_VERSION == "0.9.16"
     assert all(len(digest) == 64 for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256))
-    assert '"yutori==0.9.15"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
+    assert '"yutori==0.9.16"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
 
 
 def test_installed_sdk_matches_the_published_artifact():

--- a/uv.lock
+++ b/uv.lock
@@ -1370,7 +1370,7 @@ wheels = [
 
 [[package]]
 name = "yutori"
-version = "0.9.15"
+version = "0.9.16"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1379,14 +1379,14 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/72/476abf8d5308b5b15f3abbbed28533ca3bd8a81591e90ed05fac52cd5ba0/yutori-0.9.15.tar.gz", hash = "sha256:e93c8866d62eabafdd57ca86c616012746f9dcd7bae15c22e9e75add5ff6a8d0", size = 459835, upload-time = "2026-09-08T17:15:41.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/fd/f14e8581b9757a3c269872bdce760d08d7f9653f6bf45e89cb3e77423191/yutori-0.9.16.tar.gz", hash = "sha256:ed82e05a2fce2c8547ce90688be6b9907f37237b448a0efd8ecc26cfe7c34af0", size = 460898, upload-time = "2026-09-08T22:03:52.108Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ea/7d/10ffc0fb9087660cc3762f2f6cb6ca156ee881e16e7cf01a9ae045da6fb0/yutori-0.9.15-py3-none-any.whl", hash = "sha256:e4e4ea2fd0bf9715e60b08442a452f72c44a8ee63c0d3323f483e492a328d04f", size = 323135, upload-time = "2026-09-08T17:15:39.797Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/50/c8806e95158d5d49dfc4f1387a28085bf2f1387be0d1b113d051ad98d53e/yutori-0.9.16-py3-none-any.whl", hash = "sha256:b3ee9349476b9536088721af1b899fcf9f29b18465bf73ebeed774796d705793", size = 323723, upload-time = "2026-09-08T22:03:50.74Z" },
 ]
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.15"
+version = "0.5.16"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -1406,6 +1406,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "yutori", specifier = "==0.9.15" },
+    { name = "yutori", specifier = "==0.9.16" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
Pins SDK [yutori 0.9.16](https://github.com/yutori-ai/yutori-sdk-python/releases/tag/v0.9.16) and cuts yutori-mcp 0.5.16.

## What the SDK bump brings

- **[yutori-sdk-python#404](https://github.com/yutori-ai/yutori-sdk-python/pull/404)** — the n2 activity dialog no longer flattens its run-command panels. The transcript is a scrolling flex column and the shell panel is the one entry that clips its own overflow, which drops its automatic minimum size; once the transcript outgrew the window the flex algorithm squeezed the panel until only the `RUN COMMAND` header and the exit code survived, worse the shorter the window. Panels now sit at their text's height and the column scrolls. The same PR stands the desktop shell rail down while the activity dialog is open, so a background run's commands are listed once — in the window the operator is reading — instead of also over the desktop behind it.

## Pins

`SDK_VERSION`, `SDK_ARTIFACT_SHA256` and `SDK_INSTALLATION_SHA256` in `computer_use/constants.py`, the `yutori==` pin in `pyproject.toml`, the constants test, and `uv.lock`. `SDK_PROVENANCE_SHA256` is unchanged: 0.9.16 touches overlay assets, not `provenance.json`.

Existing installs: run computer-use setup once.

`447 passed` with `YUTORI_MCP_VERIFY_PUBLISHED_ARTIFACT=1`, so the pinned artifact hash was checked against the published wheel.

**Full Changelog**: https://github.com/yutori-ai/yutori-mcp/compare/v0.5.15...v0.5.16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No MCP or runner logic changes—only version pins and checksum constants that preflight already enforces before tasks run.
> 
> **Overview**
> Cuts **yutori-mcp 0.5.16** and pins the **`yutori==0.9.16`** dependency everywhere the computer-use runtime locks SDK provenance: `pyproject.toml`, `computer_use/constants.py` (`SDK_VERSION` plus wheel/installation SHA256 digests), tests, and `uv.lock`. **`SDK_PROVENANCE_SHA256` is unchanged** because this SDK release only adjusts overlay/UI assets.
> 
> The SDK bump is mainly for **n2 activity-dialog UX**: run-command panels keep their natural text height instead of being crushed when the transcript scrolls, and the desktop shell rail is hidden while that dialog is open so background runs aren’t duplicated on the desktop behind it.
> 
> Existing installs should re-run computer-use setup once so doctor/preflight still matches the pinned wheel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bee220dfaef7ee614eb3c4ab509c341f05c9019b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->