### PR TITLE
Make the macOS input probe deterministic

### DIFF
--- a/scripts/run-input-probe.py
+++ b/scripts/run-input-probe.py
@@ -33,6 +33,7 @@ BUNDLE_ID = "ai.yutori.input-probe"
 EXECUTABLE_NAME = "YutoriInputProbe"
 DEFAULT_APP = REPOSITORY / "tools" / "YutoriInputProbe" / ".build" / "YutoriInputProbe.app"
 INPUT_EVENT_CATEGORIES = {"nsevent", "text", "command", "control", "responder"}
+KEY_SEQUENCE_SETTLE_MS = 75
 
 
 @dataclass
@@ -186,11 +187,16 @@ async def run_case(
 
 
 async def dispatch_n2(computer: MacOSComputer, action: str, arguments: dict[str, Any], size: tuple[int, int]) -> None:
-    for translated in translate_n2_action(action, arguments, *size):
+    translated_actions = translate_n2_action(action, arguments, *size)
+    for index, translated in enumerate(translated_actions):
         translated = dict(translated)
         method_name = translated.pop("type")
         method = getattr(computer, method_name)
         await method(**translated)
+        if action == "key_press" and index + 1 < len(translated_actions):
+            # CuaDriver returns once the native key-down is accepted; its key-up can still
+            # be in flight. Keep translated key sequences from overlapping one another.
+            await computer.wait(KEY_SEQUENCE_SETTLE_MS)
 
 
 def has_event(events: list[dict[str, Any]], category: str, name: str | None = None) -> bool:
@@ -205,6 +211,28 @@ def has_text(events: list[dict[str, Any]], text: str) -> bool:
         event.get("category") == "text" and text in details(event).get("value", "")
         for event in events
     )
+
+
+def has_key_down_sequence(events: list[dict[str, Any]], key_codes: list[str]) -> bool:
+    observed = [
+        details(event).get("keyCode")
+        for event in events
+        if event.get("category") == "nsevent" and event.get("name") == "keyDown"
+    ]
+    return observed == key_codes
+
+
+def has_modified_click(events: list[dict[str, Any]], modifier: str) -> bool:
+    observed = {
+        event.get("name")
+        for event in events
+        if event.get("category") == "nsevent"
+        and event.get("name") in {"leftMouseDown", "leftMouseUp"}
+        and details(event).get("clickCount") == "1"
+        and modifier in details(event).get("modifierFlags", "").split("+")
+        and event.get("state", {}).get("appActive") is True
+    }
+    return observed == {"leftMouseDown", "leftMouseUp"}
 
 
 def stayed_in_background(events: list[dict[str, Any]]) -> bool:
@@ -246,6 +274,18 @@ async def run_mode(mode: str, log_path: Path, allow_fallback: bool) -> tuple[dic
             )
         size = await computer.get_dimensions()
 
+        async def restore_foreground_keyboard_target(tool: str) -> None:
+            if background:
+                return
+            await computer.bring_to_front(target_pid, target.get("window_id"))
+            await computer.wait(KEY_SEQUENCE_SETTLE_MS)
+            await require_frontmost_target(
+                computer,
+                target_pid,
+                tool=tool,
+                target_name="Yutori Input Probe",
+            )
+
         marker = f"{mode}-Aa0-é-中-🙂"
         cases.append(
             await run_case(
@@ -262,11 +302,12 @@ async def run_mode(mode: str, log_path: Path, allow_fallback: bool) -> tuple[dic
 
         command_cases = [
             ("meta alias", "meta+k", "cmd+k"),
-            ("command + shift alias", "command+shift+k", "cmd+shift+k"),
             ("control alias", "control+k", "ctrl+k"),
             ("option alias", "option+k", "option+k"),
+            ("command + shift alias", "command+shift+u", "cmd+shift+u"),
         ]
         for case_name, expression, expected_command in command_cases:
+            await restore_foreground_keyboard_target(f"{case_name} probe setup")
             cases.append(
                 await run_case(
                     computer,
@@ -277,11 +318,13 @@ async def run_mode(mode: str, log_path: Path, allow_fallback: bool) -> tuple[dic
                         computer, "key_press", {"key": expression}, size
                     ),
                     lambda values, expected_command=expected_command: has_event(values, "command", expected_command)
+                    and has_event(values, "nsevent", "keyUp")
                     and (not requires_background_receipt or stayed_in_background(values)),
                     allow_explicit_refusal=background and not allow_fallback,
                 )
             )
 
+        await restore_foreground_keyboard_target("navigation probe setup")
         cases.append(
             await run_case(
                 computer,
@@ -294,7 +337,7 @@ async def run_mode(mode: str, log_path: Path, allow_fallback: bool) -> tuple[dic
                     {"key": "left right escape return"},
                     size,
                 ),
-                lambda values: sum(event.get("category") == "nsevent" for event in values) >= 4
+                lambda values: has_key_down_sequence(values, ["123", "124", "53", "36"])
                 and (not requires_background_receipt or stayed_in_background(values)),
                 allow_explicit_refusal=background and not allow_fallback,
             )
@@ -332,11 +375,12 @@ async def run_mode(mode: str, log_path: Path, allow_fallback: bool) -> tuple[dic
             ]
             modified_delivery = delivery_dict(computer, starting_outcomes)
             if allow_fallback:
-                passed = modified_error is None and any(
-                    event.get("category") == "control" and details(event).get("target") == "target-1"
-                    for event in modified_events
-                ) and bool(modified_delivery and modified_delivery.get("escalated_in_case"))
-                expected = "The modified click is foreground-delivered and reported as escalated."
+                passed = (
+                    modified_error is None
+                    and has_modified_click(modified_events, "cmd")
+                    and bool(modified_delivery and modified_delivery.get("escalated_in_case"))
+                )
+                expected = "An active cmd-click NSEvent is foreground-delivered and reported as escalated."
             else:
                 passed = modified_error is not None and not any(
                     event.get("category") == "control" for event in modified_events

--- a/tests/test_input_probe.py
+++ b/tests/test_input_probe.py
@@ -4,6 +4,7 @@ import importlib.util
 import json
 from pathlib import Path
 import sys
+from unittest.mock import AsyncMock
 
 
 def _load_probe_runner():
@@ -71,3 +72,65 @@ def test_clean_refusal_rejects_partial_or_misdirected_input():
     assert probe.is_clean_refusal("delivery failed", [_event(1, "layout")], delivery) is True
     assert probe.is_clean_refusal("delivery failed", [_event(1, "text")], delivery) is False
     assert probe.is_clean_refusal(None, [], delivery) is False
+
+
+def test_key_down_sequence_requires_exact_order_without_duplicates():
+    events = []
+    for sequence, key_code in enumerate(("123", "124", "53", "36"), start=1):
+        event = _event(sequence, "nsevent", keyCode=key_code)
+        event["name"] = "keyDown"
+        events.append(event)
+
+    assert probe.has_key_down_sequence(events, ["123", "124", "53", "36"]) is True
+    assert probe.has_key_down_sequence(events, ["124", "123", "53", "36"]) is False
+    assert probe.has_key_down_sequence(events + [events[-1]], ["123", "124", "53", "36"]) is False
+
+
+def test_modified_click_requires_the_modifier_and_active_delivery():
+    events = []
+    for sequence, name in enumerate(("leftMouseDown", "leftMouseUp"), start=1):
+        event = _event(
+            sequence,
+            "nsevent",
+            active=True,
+            modifierFlags="shift+cmd",
+            clickCount="1",
+        )
+        event["name"] = name
+        events.append(event)
+
+    assert probe.has_modified_click(events, "cmd") is True
+    assert probe.has_modified_click(events, "option") is False
+    assert probe.has_modified_click(events[:1], "cmd") is False
+    events[-1]["state"]["appActive"] = False
+    assert probe.has_modified_click(events, "cmd") is False
+
+
+async def test_dispatch_n2_paces_a_multi_key_sequence():
+    computer = type(
+        "FakeComputer",
+        (),
+        {
+            "keypress": AsyncMock(),
+            "wait": AsyncMock(),
+        },
+    )()
+
+    await probe.dispatch_n2(
+        computer,
+        "key_press",
+        {"key": "left right escape return"},
+        (100, 100),
+    )
+
+    assert [call.kwargs["keys"] for call in computer.keypress.await_args_list] == [
+        ["left"],
+        ["right"],
+        ["esc"],
+        ["enter"],
+    ]
+    assert [call.args for call in computer.wait.await_args_list] == [
+        (probe.KEY_SEQUENCE_SETTLE_MS,),
+        (probe.KEY_SEQUENCE_SETTLE_MS,),
+        (probe.KEY_SEQUENCE_SETTLE_MS,),
+    ]

--- a/tools/YutoriInputProbe/Sources/YutoriInputProbe/ContentView.swift
+++ b/tools/YutoriInputProbe/Sources/YutoriInputProbe/ContentView.swift
@@ -69,7 +69,7 @@ struct ContentView: View {
 
                 HStack {
                     ShortcutChip(keys: "⌘ K", label: "Command")
-                    ShortcutChip(keys: "⌘ ⇧ K", label: "Shift")
+                    ShortcutChip(keys: "⌘ ⇧ U", label: "Shift")
                     ShortcutChip(keys: "⌃ K", label: "Control")
                     ShortcutChip(keys: "⌥ K", label: "Option")
                 }

--- a/tools/YutoriInputProbe/Sources/YutoriInputProbe/EventRecorder.swift
+++ b/tools/YutoriInputProbe/Sources/YutoriInputProbe/EventRecorder.swift
@@ -266,14 +266,14 @@ final class EventRecorder: NSObject, ObservableObject {
     }
 
     private static func recognizedCommand(_ event: NSEvent) -> String? {
-        guard event.type == .keyDown, event.charactersIgnoringModifiers?.lowercased() == "k" else {
+        guard event.type == .keyDown, let key = event.charactersIgnoringModifiers?.lowercased() else {
             return nil
         }
         let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-        if flags == [.command] { return "cmd+k" }
-        if flags == [.command, .shift] { return "cmd+shift+k" }
-        if flags == [.control] { return "ctrl+k" }
-        if flags == [.option] { return "option+k" }
+        if key == "k", flags == [.command] { return "cmd+k" }
+        if key == "u", flags == [.command, .shift] { return "cmd+shift+u" }
+        if key == "k", flags == [.control] { return "ctrl+k" }
+        if key == "k", flags == [.option] { return "option+k" }
         return nil
     }
 }

--- a/tools/YutoriInputProbe/Tests/YutoriInputProbeTests/ProbeModelTests.swift
+++ b/tools/YutoriInputProbe/Tests/YutoriInputProbeTests/ProbeModelTests.swift
@@ -30,7 +30,7 @@ struct ProbeModelTests {
     @Test("Chord formatter uses macOS modifier vocabulary")
     func chordFormatting() {
         let flags: NSEvent.ModifierFlags = [.command, .shift]
-        #expect(ProbeKeyFormatter.chord(charactersIgnoringModifiers: "k", flags: flags) == "shift+cmd+k")
+        #expect(ProbeKeyFormatter.chord(charactersIgnoringModifiers: "u", flags: flags) == "shift+cmd+u")
         #expect(ProbeKeyFormatter.displayKey("\r") == "enter")
         #expect(ProbeKeyFormatter.displayKey("\t") == "tab")
         #expect(ProbeKeyFormatter.displayKey("\u{1B}") == "escape")


### PR DESCRIPTION
## Summary

- pace translated multi-key sequences so native key-up events complete before the next driver RPC
- restore and verify the foreground target before each keyboard case
- use an inert Command+Shift chord that does not trigger unrelated key-window behavior
- require exact navigation key order and a complete active modified-click event pair
- validate foreground escalation from driver telemetry instead of relying on SwiftUI Button semantics

## Verification

- `uv run --python 3.10 --extra dev pytest -q` — 463 passed, 1 skipped
- `swift test --package-path tools/YutoriInputProbe` — 4 passed
- foreground live probe — 6/6 cases passed
- background live probe with foreground fallback — 8/8 cases passed
- `git diff --check origin/main...HEAD`

## Out of scope

Strict background delivery/result reconciliation remains unchanged for its dedicated follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to the input probe harness and test app, not production driver or MCP paths; risk is low aside from probe CI/live-run expectations shifting to stricter checks.
> 
> **Overview**
> Hardens the macOS **input probe** driver matrix so flaky keyboard and click assertions reflect real delivery instead of timing or UI side effects.
> 
> **`dispatch_n2`** now inserts a **75ms settle** between translated `key_press` steps so multi-key sequences do not overlap while native key-ups are still in flight. Foreground runs **re-front the probe and re-verify** focus before each keyboard case via `restore_foreground_keyboard_target`.
> 
> Assertions are stricter: navigation must match an **exact `keyDown` key-code sequence**; shortcut cases require a **`keyUp`** as well as the mapped command; **cmd+shift** probing moves from **⌘⇧K** to **⌘⇧U** so the chord does not disturb key-window behavior (probe UI and `recognizedCommand` updated). Background **cmd-click** escalation success now requires an **active NSEvent down/up pair with the modifier**, plus driver **escalation telemetry**, not SwiftUI control activation alone.
> 
> Unit tests cover the new matchers and pacing behavior in Python; Swift chord tests follow the new shortcut.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a570d247852142d6e663f7e3b95543e655de1190. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->