### PR TITLE
refactor(computer-use): extract capture_baseline() in run-input-probe.py

### DIFF
--- a/scripts/run-input-probe.py
+++ b/scripts/run-input-probe.py
@@ -148,6 +148,18 @@ def target_center(events: list[dict[str, Any]], target: str, capture_size: tuple
     )
 
 
+def capture_baseline(log_path: Path, computer: MacOSComputer) -> tuple[int, int]:
+    """Snapshot the log's latest sequence number and the computer's outcome count.
+
+    Call this immediately before dispatching an action so later event/outcome filtering
+    only sees what that action itself produced.
+    """
+    before = read_events(log_path)
+    starting_sequence = max((event_sequence(event) for event in before), default=-1)
+    starting_outcomes = len(computer.action_outcomes)
+    return starting_sequence, starting_outcomes
+
+
 async def run_case(
     computer: MacOSComputer,
     log_path: Path,
@@ -158,9 +170,7 @@ async def run_case(
     *,
     allow_explicit_refusal: bool = False,
 ) -> CaseResult:
-    before = read_events(log_path)
-    starting_sequence = max((event_sequence(event) for event in before), default=-1)
-    starting_outcomes = len(computer.action_outcomes)
+    starting_sequence, starting_outcomes = capture_baseline(log_path, computer)
     error: str | None = None
     try:
         await action()
@@ -361,9 +371,7 @@ async def run_mode(mode: str, log_path: Path, allow_fallback: bool) -> tuple[dic
                 )
             )
 
-            before = read_events(log_path)
-            starting_sequence = max((event_sequence(event) for event in before), default=-1)
-            starting_outcomes = len(computer.action_outcomes)
+            starting_sequence, starting_outcomes = capture_baseline(log_path, computer)
             modified_error: str | None = None
             try:
                 await computer.click(*button_point, modifier=["cmd"])

--- a/tests/test_input_probe.py
+++ b/tests/test_input_probe.py
@@ -30,6 +30,24 @@ def _event(sequence: int, category: str, *, active: bool = False, **details: str
     }
 
 
+def test_capture_baseline_reads_latest_sequence_and_outcome_count(tmp_path):
+    path = tmp_path / "events.jsonl"
+    path.write_text(
+        "\n".join(json.dumps(_event(sequence, "nsevent")) for sequence in (1, 3, 2)) + "\n",
+        encoding="utf-8",
+    )
+    computer = type("FakeComputer", (), {"action_outcomes": ("a", "b")})()
+
+    assert probe.capture_baseline(path, computer) == (3, 2)
+
+
+def test_capture_baseline_defaults_to_no_prior_sequence(tmp_path):
+    path = tmp_path / "events.jsonl"
+    computer = type("FakeComputer", (), {"action_outcomes": ()})()
+
+    assert probe.capture_baseline(path, computer) == (-1, 0)
+
+
 def test_read_events_ignores_an_incomplete_trailing_line(tmp_path):
     path = tmp_path / "events.jsonl"
     path.write_text(json.dumps(_event(1, "session")) + "\n{", encoding="utf-8")


### PR DESCRIPTION
## Summary
- `run_case()` and the modified-background-click case inside `run_mode()` (both in `scripts/run-input-probe.py`, added in #284/#285) each independently built the identical 3-line snapshot before dispatching an action: latest log sequence number + current `action_outcomes` count.
- Extracted `capture_baseline(log_path, computer) -> tuple[int, int]`; both call sites now share one definition of "what counts as before this action ran".
- Added 2 focused unit tests for the new helper (`test_capture_baseline_reads_latest_sequence_and_outcome_count`, `test_capture_baseline_defaults_to_no_prior_sequence`), matching this test file's existing style for the module's other pure helpers.
- No behavior change: same values computed at the same point in each caller.

## Test plan
- [x] `uv run --extra dev pytest -q` -> 465 passed, 1 skipped (baseline was 463/1 before this change; +2 new tests)
- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check` flags on the 2 touched files confirmed pre-existing on `main` via `git stash` (repo has no CI lint-format gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XTrzJ1rP8rQmib3Rs9WfQS

---
_Generated by [Claude Code](https://claude.ai/code/session_01XTrzJ1rP8rQmib3Rs9WfQS)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of probe test harness logic with matching unit tests; no production driver or security paths touched.
> 
> **Overview**
> Pulls duplicated “before this action” bookkeeping out of the input probe runner into **`capture_baseline(log_path, computer)`**, which records the latest event log sequence and current `action_outcomes` length so post-action filtering only sees what that dispatch produced.
> 
> **`run_case()`** and the inline **modified background click** path in **`run_mode()`** now call the helper at the same point they previously inlined those three lines—no intended behavior change.
> 
> Adds two unit tests covering max sequence over out-of-order log lines and the empty-log default **`(-1, 0)`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f83d52fdbb168016cb61ef0d25fb9bfd0cfae0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->