### PR TITLE
chore(release): 0.5.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.16"
+version = "0.5.17"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1386,7 +1386,7 @@ wheels = [
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.16"
+version = "0.5.17"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
Publishes the macOS computer-use reliability work merged since 0.5.16.

## Included

- Adds the Yutori Input Probe Swift app and scripts for exercising foreground/background delivery and key-command mapping.
- Adds a foreground target-PID guard so keyboard input fails closed instead of reaching the wrong app.
- Makes input-probe launch and window targeting deterministic.
- Bumps `yutori-mcp` from 0.5.16 to 0.5.17. The SDK remains pinned at 0.9.16.

## Verification

- `uv lock --check`
- `uv run yutori-mcp --version` → `yutori-mcp 0.5.17`
- `uv run python -m pytest -q` → `463 passed, 1 skipped`
- Built wheel and sdist; `twine check` passed for both artifacts.

**Full Changelog**: https://github.com/yutori-ai/yutori-mcp/compare/v0.5.16...HEAD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release metadata only: version and lockfile alignment with no code or dependency changes in the diff.
> 
> **Overview**
> **Release 0.5.17** — bumps the `yutori-mcp` package version from `0.5.16` to `0.5.17` in `pyproject.toml` and syncs the matching `yutori-mcp` entry in `uv.lock`. No dependency pins change in this diff (e.g. `yutori` stays at `0.9.16`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64dd48a66e92e9321454ee66030899ccd720473f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->