### PR TITLE
refactor(computer-use): extract _content_windows() in app.py

### DIFF
--- a/src/yutori_mcp/computer_use/app.py
+++ b/src/yutori_mcp/computer_use/app.py
@@ -78,15 +78,24 @@ def _best_content_window(candidates: list[dict[str, Any]]) -> dict[str, Any]:
     return max(titled, key=lambda window: (window.get("z_index") or 0, _area(window)))
 
 
+def _content_windows(windows: list[dict[str, Any]], min_edge_points: float) -> list[dict[str, Any]]:
+    """Windows whose shorter edge clears ``min_edge_points``, excluding menu-bar-strip-sized helpers.
+
+    Shared by :func:`pick_best_window` and :func:`_best_fallback_window`, which both need the
+    same "is this big enough to be real content" cut before picking among the survivors.
+    """
+    return [
+        window for window in windows if min(window["bounds"]["width"], window["bounds"]["height"]) >= min_edge_points
+    ]
+
+
 def _best_fallback_window(
     windows: list[dict[str, Any]], min_edge_points: float = 100
 ) -> dict[str, Any] | None:
     """Choose eventual background fallback content without favoring a visible helper host."""
     if not windows:
         return None
-    content = [
-        window for window in windows if min(window["bounds"]["width"], window["bounds"]["height"]) >= min_edge_points
-    ]
+    content = _content_windows(windows, min_edge_points)
     return _best_content_window(content) if content else max(windows, key=_area)
 
 
@@ -99,9 +108,7 @@ def pick_best_window(windows: list[dict[str, Any]], min_edge_points: float = 100
     """
     if not windows:
         return None
-    content = [
-        window for window in windows if min(window["bounds"]["width"], window["bounds"]["height"]) >= min_edge_points
-    ]
+    content = _content_windows(windows, min_edge_points)
     visible = [
         window
         for window in content


### PR DESCRIPTION
## What

`pick_best_window()` and `_best_fallback_window()` in `src/yutori_mcp/computer_use/app.py` each independently filtered a window list with the identical list comprehension:

```python
content = [
    window for window in windows if min(window["bounds"]["width"], window["bounds"]["height"]) >= min_edge_points
]
```

Extracted the shared filter into a small named helper, `_content_windows(windows, min_edge_points)`, with a docstring naming both callers so the "what counts as real content vs. a menu-bar-strip-sized helper" cut can't silently drift between them.

## Why this is safe

- Pure extraction: the returned list is byte-identical to what each call site built inline before — same expression, same parameters, no new branches.
- Both call sites (`pick_best_window`, `_best_fallback_window`) pass through unchanged; no signature or behavior change anywhere else in the file.
- Single file touched, +13/-6.
- `uv run --extra dev pytest -q` → 465 passed, 1 skipped (existing `test_pick_best_window_*` suite in `tests/test_computer_use.py` covers `pick_best_window` end-to-end and passes unchanged).
- `uv run ruff check .` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DmGgsEmUcd3DZfwGNtzReu

---
_Generated by [Claude Code](https://claude.ai/code/session_01DmGgsEmUcd3DZfwGNtzReu)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor in window-selection helpers only; no API or logic changes beyond sharing one filter.
> 
> **Overview**
> **Deduplicates** the “real content window vs. tiny helper strip” size filter used when choosing which macOS window to target.
> 
> `pick_best_window` and `_best_fallback_window` previously each inlined the same comprehension (shorter edge ≥ `min_edge_points`). That logic now lives in **`_content_windows()`**, with a docstring tying both callers together so the threshold cannot drift between foreground picking and background fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ae24c60ff3880e909058d66f6489dfa202fa0a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->