### PR TITLE
chore(release): 0.5.18 — SDK 0.9.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.17"
+version = "0.5.18"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"
@@ -30,10 +30,11 @@ dependencies = [
     # breaks the install as soon as 2.x resolves.
     "mcp>=1.0.0,<2.0.0",
     "pydantic>=2.0.0",
-    # SDK 0.9.16 keeps the activity dialog's run-command panels at their text's
-    # height instead of letting the transcript squeeze them flat, and stands the
-    # desktop shell rail down while that dialog is open.
-    "yutori==0.9.16",
+    # SDK 0.9.17 keeps the overlay on screen through a capture (the compositor
+    # excludes it instead of the driver hiding and re-showing it around every
+    # screenshot), marks a background run with an activity dot beside the menu
+    # bar icon, and folds a batch's consecutive waits into one pause.
+    "yutori==0.9.17",
 ]
 
 [project.optional-dependencies]

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -26,11 +26,11 @@ OBSERVATION_FORMAT = "webp"
 DELIVERY_MODE_FOREGROUND = "foreground"
 DELIVERY_MODE_BACKGROUND = "background"
 DELIVERY_MODES = (DELIVERY_MODE_FOREGROUND, DELIVERY_MODE_BACKGROUND)
-SDK_VERSION = "0.9.16"
+SDK_VERSION = "0.9.17"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.
-SDK_ARTIFACT_SHA256 = "b3ee9349476b9536088721af1b899fcf9f29b18465bf73ebeed774796d705793"
-SDK_INSTALLATION_SHA256 = "ed219d19147568d99b68db9eb58ab0dc504a9388b9ce5ffe096e8c8acb6fa146"
+SDK_ARTIFACT_SHA256 = "43c0e75f0dbb14b0d4e02e19789d79c8fb577a70fbf5b35de8c7f2651658d4d2"
+SDK_INSTALLATION_SHA256 = "84b0556503d3a42dbc782f25d77376dc8ed3e170b8dc5fb0109d906f9eeafb96"
 SDK_PROVENANCE_SHA256 = "7cab595d2f00e1a9ab5cd121204fbd6dd4c24163ead3eb76f76eef7fba495fc4"
 
 # The cua-driver release that implements this tool contract, and the checksum

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -856,9 +856,9 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 
 def test_runtime_constants_select_latest_python_surface():
     assert TOOL_SET == "computer_use_tools-20260830"
-    assert SDK_VERSION == "0.9.16"
+    assert SDK_VERSION == "0.9.17"
     assert all(len(digest) == 64 for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256))
-    assert '"yutori==0.9.16"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
+    assert '"yutori==0.9.17"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
 
 
 def test_installed_sdk_matches_the_published_artifact():

--- a/uv.lock
+++ b/uv.lock
@@ -1370,7 +1370,7 @@ wheels = [
 
 [[package]]
 name = "yutori"
-version = "0.9.16"
+version = "0.9.17"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1379,14 +1379,14 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/fd/f14e8581b9757a3c269872bdce760d08d7f9653f6bf45e89cb3e77423191/yutori-0.9.16.tar.gz", hash = "sha256:ed82e05a2fce2c8547ce90688be6b9907f37237b448a0efd8ecc26cfe7c34af0", size = 460898, upload-time = "2026-09-08T22:03:52.108Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/06/9f5efbf63f50bd38cff10972b8c17348fe53bc62ea2c6c39d7b94f450a49/yutori-0.9.17.tar.gz", hash = "sha256:83a97519a5208cacda7a8d7777d2f959b075c3664c8dcc1241bf7e6779fc26e4", size = 470093, upload-time = "2026-09-09T07:30:35.18Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/50/c8806e95158d5d49dfc4f1387a28085bf2f1387be0d1b113d051ad98d53e/yutori-0.9.16-py3-none-any.whl", hash = "sha256:b3ee9349476b9536088721af1b899fcf9f29b18465bf73ebeed774796d705793", size = 323723, upload-time = "2026-09-08T22:03:50.74Z" },
+    { url = "https://files.pythonhosted.org/packages/07/67/b6a235fb46876188df68e31d2d97fcdd289f905abe230fecb89ecb59caa2/yutori-0.9.17-py3-none-any.whl", hash = "sha256:43c0e75f0dbb14b0d4e02e19789d79c8fb577a70fbf5b35de8c7f2651658d4d2", size = 328771, upload-time = "2026-09-09T07:30:33.479Z" },
 ]
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.17"
+version = "0.5.18"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -1406,6 +1406,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "yutori", specifier = "==0.9.16" },
+    { name = "yutori", specifier = "==0.9.17" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
Pins the macOS computer-use runtime at yutori 0.9.17 and cuts yutori-mcp 0.5.18.

## What the SDK bump brings

- **SDK #406** — the overlay stays on screen through a capture. The session probes once and sets `sharingType = .none` on the overlay windows, so the compositor excludes them instead of the driver hiding and re-showing them around every screenshot; hiding stays as the fallback when the probe says exclusion did not take.
- **SDK #409** — a background run is marked with an activity dot beside the menu bar icon, visible without opening the activity window.
- **SDK #411** — the overlay's loop mark paints with a flat colour instead of a gradient reference that could stop painting and leave a faint dark diamond.
- **SDK #410** — `computer_batch` folds each run of consecutive `wait` members into a single wait of the summed duration. Three two-second waits in a row were three separate pauses, each paying executor and frame-poll overhead, an overlay queue slot, and a confirmation line for the same total sleep.
- **SDK #407, #408** — internal refactors in the macOS presentation controller.

## Pin

`SDK_VERSION`, `SDK_ARTIFACT_SHA256` (the published 0.9.17 wheel digest), and `SDK_INSTALLATION_SHA256` (that wheel's RECORD-derived digest, unpacked) in `constants.py`; the `yutori==` pin and `version` in `pyproject.toml`; the constants assertion in `tests/test_computer_use.py`; `uv.lock`.

`SDK_PROVENANCE_SHA256` is unchanged: it digests the driver provenance asset, and the cua-driver pin (`DRIVER_VERSION` 0.23.2) did not move.

## Testing

- `uv run pytest` → 465 passed, 1 skipped.
- `test_installed_sdk_matches_the_published_artifact` (doctor's `check_runtime()` against the real install) passes, which is what actually confirms the installation and provenance digests.
- `YUTORI_MCP_VERIFY_PUBLISHED_ARTIFACT=1` release check passes, confirming `SDK_ARTIFACT_SHA256` against PyPI.

Existing installs: run computer-use setup once to pick up the new runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and digest pin only; doctor/preflight enforces the new SDK artifact but application logic in this repo is unchanged.
> 
> **Overview**
> Releases **yutori-mcp 0.5.18** by pinning the macOS computer-use stack to **`yutori==0.9.17`**: package version in `pyproject.toml`, `SDK_VERSION` plus wheel/installation SHA256 digests in `constants.py`, matching assertions in `tests/test_computer_use.py`, and `uv.lock`.
> 
> Behavior users get comes from the SDK bump (documented in the release notes): overlay stays visible during screenshots via compositor exclusion, a menu-bar activity dot for background runs, overlay rendering fix, and merged consecutive `wait` steps in `computer_batch`. **No MCP runtime code changes** beyond the pin and checksums; `SDK_PROVENANCE_SHA256` and the cua-driver pin are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acd79030e03430c9b62cc33aeae66e81f156cdee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->