### PR TITLE
chore(release): 0.5.19 — SDK 0.9.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.18"
+version = "0.5.19"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"
@@ -30,11 +30,11 @@ dependencies = [
     # breaks the install as soon as 2.x resolves.
     "mcp>=1.0.0,<2.0.0",
     "pydantic>=2.0.0",
-    # SDK 0.9.17 keeps the overlay on screen through a capture (the compositor
-    # excludes it instead of the driver hiding and re-showing it around every
-    # screenshot), marks a background run with an activity dot beside the menu
-    # bar icon, and folds a batch's consecutive waits into one pause.
-    "yutori==0.9.17",
+    # SDK 0.9.18 lets clicks through the activity window: its body ignores the
+    # mouse, so a click there reaches the app behind it instead of the
+    # transcript, and only the grip strip (drag, close) takes the mouse; model
+    # input on that grip is refused the way input on the Stop item is.
+    "yutori==0.9.18",
 ]
 
 [project.optional-dependencies]

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -26,11 +26,11 @@ OBSERVATION_FORMAT = "webp"
 DELIVERY_MODE_FOREGROUND = "foreground"
 DELIVERY_MODE_BACKGROUND = "background"
 DELIVERY_MODES = (DELIVERY_MODE_FOREGROUND, DELIVERY_MODE_BACKGROUND)
-SDK_VERSION = "0.9.17"
+SDK_VERSION = "0.9.18"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.
-SDK_ARTIFACT_SHA256 = "43c0e75f0dbb14b0d4e02e19789d79c8fb577a70fbf5b35de8c7f2651658d4d2"
-SDK_INSTALLATION_SHA256 = "84b0556503d3a42dbc782f25d77376dc8ed3e170b8dc5fb0109d906f9eeafb96"
+SDK_ARTIFACT_SHA256 = "5c5e7b12b6671a4a8bf14f833635017e2429811e1ba3e5a6f28e756361fa4882"
+SDK_INSTALLATION_SHA256 = "814cc248c631c90966fab16237c2c59c2cc8485b4220817ee31b8c828b25f838"
 SDK_PROVENANCE_SHA256 = "7cab595d2f00e1a9ab5cd121204fbd6dd4c24163ead3eb76f76eef7fba495fc4"
 
 # The cua-driver release that implements this tool contract, and the checksum

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -856,9 +856,9 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 
 def test_runtime_constants_select_latest_python_surface():
     assert TOOL_SET == "computer_use_tools-20260830"
-    assert SDK_VERSION == "0.9.17"
+    assert SDK_VERSION == "0.9.18"
     assert all(len(digest) == 64 for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256))
-    assert '"yutori==0.9.17"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
+    assert '"yutori==0.9.18"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
 
 
 def test_installed_sdk_matches_the_published_artifact():

--- a/uv.lock
+++ b/uv.lock
@@ -1370,7 +1370,7 @@ wheels = [
 
 [[package]]
 name = "yutori"
-version = "0.9.17"
+version = "0.9.18"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1379,14 +1379,14 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/95/06/9f5efbf63f50bd38cff10972b8c17348fe53bc62ea2c6c39d7b94f450a49/yutori-0.9.17.tar.gz", hash = "sha256:83a97519a5208cacda7a8d7777d2f959b075c3664c8dcc1241bf7e6779fc26e4", size = 470093, upload-time = "2026-09-09T07:30:35.18Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/3e/c9f924eb6f5ed2eb1f7ff09ac0a20378590d54e16d5695407207a3c1acac/yutori-0.9.18.tar.gz", hash = "sha256:edd45d93f9598eb90257c7249b466c15d4dc6d97a55a84d770f6807a563ba30a", size = 473450, upload-time = "2026-09-09T08:12:17.057Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/67/b6a235fb46876188df68e31d2d97fcdd289f905abe230fecb89ecb59caa2/yutori-0.9.17-py3-none-any.whl", hash = "sha256:43c0e75f0dbb14b0d4e02e19789d79c8fb577a70fbf5b35de8c7f2651658d4d2", size = 328771, upload-time = "2026-09-09T07:30:33.479Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/0f/49de6bf50dbf64779ba6702e3f432feff135cedb07e1701e29c1f59894d5/yutori-0.9.18-py3-none-any.whl", hash = "sha256:5c5e7b12b6671a4a8bf14f833635017e2429811e1ba3e5a6f28e756361fa4882", size = 331052, upload-time = "2026-09-09T08:12:15.446Z" },
 ]
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.18"
+version = "0.5.19"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -1406,6 +1406,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "yutori", specifier = "==0.9.17" },
+    { name = "yutori", specifier = "==0.9.18" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
## Summary

- Pins the macOS computer-use runtime at `yutori==0.9.18` (SDK PR yutori-ai/yutori-sdk-python#413, released as v0.9.18).
- SDK 0.9.18 lets clicks through the activity window: its body ignores the mouse, so a click there reaches the app behind it instead of the transcript. Only the grip strip along its top (drag, close) takes the mouse, and model input on that grip is refused the way input on the Stop item is. Fixes foreground runs where a model click posted to the desktop landed on the window.
- Bumps yutori-mcp to 0.5.19; updates `SDK_ARTIFACT_SHA256` / `SDK_INSTALLATION_SHA256` (provenance unchanged: the driver pin did not move), the constants test, and `uv.lock`.

## Test plan

- [x] `pytest` — 465 passed, 1 skipped (includes `test_installed_sdk_matches_the_published_artifact` against the synced 0.9.18 wheel)
- [x] Wheel digest matches the v0.9.18 release SHA256SUMS and PyPI
- [ ] CI green, then `gh release create v0.5.19`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and checksum sync with a patch SDK bump; no auth or MCP protocol changes, only updated install verification constants and lockfile.
> 
> **Overview**
> **Release 0.5.19** bumps the pinned **yutori** macOS computer-use SDK from **0.9.17** to **0.9.18** and aligns **yutori-mcp**’s package version with that release.
> 
> The dependency comment documents the behavioral reason: SDK **0.9.18** makes the activity overlay **click-through** on its main body (clicks hit the app behind it), while only the top grip strip handles drag/close—and model input on that grip is refused like the Stop control. **No MCP runtime code changes** beyond syncing `SDK_VERSION`, wheel/installation **SHA256** digests used by doctor/preflight, the constants/pyproject lockfile test, and **`uv.lock`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab433c08891af2f188097f89713efa8281fd97c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->