### PR TITLE
refactor(computer-use): reuse requires_background_receipt in run-input-probe.py

### DIFF
--- a/scripts/run-input-probe.py
+++ b/scripts/run-input-probe.py
@@ -306,7 +306,7 @@ async def run_mode(mode: str, log_path: Path, allow_fallback: bool) -> tuple[dic
                 lambda: dispatch_n2(computer, "type", {"text": marker}, size),
                 lambda values: has_text(values, marker)
                 and (not requires_background_receipt or stayed_in_background(values)),
-                allow_explicit_refusal=background and not allow_fallback,
+                allow_explicit_refusal=requires_background_receipt,
             )
         )
 
@@ -330,7 +330,7 @@ async def run_mode(mode: str, log_path: Path, allow_fallback: bool) -> tuple[dic
                     lambda values, expected_command=expected_command: has_event(values, "command", expected_command)
                     and has_event(values, "nsevent", "keyUp")
                     and (not requires_background_receipt or stayed_in_background(values)),
-                    allow_explicit_refusal=background and not allow_fallback,
+                    allow_explicit_refusal=requires_background_receipt,
                 )
             )
 
@@ -349,7 +349,7 @@ async def run_mode(mode: str, log_path: Path, allow_fallback: bool) -> tuple[dic
                 ),
                 lambda values: has_key_down_sequence(values, ["123", "124", "53", "36"])
                 and (not requires_background_receipt or stayed_in_background(values)),
-                allow_explicit_refusal=background and not allow_fallback,
+                allow_explicit_refusal=requires_background_receipt,
             )
         )
 


### PR DESCRIPTION
## What

`run_mode()` in `scripts/run-input-probe.py` already computes `requires_background_receipt = background and not allow_fallback` once and uses it in each of three test cases' background-receipt assertions. But each of those same three `run_case(...)` calls independently re-derived the identical expression `background and not allow_fallback` inline for the `allow_explicit_refusal` argument, instead of reusing the existing variable.

## Why it's an improvement

Two independent computations of the same value inside one function is a latent drift risk: if either expression were edited later without updating the other, the two checks would silently diverge. Reusing the named variable removes that risk and makes the intent (both checks depend on the same condition) explicit at the call site.

## Why it's safe

- Byte-identical value in all three spots (`background and not allow_fallback` == `requires_background_receipt`), so no behavior change.
- `uv run --extra dev pytest -q`: 465 passed, 1 skipped — identical before (verified via `git stash`) and after.
- `uv run ruff check scripts/run-input-probe.py`: clean.

1 file changed, +3/-3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sj1pj35MkTqWRfQNgRZNmg

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sj1pj35MkTqWRfQNgRZNmg)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical refactor with equivalent boolean values in a test/probe script; no production logic changes.
> 
> **Overview**
> In `run_mode()` inside `scripts/run-input-probe.py`, three `run_case(...)` calls now pass **`allow_explicit_refusal=requires_background_receipt`** instead of repeating **`background and not allow_fallback`**.
> 
> That matches the existing **`requires_background_receipt`** flag already used in each case’s pass/fail matcher for background delivery checks, so refusal handling and receipt expectations stay tied to one condition with **no intended behavior change**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a4583a0d2f57804390438f3738ef76ba9f1e27c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->