### PR TITLE
perf(computer-use): expose and reduce startup latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,8 +413,10 @@ types into Calculator to confirm the permissions took effect, then has the agent
 
 While a task runs, `run` prints each action as the agent takes it — including the individual
 clicks, keystrokes, and scrolls inside each `computer_batch` — and closes with the model's
-answer in a labeled `FINAL OUTPUT` block. Output is colorized when stdout is a terminal; set
-`NO_COLOR=1` to turn that off, or `FORCE_COLOR=1` to keep it through a pipe.
+answer in a labeled `FINAL OUTPUT` block. Before the first model request it also prints elapsed
+timers for preflight, runner startup, API-client setup, the computer session, and target-app
+preparation. Output is colorized when stdout is a terminal; set `NO_COLOR=1` to turn that off,
+or `FORCE_COLOR=1` to keep it through a pipe.
 
 The harness in this repository is minimal: one task at a time (a machine-wide lock), either on
 the visible desktop or targeting one app window in the background, with no multiplexing. For

--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -6,6 +6,7 @@ import hashlib
 import os
 import subprocess
 import tempfile
+import time
 import uuid
 from collections.abc import Callable
 from pathlib import Path
@@ -38,6 +39,8 @@ from .preflight import (
 from .result import (
     Terminal,
     describe_delivery_surface,
+    format_duration,
+    format_startup_line,
     format_runtime_version,
     format_terminal_action,
     format_terminal_result,
@@ -206,13 +209,33 @@ def hands_off_notice(mode: str) -> str:
     return "The model takes over this Mac's desktop now; do not touch it during the run."
 
 
-def _event_printer(mode: str, app: str | None, paint: Terminal | None = None):
+def _event_printer(
+    mode: str,
+    app: str | None,
+    paint: Terminal | None = None,
+    *,
+    started_at: float | None = None,
+    clock: Callable[[], float] = time.monotonic,
+):
     surface = describe_delivery_surface(mode, app)
     paint = Terminal.detect() if paint is None else paint
+    started_at = clock() if started_at is None else started_at
 
     async def print_event(event: dict) -> None:
         if event.get("type") == "ready":
-            print(f"{paint(paint.glyph('bullet'), 'green')} runner ready, driving {surface}\n", flush=True)
+            elapsed_ms = max(0, round((clock() - started_at) * 1000))
+            print(
+                f"{paint(paint.glyph('bullet'), 'green')} runner process ready"
+                f"  {paint(format_duration(elapsed_ms), 'dim')}",
+                flush=True,
+            )
+            return
+        if event.get("type") == "startup":
+            observed = {**event, "elapsed_ms": max(0, round((clock() - started_at) * 1000))}
+            line = format_startup_line(observed, app=app)
+            if event.get("phase") == "computer" and app is None:
+                line = line.replace("computer session ready", f"ready to drive {surface}", 1)
+            print(f"{paint(paint.glyph('bullet'), 'green')} {line}", flush=True)
             return
         print("\n".join(format_terminal_action(event, paint)), flush=True)
 
@@ -255,13 +278,21 @@ async def _run_custom(args: argparse.Namespace) -> int:
         allow_foreground_fallback=args.allow_foreground_fallback,
         allow_local_shell=args.allow_local_shell,
     )
+    paint = Terminal.detect()
+    preflight_started = time.monotonic()
     if _blocked():
         return 1
-    paint = Terminal.detect()
+    preflight_ms = max(0, round((time.monotonic() - preflight_started) * 1000))
+    print(
+        f"{paint(paint.glyph('bullet'), 'green')} preflight ready"
+        f"  {paint(format_duration(preflight_ms), 'dim')}",
+        flush=True,
+    )
     print(format_run_header(params, paint))
+    runner_started = time.monotonic()
     result = await run_task_with_resolved_credentials(
         **params.model_dump(),
-        on_event=_event_printer(params.mode, params.app, paint),
+        on_event=_event_printer(params.mode, params.app, paint, started_at=runner_started),
     )
     return _report(result, include_actions=False)
 

--- a/src/yutori_mcp/computer_use/preflight.py
+++ b/src/yutori_mcp/computer_use/preflight.py
@@ -560,6 +560,26 @@ _ENVIRONMENT_CHECKS: tuple[Callable[[], CheckResult], ...] = (
     check_api_access,
 )
 
+# The latency-sensitive gate before every real run. Keep checks that prevent a
+# session from starting safely, but leave diagnostic-only probes to ``doctor``:
+# desktop capture, compiler, and overlay failures are explicitly non-blocking,
+# while ``check_api_access`` makes a synthetic model request that the run's first
+# real completion immediately supersedes. On a healthy development Mac those
+# four probes accounted for most of the pre-run wall time.
+_RUN_BLOCKING_CHECKS: tuple[Callable[[], CheckResult], ...] = (
+    check_macos,
+    check_architecture,
+    check_runtime,
+    # Resolve credentials before touching the driver so a missing login fails fast.
+    check_api_key,
+    check_driver_app,
+    check_driver_binary,
+    check_driver_contract,
+    check_daemon_identity,
+    check_permissions,
+    check_gui_session,
+)
+
 
 def checks_for() -> tuple[Callable[[], CheckResult], ...]:
     return _PLATFORM_CHECKS + _ENVIRONMENT_CHECKS
@@ -574,9 +594,16 @@ def run_checks() -> list[CheckResult]:
 
 
 def first_blocker() -> CheckResult | None:
-    for check in checks_for():
+    """Return the first safety blocker without running diagnostic-only probes.
+
+    ``run_checks()`` remains the exhaustive readiness audit used by
+    ``computer-use doctor``, including capture/overlay warnings and the synthetic
+    API completion. A real run needs only the cheap local gates here; its first
+    model request is the authoritative API-access check.
+    """
+    for check in _RUN_BLOCKING_CHECKS:
         result = check()
-        if not result.ok and result.blocking:
+        if not result.ok:
             return result
     return None
 

--- a/src/yutori_mcp/computer_use/result.py
+++ b/src/yutori_mcp/computer_use/result.py
@@ -248,7 +248,7 @@ class Terminal:
         return "  " + self(label.ljust(_LABEL_WIDTH), "dim") + value
 
 
-def _clock(ms: Any) -> str:
+def format_duration(ms: Any) -> str:
     """A duration scaled for reading: milliseconds under a second, minutes past sixty."""
     if not isinstance(ms, (int, float)):
         return "?"
@@ -258,6 +258,28 @@ def _clock(ms: Any) -> str:
     if seconds < 60:
         return f"{seconds:.1f}s"
     return f"{int(seconds // 60)}m {seconds % 60:04.1f}s"
+
+
+_STARTUP_PHASE_LABELS = {
+    "api_client": "API client ready",
+    "computer": "computer session ready",
+    "target": "target application ready",
+    "model": "first model request started",
+}
+
+
+def format_startup_line(event: dict[str, Any], *, app: str | None = None) -> str:
+    """Render one runner startup checkpoint with phase and cumulative timing."""
+    phase = str(event.get("phase") or "startup")
+    label = _STARTUP_PHASE_LABELS.get(phase, phase.replace("_", " "))
+    if phase == "target" and app:
+        label = f"{app} ready"
+    timings = []
+    if event.get("duration_ms") is not None:
+        timings.append(format_duration(event["duration_ms"]))
+    if event.get("elapsed_ms") is not None:
+        timings.append(f"at {format_duration(event['elapsed_ms'])}")
+    return label + (f"  {' | '.join(timings)}" if timings else "")
 
 
 def format_terminal_action(event: dict[str, Any], paint: Terminal) -> list[str]:
@@ -280,9 +302,9 @@ def format_terminal_action(event: dict[str, Any], paint: Terminal) -> list[str]:
         line += " " + paint("[fronted]", "yellow")
     if event.get("run_in_background"):
         line += " " + paint("[background]", "yellow")
-    timings = [_clock(event["duration_ms"])] if event.get("duration_ms") is not None else []
+    timings = [format_duration(event["duration_ms"])] if event.get("duration_ms") is not None else []
     if event.get("elapsed_ms") is not None:
-        timings.append(f"at {_clock(event['elapsed_ms'])}")
+        timings.append(f"at {format_duration(event['elapsed_ms'])}")
     if timings:
         line += "  " + paint(f" {paint.glyph('separator')} ".join(timings), "dim")
     lines = [line]
@@ -317,7 +339,7 @@ def format_terminal_result(
     glyph, color = _OUTCOME_STYLES.get(outcome, ("bullet", "yellow"))
     facts = []
     if result.get("elapsed_ms") is not None:
-        facts.append(_clock(result["elapsed_ms"]))
+        facts.append(format_duration(result["elapsed_ms"]))
     if isinstance(result.get("steps"), int):
         facts.append(f"{result['steps']} model turns")
     facts.append(str(result.get("delivery_mode") or DELIVERY_MODE_FOREGROUND))

--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -462,6 +462,45 @@ class ApiCounter:
         self.calls += 1
 
 
+class StartupReporter:
+    """Emit the milestones before the run's first model request.
+
+    Durations are per phase and ``elapsed_ms`` is cumulative from
+    ``run_request()``. The first API callback closes startup; limit summaries
+    and later model turns therefore do not emit duplicate milestones.
+    """
+
+    def __init__(
+        self,
+        emitter: Emitter,
+        run_start: float,
+        *,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._emitter = emitter
+        self._run_start = run_start
+        self._phase_start = run_start
+        self._clock = clock
+        self._model_started = False
+
+    def mark(self, phase: str) -> None:
+        now = self._clock()
+        self._emitter.emit(
+            {
+                "type": "startup",
+                "phase": phase,
+                "duration_ms": max(0, round((now - self._phase_start) * 1000)),
+                "elapsed_ms": max(0, round((now - self._run_start) * 1000)),
+            }
+        )
+        self._phase_start = now
+
+    async def on_api_start(self, _kwargs: dict[str, Any]) -> None:
+        if not self._model_started:
+            self._model_started = True
+            self.mark("model")
+
+
 class ChatTracker:
     """Remember the platform's identity for this run: the first model call's request_id.
 
@@ -881,6 +920,7 @@ async def run_request(
     guard = RunGuard(request["max_steps"], deadline)
     chat = ChatTracker()
     api_counter = ApiCounter()
+    startup = StartupReporter(emitter, run_start)
     computer = MacOSComputer(
         **_computer_kwargs(
             request,
@@ -900,28 +940,42 @@ async def run_request(
     outcome = "failed"
     final_text: str | None = None
     try:
-        await computer.__aenter__()
-        if request["app"]:
-            if not background:
-                # Consume the pre-launch frame captured during session startup so
-                # the first model observation is guaranteed to show the target.
-                # (Window scope captures nothing until a window is bound.)
-                await computer.screenshot()
-            target = await prepare_app(computer, request["app"], request["start_url"], front=not background)
-            computer.target_pid = target["pid"]
-            if background:
-                await _bind_window_target(computer, target)
-
-            async def recover_target() -> int | None:
-                recovered = await prepare_app(computer, request["app"], request["start_url"], front=not background)
-                if background:
-                    await _bind_window_target(computer, recovered)
-                return recovered["pid"]
-
-            computer.recover_target = recover_target
-
         async with AsyncYutoriClient(api_key=api_key, base_url=request["api_base_url"]) as client:
             completions = client.chat.completions
+            # AsyncOpenAI constructs its HTTP/SSL client synchronously. Do that
+            # before the desktop session and overlay take control rather than
+            # making the user wait for it after the target app is ready.
+            startup.mark("api_client")
+            await computer.__aenter__()
+            startup.mark("computer")
+            if request["app"]:
+                # A mutating launch/front call invalidates MacOSComputer's cached
+                # pre-launch frame, so there is no need to encode and discard it
+                # before preparing the target.
+                target = await prepare_app(
+                    computer,
+                    request["app"],
+                    request["start_url"],
+                    front=not background,
+                )
+                computer.target_pid = target["pid"]
+                if background:
+                    await _bind_window_target(computer, target)
+                startup.mark("target")
+
+                async def recover_target() -> int | None:
+                    recovered = await prepare_app(
+                        computer,
+                        request["app"],
+                        request["start_url"],
+                        front=not background,
+                    )
+                    if background:
+                        await _bind_window_target(computer, recovered)
+                    return recovered["pid"]
+
+                computer.recover_target = recover_target
+
             async with N2ComputerAgent(
                 **_agent_base_kwargs(
                     request,
@@ -929,7 +983,7 @@ async def run_request(
                     computer=computer,
                     deadline=deadline,
                 ),
-                callbacks=[guard, reporter, api_counter, chat],
+                callbacks=[guard, reporter, api_counter, chat, startup],
             ) as agent:
                 final_text = await _collect_final_text(agent, request["task"])
                 if guard.limit_reached or guard.deadline_reached:

--- a/src/yutori_mcp/computer_use/supervisor.py
+++ b/src/yutori_mcp/computer_use/supervisor.py
@@ -243,6 +243,12 @@ def _event_shape_error(event: dict[str, Any]) -> str | None:
             "route": str,
             "refusal_code": (str, type(None)),
         }
+    elif event_type == "startup":
+        required = {
+            "phase": str,
+            "duration_ms": int,
+            "elapsed_ms": int,
+        }
     elif event_type == "result":
         required = {
             "outcome": str,
@@ -326,10 +332,11 @@ async def _supervise(
             event_type = event.get("type")
             if shape_error := _event_shape_error(event):
                 return protocol_failure(f"emitted malformed {event_type!r} event: {shape_error}.")
-            if event_type == "action":
+            if event_type in {"action", "startup"}:
                 if not ready:
-                    return protocol_failure("emitted an action before ready.")
-                actions.append(event)
+                    return protocol_failure(f"emitted {event_type} before ready.")
+                if event_type == "action":
+                    actions.append(event)
                 if notifier is not None:
                     notifier.submit(event)
             elif event_type == "ready":

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -612,12 +612,16 @@ def _progress_reporter(
     is not an upper bound for it. The human-readable message carries the model-turn
     budget instead.
     """
-    from .computer_use.result import describe_delivery_surface, format_action_line
+    from .computer_use.result import describe_delivery_surface, format_action_line, format_startup_line
 
     async def on_event(event: dict[str, Any]) -> None:
         if event.get("type") == "ready":
             surface = describe_delivery_surface(mode, app)
             message = f"Computer-use runner ready; driving {surface} (up to {max_steps} model turns)."
+            await asyncio.gather(ctx.report_progress(progress=0, message=message), ctx.info(message))
+            return
+        if event.get("type") == "startup":
+            message = "Computer-use startup: " + format_startup_line(event, app=app)
             await asyncio.gather(ctx.report_progress(progress=0, message=message), ctx.info(message))
             return
         index = event.get("index", 0)

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -52,7 +52,9 @@ from yutori_mcp.computer_use.result import (
     FINAL_OUTPUT_HEADING,
     Terminal,
     failure,
+    format_duration,
     format_result,
+    format_startup_line,
     format_terminal_action,
     format_terminal_result,
     redact,
@@ -342,6 +344,17 @@ def _action_event(**overrides):
     return event
 
 
+def _startup_event(**overrides):
+    event = {
+        "type": "startup",
+        "phase": "computer",
+        "duration_ms": 250,
+        "elapsed_ms": 300,
+    }
+    event.update(overrides)
+    return event
+
+
 async def _run_supervised(process, *, api_key="yt-key", deadline_seconds=1, **supervise_kwargs):
     """Patch the child process and call `_supervise` with the shared fixed args this file's tests repeat.
 
@@ -433,6 +446,7 @@ async def test_supervisor_redacts_key_and_keeps_it_out_of_argv():
 async def test_supervisor_forwards_ready_and_action_events():
     events = [
         _ready_event(reasoning_overlay_requested=True),
+        _startup_event(),
         _action_event(index=1, tool="computer_batch", elapsed_ms=42),
         _result_event(),
     ]
@@ -443,8 +457,8 @@ async def test_supervisor_forwards_ready_and_action_events():
         seen.append(event)
 
     result = await _run_supervised(process, on_event=on_event)
-    assert [event["type"] for event in seen] == ["ready", "action"]
-    assert result["actions"] == [events[1]]
+    assert [event["type"] for event in seen] == ["ready", "startup", "action"]
+    assert result["actions"] == [events[2]]
 
 
 async def test_supervisor_does_not_let_a_blocked_progress_callback_stall_protocol_drain(monkeypatch):
@@ -539,6 +553,7 @@ async def test_supervisor_rejects_runner_provenance_drift():
             "delivery_mode": "foreground",
             "route": "pixel",
         },
+        {"type": "startup", "phase": "computer"},
         {"type": "result", "outcome": "completed"},
     ],
 )
@@ -1053,15 +1068,32 @@ def test_gui_session_checks_machine_lock_state(monkeypatch, lock_value, ok, deta
     assert result.detail == detail
 
 
-def test_first_blocker_skips_warnings(monkeypatch):
-    def warning():
-        return preflight.CheckResult("overlay", False, "missing", "setup", blocking=False)
+def test_first_blocker_uses_only_the_live_run_safety_checks(monkeypatch):
+    calls = []
+
+    def ok():
+        calls.append("ok")
+        return preflight.CheckResult("runtime", True, "ready")
 
     def blocker():
+        calls.append("blocker")
         return preflight.CheckResult("driver", False, "missing", "setup")
 
-    monkeypatch.setattr(preflight, "checks_for", lambda: (warning, blocker))
+    def never():
+        raise AssertionError("checks after the first blocker must not run")
+
+    monkeypatch.setattr(preflight, "_RUN_BLOCKING_CHECKS", (ok, blocker, never))
     assert preflight.first_blocker().name == "driver"
+    assert calls == ["ok", "blocker"]
+
+
+def test_live_run_preflight_leaves_diagnostic_and_synthetic_api_probes_to_doctor():
+    live_checks = set(preflight._RUN_BLOCKING_CHECKS)
+    assert preflight.check_capture not in live_checks
+    assert preflight.check_compiler not in live_checks
+    assert preflight.check_overlay not in live_checks
+    assert preflight.check_api_access not in live_checks
+    assert live_checks.issubset(set(preflight.checks_for()))
 
 
 def test_doctor_labels_nonblocking_failures_as_warnings(monkeypatch, capsys):
@@ -1618,6 +1650,22 @@ class _CollectStream:
         pass
 
 
+async def test_startup_reporter_emits_each_phase_and_only_the_first_model_request():
+    stream = _CollectStream()
+    clock = iter((10.1, 10.5, 11.0)).__next__
+    reporter = runner_module.StartupReporter(Emitter(stream), 10.0, clock=clock)
+
+    reporter.mark("api_client")
+    reporter.mark("computer")
+    await reporter.on_api_start({})
+    await reporter.on_api_start({})
+
+    events = [json.loads(line) for line in stream.lines]
+    assert [event["phase"] for event in events] == ["api_client", "computer", "model"]
+    assert [event["duration_ms"] for event in events] == [100, 400, 500]
+    assert [event["elapsed_ms"] for event in events] == [100, 500, 1000]
+
+
 def test_runner_main_unexpected_failure_preserves_the_requested_background_mode(monkeypatch):
     stream = _CollectStream()
 
@@ -1852,6 +1900,8 @@ async def test_run_request_wires_sdk_runtime_and_reports_effective_state(monkeyp
     assert "Never ask them to give you a password" in agent.kwargs["system_prompt"]
     assert "Do not install software or packages" in agent.kwargs["system_prompt"]
     assert computer.closed
+    startup_events = [json.loads(line) for line in stream.lines if json.loads(line)["type"] == "startup"]
+    assert [event["phase"] for event in startup_events] == ["api_client", "computer", "model"]
     result = json.loads(stream.lines[-1])
     assert result["final_text"] == "Done"
     assert result["reasoning_overlay_requested"] is True
@@ -2227,6 +2277,21 @@ async def test_progress_reporter_delivers_progress_and_log_notifications_concurr
     assert "12 model turns" in progress_call["message"]
 
 
+async def test_progress_reporter_formats_startup_phases_without_action_fields():
+    from yutori_mcp import server
+
+    ctx = SimpleNamespace(report_progress=AsyncMock(), info=AsyncMock())
+    on_event = server._progress_reporter(ctx, 12, mode="background", app="Notes")
+
+    await on_event(_startup_event(phase="target"))
+
+    ctx.report_progress.assert_awaited_once_with(
+        progress=0,
+        message="Computer-use startup: Notes ready  250ms | at 300ms",
+    )
+    ctx.info.assert_awaited_once_with("Computer-use startup: Notes ready  250ms | at 300ms")
+
+
 async def test_server_early_failures_preserve_the_requested_background_mode(monkeypatch, tmp_path):
     from yutori_mcp import server
     from yutori_mcp.computer_use import lock as lock_module
@@ -2310,6 +2375,7 @@ async def test_cli_run_forwards_the_mode_and_prints_the_matching_notice(monkeypa
     assert run.await_args.kwargs["allow_local_shell"] is False
     assert run.await_args.kwargs["platform_url"] == "https://platform.yutori.com"
     out = capsys.readouterr().out
+    assert "preflight ready" in out
     assert cli.hands_off_notice("background") in out
     assert "completed" in out and "background" in out
     with pytest.raises(ValidationError, match="requires app"):
@@ -2482,6 +2548,8 @@ async def test_run_request_background_binds_the_window_and_never_fronts(monkeypa
     assert result["window_rebinds"] == 1 and result["focus_guard_trips"] == 0
     assert result["preview_frames"] == 0
     assert result["window_target"] == {"pid": 42, "window_id": 7, "app_name": "Notes"}
+    startup_events = [json.loads(line) for line in stream.lines if json.loads(line)["type"] == "startup"]
+    assert [event["phase"] for event in startup_events] == ["api_client", "computer", "target", "model"]
     action = next(json.loads(line) for line in stream.lines if json.loads(line)["type"] == "action")
     assert action["delivery_mode"] == "background" and action["route"] == "pixel"
     assert action["effect"] is None and action["escalated"] is False
@@ -2492,7 +2560,7 @@ async def test_run_request_background_binds_the_window_and_never_fronts(monkeypa
     assert computer.window_targets[-1] == _FakeWindowTarget(43, 9, app_name="Notes")
 
 
-async def test_run_request_foreground_still_consumes_the_prelaunch_frame_and_fronts(monkeypatch):
+async def test_run_request_foreground_does_not_encode_the_invalidated_prelaunch_frame(monkeypatch):
     _FakeComputer.instances.clear()
     prepared = AsyncMock(return_value={"name": "Notes", "pid": 42, "window_id": 7})
     _patch_runner_sdk(monkeypatch)
@@ -2503,12 +2571,25 @@ async def test_run_request_foreground_still_consumes_the_prelaunch_frame_and_fro
     assert await runner_module.run_request(request, Emitter(stream), "yt-secret") == "completed"
 
     computer = _FakeComputer.instances[-1]
-    assert computer.screenshots == 1
+    assert computer.screenshots == 0
     assert prepared.await_args.kwargs == {"front": True}
     assert computer.window_targets == []
     result = json.loads(stream.lines[-1])
     assert result["delivery_mode"] == "foreground" and result["window_target"] is None
     assert result["fallback_escalations"] == 0 and result["background_refusals"] == 0
+
+
+async def test_pinned_sdk_launch_invalidates_its_cached_prelaunch_frame():
+    from yutori.navigator.macos import MacOSComputer
+
+    transport = SimpleNamespace(
+        call_tool=AsyncMock(return_value={"structuredContent": {"name": "Notes", "pid": 42}})
+    )
+    computer = MacOSComputer(transport=transport, owns_transport=False, presentation=False)
+    computer._initial_png = b"stale desktop"
+
+    assert await computer.launch_app(name="Notes") == {"name": "Notes", "pid": 42}
+    assert computer._initial_png is None
 
 
 async def test_run_request_background_without_sdk_support_fails_before_touching_the_desktop(monkeypatch):
@@ -3051,6 +3132,28 @@ def test_cli_run_header_states_the_task_target_and_limits():
     assert f"version   yutori-mcp {MCP_VERSION}  |  yutori {SDK_VERSION}" in text
     assert "limits    foreground  |  5 min  |  60 model turns" in text
     assert cli.hands_off_notice("foreground") in text
+
+
+async def test_cli_startup_printer_shows_phase_and_cumulative_timers(capsys):
+    from yutori_mcp.computer_use import cli
+
+    clock = iter((10.25, 10.5)).__next__
+    printer = cli._event_printer("foreground", "Safari", _PLAIN_TERMINAL, started_at=10.0, clock=clock)
+
+    await printer(_ready_event())
+    await printer(_startup_event(phase="target", duration_ms=120))
+
+    output = capsys.readouterr().out
+    assert "runner process ready  250ms" in output
+    assert "Safari ready  120ms | at 500ms" in output
+
+
+def test_startup_timing_formatter_scales_durations_and_names_phases():
+    assert format_duration(85) == "85ms"
+    assert format_duration(1_250) == "1.2s"
+    assert format_startup_line(_startup_event(phase="target"), app="Notes") == (
+        "Notes ready  250ms | at 300ms"
+    )
 
 
 async def test_progress_reporter_folds_the_batch_detail_into_one_message():


### PR DESCRIPTION
This reduces live-run preflight latency by keeping expensive diagnostic-only capture, overlay, compiler, and synthetic API probes in computer-use doctor. It adds structured startup events and CLI/MCP timing output for preflight, runner launch, API-client setup, computer-session setup, target preparation, and the first model request. It also initializes the API client before desktop takeover and removes a redundant pre-launch screenshot that the SDK invalidates during target preparation. Validation: 474 tests passed with 1 skipped on Python 3.10 and 3.14, with Ruff and diff checks passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Preflight no longer blocks on synthetic API access or capture probes before runs, so some failures surface on the first model call instead of upfront; startup ordering changes touch the critical run path.
> 
> **Overview**
> **Faster path to the first model turn** by narrowing live-run preflight to safety-only checks (`_RUN_BLOCKING_CHECKS`); capture, overlay, compiler, and synthetic API probes stay on `computer-use doctor`. The first real completion is treated as the API-access check.
> 
> **Visible startup timing** via new runner `startup` protocol events (API client, computer session, target app, first model request), with shared `format_duration` / `format_startup_line` in the CLI (`preflight ready`, phased bullets) and MCP progress notifications. README documents the new output.
> 
> **Runner startup reordering**: `AsyncYutoriClient` is constructed before the desktop session; the redundant foreground pre-launch screenshot before `prepare_app` is removed because launch/front invalidates the cached frame.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20228311eae40d40d9a4ea01cb13c24642930535. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->