### PR TITLE
chore(release): 0.5.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.19"
+version = "0.5.20"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1386,7 +1386,7 @@ wheels = [
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.19"
+version = "0.5.20"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
Bumps yutori-mcp from 0.5.19 to 0.5.20 and updates the lockfile package metadata. This release includes the experimental iPhone Mirroring workflow, startup latency reductions and timing telemetry, and the latest input-probe refactor already merged to main. Validation: 474 tests passed with 1 skipped on both Python 3.10 and 3.14, and the lockfile and diff checks pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only version and lockfile sync with no runtime code changes in this PR.
> 
> **Overview**
> **Release version bump** from `0.5.19` to `0.5.20` in `pyproject.toml`, with matching `yutori-mcp` package version metadata in `uv.lock`. No application or dependency changes appear in this diff—only the published package version and lockfile entry are updated for the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3d0c0e8e25311edb7c7c7d7cfdc318596fb5e0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->