### PR TITLE
refactor(computer-use): consolidate the elapsed-ms formula and CLI milestone print

### DIFF
--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -39,6 +39,7 @@ from .preflight import (
 from .result import (
     Terminal,
     describe_delivery_surface,
+    elapsed_ms_since,
     format_duration,
     format_startup_line,
     format_runtime_version,
@@ -209,6 +210,14 @@ def hands_off_notice(mode: str) -> str:
     return "The model takes over this Mac's desktop now; do not touch it during the run."
 
 
+def _print_milestone(
+    paint: Terminal, label: str, start: float, *, clock: Callable[[], float] = time.monotonic
+) -> None:
+    """One green "<label>  <duration since start>" line, this file's style for a reached milestone."""
+    duration = paint(format_duration(elapsed_ms_since(start, clock=clock)), "dim")
+    print(f"{paint(paint.glyph('bullet'), 'green')} {label}  {duration}", flush=True)
+
+
 def _event_printer(
     mode: str,
     app: str | None,
@@ -223,12 +232,7 @@ def _event_printer(
 
     async def print_event(event: dict) -> None:
         if event.get("type") == "ready":
-            elapsed_ms = max(0, round((clock() - started_at) * 1000))
-            print(
-                f"{paint(paint.glyph('bullet'), 'green')} runner process ready"
-                f"  {paint(format_duration(elapsed_ms), 'dim')}",
-                flush=True,
-            )
+            _print_milestone(paint, "runner process ready", started_at, clock=clock)
             return
         if event.get("type") == "startup":
             observed = {**event, "elapsed_ms": max(0, round((clock() - started_at) * 1000))}
@@ -282,12 +286,7 @@ async def _run_custom(args: argparse.Namespace) -> int:
     preflight_started = time.monotonic()
     if _blocked():
         return 1
-    preflight_ms = max(0, round((time.monotonic() - preflight_started) * 1000))
-    print(
-        f"{paint(paint.glyph('bullet'), 'green')} preflight ready"
-        f"  {paint(format_duration(preflight_ms), 'dim')}",
-        flush=True,
-    )
+    _print_milestone(paint, "preflight ready", preflight_started)
     print(format_run_header(params, paint))
     runner_started = time.monotonic()
     result = await run_task_with_resolved_credentials(

--- a/src/yutori_mcp/computer_use/result.py
+++ b/src/yutori_mcp/computer_use/result.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import sys
 import time
+from collections.abc import Callable
 from typing import Any, TextIO
 
 from .constants import DELIVERY_MODE_BACKGROUND, DELIVERY_MODE_FOREGROUND, MCP_VERSION, SDK_VERSION
@@ -42,6 +43,17 @@ def remaining_seconds(deadline: float) -> float:
     if remaining <= 0:
         raise asyncio.TimeoutError
     return remaining
+
+
+def elapsed_ms_since(start: float, *, clock: Callable[[], float] = time.monotonic) -> int:
+    """Milliseconds elapsed since ``start`` (a ``time.monotonic()`` value), floor-clamped at zero.
+
+    Shared by the runner's per-action and per-run timing (``ActionReporter``, the final
+    ``elapsed_ms`` in ``run_request``) and the CLI's own "ready" milestone prints, so both
+    sides of the runner/CLI boundary compute a duration the same way. Named to avoid
+    colliding with the ``elapsed_ms`` variable/dict-key name most callers use for its result.
+    """
+    return max(0, round((clock() - start) * 1000))
 
 
 def _seconds(ms: Any) -> str:

--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -38,7 +38,7 @@ from .constants import (
     SDK_VERSION,
     TOOL_SET,
 )
-from .result import redact, remaining_seconds
+from .result import elapsed_ms_since, redact, remaining_seconds
 from .targeting import TargetGuardedMacOSComputer as MacOSComputer
 
 _FOREGROUND_OPENING = "You control the entire macOS screen. "
@@ -374,11 +374,6 @@ def _background_task_id(outputs: list[dict[str, Any]] | None) -> str | None:
     return None
 
 
-def _elapsed_ms(start: float, *, clock: Callable[[], float] = time.monotonic) -> int:
-    """Milliseconds elapsed since `start`, floor-clamped at zero."""
-    return max(0, round((clock() - start) * 1000))
-
-
 class ActionReporter:
     """Emit one privacy-safe action event for each attempted top-level tool call."""
 
@@ -419,7 +414,7 @@ class ActionReporter:
     def _emit(self, item: dict[str, Any], raw_status: str, result: list[dict[str, Any]]) -> None:
         duration_ms = None
         if self._call_start is not None:
-            duration_ms = _elapsed_ms(self._call_start, clock=self._clock)
+            duration_ms = elapsed_ms_since(self._call_start, clock=self._clock)
         self._call_start = None
         self._pending_item = None
         arguments = _arguments(item)
@@ -439,7 +434,7 @@ class ActionReporter:
                 "refusal_code": delivery.get("refusal_code") or ("driver_refused" if raw_status == "refused" else None),
                 "effect": delivery.get("effect"),
                 "escalated": bool(delivery.get("escalated")),
-                "elapsed_ms": _elapsed_ms(self._run_start, clock=self._clock),
+                "elapsed_ms": elapsed_ms_since(self._run_start, clock=self._clock),
                 "duration_ms": duration_ms,
                 "command": shell_command_preview(item),
                 "details": batch_action_previews(item),
@@ -1016,7 +1011,7 @@ async def run_request(
                 final_text = _redacted_error_text(error, api_key)
 
     reporter.flush_interrupted()
-    elapsed_ms = _elapsed_ms(run_start)
+    elapsed_ms = elapsed_ms_since(run_start)
     emitter.emit(
         {
             **_result_event(outcome, final_text, mode),


### PR DESCRIPTION
## The structural issue

`perf(computer-use): expose and reduce startup latency` (#293), merged today, introduced two small pieces of duplication in the same files it touched:

1. **The elapsed-ms formula, `max(0, round((now - start) * 1000))`, existed in two places.** `runner.py` already had a named private helper for it, `_elapsed_ms(start, *, clock=...)`, used at 3 call sites (`ActionReporter._emit`'s `duration_ms`/`elapsed_ms`, and `run_request`'s final `elapsed_ms`). #293 added `StartupReporter.mark()`, which inlines the identical formula again rather than reusing that helper (kept as-is here — it computes both `duration_ms` and `elapsed_ms` from one captured `now`, a single 2-line in-method shape not worth disturbing). More importantly, #293's `cli.py` changes reimplemented the same formula a *third* time, inline, at two separate print sites — `_event_printer`'s "ready" handler and `_run_custom`'s new "preflight ready" line — neither of which could reach `runner.py`'s private helper (it's underscore-prefixed and `cli.py`/`runner.py` don't import from each other; they both already import shared protocol/formatting helpers from `result.py`).
2. **The "green bullet + label + dim duration" milestone print** in `cli.py` was hand-written twice, byte-for-byte identical in shape, for "runner process ready" and "preflight ready" — the same two call sites from (1).

## Why this is an improvement

- Moves the elapsed-ms formula into `result.py` as `elapsed_ms_since()` — the module `runner.py` and `cli.py` already both import for exactly this kind of cross-boundary helper (`redact`, `remaining_seconds`, `format_duration` all live there for the same reason). `runner.py`'s 3 call sites and `cli.py`'s 2 call sites now share one definition instead of three.
- Extracts `_print_milestone()` in `cli.py` for the repeated print block, so the two call sites can't drift in formatting.
- **Naming note:** the new function is `elapsed_ms_since()`, not `elapsed_ms()`. `elapsed_ms` is already the local variable/dict-key name holding the result at every call site (including in `runner.py`, where `elapsed_ms = _elapsed_ms(run_start)` — literally the pattern this repo's own refactor backlog flagged as a shadowing hazard for a different function name today). Importing a same-named function would silently shadow it in module scope.

## Why this is safe

- Pure consolidation, no behavior change: `elapsed_ms_since()` is character-for-character the same formula as the old `_elapsed_ms()`; `_print_milestone()` produces the exact same string as the two inlined print blocks it replaces (verified against `test_cli_startup_printer_shows_phase_and_cumulative_timers` and `test_cli_run_forwards_the_mode_and_prints_the_matching_notice`, which assert the literal output substrings).
- 3 files touched (`result.py`, `runner.py`, `cli.py`), no call-site signature changes outside the touched functions, no test changes needed.
- `uv run --extra dev pytest -q` → 474 passed, 1 skipped (matches `main` exactly).
- `uv run ruff check .` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YSvSZY7338x8ztt9v5HXfX

---
_Generated by [Claude Code](https://claude.ai/code/session_01YSvSZY7338x8ztt9v5HXfX)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor of timing and terminal output only; no protocol, auth, or runtime logic changes.
> 
> **Overview**
> This refactor deduplicates computer-use timing and CLI output without changing behavior.
> 
> **Shared timing:** The `max(0, round((clock - start) * 1000))` logic moves from private `runner._elapsed_ms` into public `elapsed_ms_since()` in `result.py` (alongside `remaining_seconds` and `format_duration`). The runner’s action/run timing and the CLI milestone durations now call that helper. The name avoids shadowing local `elapsed_ms` variables.
> 
> **CLI milestones:** `_print_milestone()` centralizes the green-bullet + label + dim duration lines used for “preflight ready” and “runner process ready”, replacing two copy-pasted print blocks.
> 
> Startup-phase events in `_event_printer` still compute `elapsed_ms` inline for `format_startup_line`; `StartupReporter.mark()` in the runner is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eddad2c2946075a0155f3604ffdafde2dba2521f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->