### PR TITLE
feat(computer-use): recordable overlay switch, yutori 0.9.19, release 0.5.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.20"
+version = "0.5.21"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"
@@ -34,7 +34,7 @@ dependencies = [
     # mouse, so a click there reaches the app behind it instead of the
     # transcript, and only the grip strip (drag, close) takes the mouse; model
     # input on that grip is refused the way input on the Stop item is.
-    "yutori==0.9.18",
+    "yutori==0.9.19",
 ]
 
 [project.optional-dependencies]

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -26,6 +26,12 @@ OBSERVATION_FORMAT = "webp"
 DELIVERY_MODE_FOREGROUND = "foreground"
 DELIVERY_MODE_BACKGROUND = "background"
 DELIVERY_MODES = (DELIVERY_MODE_FOREGROUND, DELIVERY_MODE_BACKGROUND)
+# Set to "1" to keep the overlay in screen recordings and screen shares of a foreground run
+# (demos). The SDK then takes the model's frames through the overlay host with its own windows
+# filtered out (`exclude_overlay_from_capture=False`); by default the overlay opts out of screen
+# capture altogether, which also hides it from recorders. Read by the runner; the supervisor
+# forwards it to the runner's environment.
+ENV_RECORDABLE_OVERLAY = "YUTORI_RECORDABLE_OVERLAY"
 SDK_VERSION = "0.9.18"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -32,11 +32,11 @@ DELIVERY_MODES = (DELIVERY_MODE_FOREGROUND, DELIVERY_MODE_BACKGROUND)
 # capture altogether, which also hides it from recorders. Read by the runner; the supervisor
 # forwards it to the runner's environment.
 ENV_RECORDABLE_OVERLAY = "YUTORI_RECORDABLE_OVERLAY"
-SDK_VERSION = "0.9.18"
+SDK_VERSION = "0.9.19"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.
-SDK_ARTIFACT_SHA256 = "5c5e7b12b6671a4a8bf14f833635017e2429811e1ba3e5a6f28e756361fa4882"
-SDK_INSTALLATION_SHA256 = "814cc248c631c90966fab16237c2c59c2cc8485b4220817ee31b8c828b25f838"
+SDK_ARTIFACT_SHA256 = "30d6b51398788fc74cee83732b2608440b8ab5779fae57b727d8bc858bcdd556"
+SDK_INSTALLATION_SHA256 = "6848a2c28aabfc4ea97c51affee9f223a17985b1cee32d3e7e6200d6e067fa9f"
 SDK_PROVENANCE_SHA256 = "7cab595d2f00e1a9ab5cd121204fbd6dd4c24163ead3eb76f76eef7fba495fc4"
 
 # The cua-driver release that implements this tool contract, and the checksum

--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -27,10 +27,11 @@ from yutori.navigator.macos import (
 
 from .app import prepare_app
 from .constants import (
+    DELIVERY_MODES,
     DELIVERY_MODE_BACKGROUND,
     DELIVERY_MODE_FOREGROUND,
-    DELIVERY_MODES,
     DRIVER_VERSION,
+    ENV_RECORDABLE_OVERLAY,
     OBSERVATION_FORMAT,
     PROTOCOL_VERSION,
     SDK_ARTIFACT_SHA256,
@@ -745,6 +746,8 @@ def _computer_kwargs(
             scope="window",
             allow_foreground_fallback=request["allow_foreground_fallback"],
         )
+    elif os.environ.get(ENV_RECORDABLE_OVERLAY) == "1":
+        kwargs["exclude_overlay_from_capture"] = False
     return kwargs
 
 

--- a/src/yutori_mcp/computer_use/supervisor.py
+++ b/src/yutori_mcp/computer_use/supervisor.py
@@ -15,9 +15,10 @@ from pathlib import Path
 from typing import Any
 
 from .constants import (
-    DELIVERY_MODE_FOREGROUND,
     DELIVERY_MODES,
+    DELIVERY_MODE_FOREGROUND,
     DRIVER_VERSION,
+    ENV_RECORDABLE_OVERLAY,
     MCP_VERSION,
     MODEL,
     PROTOCOL_VERSION,
@@ -182,7 +183,7 @@ def _child_environment(api_key: str) -> dict[str, str]:
         "YUTORI_API_KEY": api_key,
         "PATH": child_search_path(),
     }
-    for name in ("HOME", "TMPDIR", "LANG", "LC_ALL"):
+    for name in ("HOME", "TMPDIR", "LANG", "LC_ALL", ENV_RECORDABLE_OVERLAY):
         if value := os.environ.get(name):
             env[name] = value
     return env

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -871,9 +871,9 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 
 def test_runtime_constants_select_latest_python_surface():
     assert TOOL_SET == "computer_use_tools-20260830"
-    assert SDK_VERSION == "0.9.18"
+    assert SDK_VERSION == "0.9.19"
     assert all(len(digest) == 64 for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256))
-    assert '"yutori==0.9.18"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
+    assert '"yutori==0.9.19"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
 
 
 def test_installed_sdk_matches_the_published_artifact():

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -2464,6 +2464,30 @@ def test_computer_kwargs_keep_the_foreground_shape_and_add_window_scope_for_back
     }
 
 
+def test_computer_kwargs_keep_a_recordable_overlay_only_for_foreground_runs(monkeypatch):
+    monkeypatch.setenv(runner_module.ENV_RECORDABLE_OVERLAY, "1")
+    foreground = runner_module._computer_kwargs(
+        parse_request(_valid_request()), deadline=1.0, cancellation=object(), api_key="k"
+    )
+    assert foreground["exclude_overlay_from_capture"] is False
+    # Window scope shows no full-screen overlay; nothing to keep in a recording.
+    background = runner_module._computer_kwargs(
+        parse_request(_valid_request(app="Notes", mode="background")), deadline=1.0, cancellation=object(), api_key="k"
+    )
+    assert "exclude_overlay_from_capture" not in background
+    monkeypatch.setenv(runner_module.ENV_RECORDABLE_OVERLAY, "true")
+    assert "exclude_overlay_from_capture" not in runner_module._computer_kwargs(
+        parse_request(_valid_request()), deadline=1.0, cancellation=object(), api_key="k"
+    )
+
+
+def test_child_environment_forwards_the_recordable_overlay_switch(monkeypatch):
+    monkeypatch.delenv(runner_module.ENV_RECORDABLE_OVERLAY, raising=False)
+    assert runner_module.ENV_RECORDABLE_OVERLAY not in supervisor._child_environment("k")
+    monkeypatch.setenv(runner_module.ENV_RECORDABLE_OVERLAY, "1")
+    assert supervisor._child_environment("k")[runner_module.ENV_RECORDABLE_OVERLAY] == "1"
+
+
 def test_computer_kwargs_can_disable_local_shell():
     request = parse_request(_valid_request(app="iPhone Mirroring", mode="background", allow_local_shell=False))
     kwargs = runner_module._computer_kwargs(request, deadline=1.0, cancellation=object(), api_key="k")

--- a/uv.lock
+++ b/uv.lock
@@ -1370,7 +1370,7 @@ wheels = [
 
 [[package]]
 name = "yutori"
-version = "0.9.18"
+version = "0.9.19"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1379,14 +1379,14 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/3e/c9f924eb6f5ed2eb1f7ff09ac0a20378590d54e16d5695407207a3c1acac/yutori-0.9.18.tar.gz", hash = "sha256:edd45d93f9598eb90257c7249b466c15d4dc6d97a55a84d770f6807a563ba30a", size = 473450, upload-time = "2026-09-09T08:12:17.057Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/88/ca1dfe15836c1d8eabd5d93368cc55ba6495be72390668e3ec7651bc1de3/yutori-0.9.19.tar.gz", hash = "sha256:6f970c1e73717920b2392df30c41bc0766a002cb11c9c5e7baf505e94e2517f3", size = 477083, upload-time = "2026-09-09T21:46:25.076Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/0f/49de6bf50dbf64779ba6702e3f432feff135cedb07e1701e29c1f59894d5/yutori-0.9.18-py3-none-any.whl", hash = "sha256:5c5e7b12b6671a4a8bf14f833635017e2429811e1ba3e5a6f28e756361fa4882", size = 331052, upload-time = "2026-09-09T08:12:15.446Z" },
+    { url = "https://files.pythonhosted.org/packages/57/82/b3c0aa1af08c223eab88dbe7d3a79615c69ad5389e07d69f4bb9171a19e1/yutori-0.9.19-py3-none-any.whl", hash = "sha256:30d6b51398788fc74cee83732b2608440b8ab5779fae57b727d8bc858bcdd556", size = 333746, upload-time = "2026-09-09T21:46:23.407Z" },
 ]
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.20"
+version = "0.5.21"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -1406,6 +1406,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "yutori", specifier = "==0.9.18" },
+    { name = "yutori", specifier = "==0.9.19" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
## What

- **`YUTORI_RECORDABLE_OVERLAY=1`** keeps the reasoning overlay in screen recordings and screen shares of a foreground run. The runner passes `exclude_overlay_from_capture=False`; the supervisor forwards the variable to the runner's environment. Window scope ignores it (no full-screen overlay there).
- **yutori 0.9.19** (SDK [#416](https://github.com/yutori-ai/yutori-sdk-python/pull/416)): with that flag the overlay stays capturable and the model's desktop frames come from the overlay host's own ScreenCaptureKit capture with the host's windows filtered out, verified by the existing start-of-session probe. No hide/reveal fade. Default runs are unchanged (`sharingType = .none`).
- **0.5.21**: version bump, `SDK_ARTIFACT_SHA256` / `SDK_INSTALLATION_SHA256` recomputed from a registry install (provenance digest unchanged, driver pin unchanged), uv.lock moved.

## Verified

- `pytest` with `YUTORI_MCP_VERIFY_PUBLISHED_ARTIFACT=1`: 478 passed, 1 skipped, including the installed-SDK digest check against the published wheel.
- Live on this Mac with the worktree SDK: overlay present in `screencapture -x` and absent from the model's frames, screenshots ~0.2 s per capture; a run with the flag showed no pointer fade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Opt-in env flag with default behavior unchanged; main risk is SDK pin and digest alignment for installs, covered by existing preflight and tests.
> 
> **Overview**
> **Release 0.5.21** bumps the pinned **yutori SDK to 0.9.19** (with updated wheel/installation digests and `uv.lock`) and adds an opt-in demo/recording path for foreground computer-use runs.
> 
> Setting **`YUTORI_RECORDABLE_OVERLAY=1`** keeps the reasoning overlay visible in screen recordings and shares. The runner passes `exclude_overlay_from_capture=False` to `MacOSComputer` only for **foreground** runs when the value is exactly `"1"`; background window scope is unchanged. The supervisor forwards the variable into the isolated runner child via `_child_environment`.
> 
> Tests lock in the foreground-only kwargs behavior, strict `"1"` parsing, and env forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 071c99d42ba52a38dfec27daac38a4ce18e55e98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->