### PR TITLE
feat(computer-use): make the recordable overlay the default for foreground runs

### DIFF
--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -26,11 +26,12 @@ OBSERVATION_FORMAT = "webp"
 DELIVERY_MODE_FOREGROUND = "foreground"
 DELIVERY_MODE_BACKGROUND = "background"
 DELIVERY_MODES = (DELIVERY_MODE_FOREGROUND, DELIVERY_MODE_BACKGROUND)
-# Set to "1" to keep the overlay in screen recordings and screen shares of a foreground run
-# (demos). The SDK then takes the model's frames through the overlay host with its own windows
-# filtered out (`exclude_overlay_from_capture=False`); by default the overlay opts out of screen
-# capture altogether, which also hides it from recorders. Read by the runner; the supervisor
-# forwards it to the runner's environment.
+# Foreground runs keep the overlay in screen recordings and screen shares by default: the SDK
+# takes the model's frames through the overlay host with its own windows filtered out
+# (`exclude_overlay_from_capture=False`), so the model never sees it and nothing fades around a
+# capture. Set to "0" to make the overlay opt out of screen capture altogether instead, which
+# also hides it from recorders. Read by the runner; the supervisor forwards it to the runner's
+# environment.
 ENV_RECORDABLE_OVERLAY = "YUTORI_RECORDABLE_OVERLAY"
 SDK_VERSION = "0.9.19"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.

--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -746,8 +746,8 @@ def _computer_kwargs(
             scope="window",
             allow_foreground_fallback=request["allow_foreground_fallback"],
         )
-    elif os.environ.get(ENV_RECORDABLE_OVERLAY) == "1":
-        kwargs["exclude_overlay_from_capture"] = False
+    else:
+        kwargs["exclude_overlay_from_capture"] = os.environ.get(ENV_RECORDABLE_OVERLAY) == "0"
     return kwargs
 
 

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -1886,6 +1886,7 @@ async def test_run_request_wires_sdk_runtime_and_reports_effective_state(monkeyp
         "execution_deadline": pytest.approx(computer.kwargs["execution_deadline"]),
         "cancellation": computer.kwargs["cancellation"],
         "known_secrets": ("yt-secret",),
+        "exclude_overlay_from_capture": False,
     }
     assert agent.kwargs["tool_set"] == TOOL_SET
     assert agent.kwargs["presentation"] is computer.presentation
@@ -2439,18 +2440,22 @@ def test_parse_request_accepts_background_with_app():
     assert parse_request(_valid_request())["mode"] == "foreground"
 
 
-def test_computer_kwargs_keep_the_foreground_shape_and_add_window_scope_for_background():
+def test_computer_kwargs_keep_the_foreground_shape_and_add_window_scope_for_background(monkeypatch):
+    monkeypatch.delenv(runner_module.ENV_RECORDABLE_OVERLAY, raising=False)
     cancellation = object()
-    foreground = runner_module._computer_kwargs(
-        parse_request(_valid_request()), deadline=1.0, cancellation=cancellation, api_key="k"
-    )
-    assert foreground == {
+    shared = {
         "presentation": True,
         "allow_local_shell": True,
         "execution_deadline": 1.0,
         "cancellation": cancellation,
         "known_secrets": ("k",),
     }
+    foreground = runner_module._computer_kwargs(
+        parse_request(_valid_request()), deadline=1.0, cancellation=cancellation, api_key="k"
+    )
+    # Recordable by default: the overlay stays in screen recordings, the SDK keeps it out of the
+    # model's frames on the capturer's side.
+    assert foreground == {**shared, "exclude_overlay_from_capture": False}
     background = runner_module._computer_kwargs(
         parse_request(_valid_request(app="Notes", mode="background", allow_foreground_fallback=True)),
         deadline=1.0,
@@ -2458,34 +2463,37 @@ def test_computer_kwargs_keep_the_foreground_shape_and_add_window_scope_for_back
         api_key="k",
     )
     assert background == {
-        **foreground,
+        **shared,
         "scope": "window",
         "allow_foreground_fallback": True,
     }
 
 
-def test_computer_kwargs_keep_a_recordable_overlay_only_for_foreground_runs(monkeypatch):
-    monkeypatch.setenv(runner_module.ENV_RECORDABLE_OVERLAY, "1")
-    foreground = runner_module._computer_kwargs(
-        parse_request(_valid_request()), deadline=1.0, cancellation=object(), api_key="k"
-    )
-    assert foreground["exclude_overlay_from_capture"] is False
-    # Window scope shows no full-screen overlay; nothing to keep in a recording.
+def test_computer_kwargs_recordable_overlay_switch(monkeypatch):
+    def foreground():
+        return runner_module._computer_kwargs(
+            parse_request(_valid_request()), deadline=1.0, cancellation=object(), api_key="k"
+        )
+
+    # "0" opts out: the overlay leaves screen capture altogether (and recordings with it).
+    monkeypatch.setenv(runner_module.ENV_RECORDABLE_OVERLAY, "0")
+    assert foreground()["exclude_overlay_from_capture"] is True
+    # Anything else keeps the default.
+    for value in ("1", "true", ""):
+        monkeypatch.setenv(runner_module.ENV_RECORDABLE_OVERLAY, value)
+        assert foreground()["exclude_overlay_from_capture"] is False
+    # Window scope shows no full-screen overlay; the switch does not apply.
     background = runner_module._computer_kwargs(
         parse_request(_valid_request(app="Notes", mode="background")), deadline=1.0, cancellation=object(), api_key="k"
     )
     assert "exclude_overlay_from_capture" not in background
-    monkeypatch.setenv(runner_module.ENV_RECORDABLE_OVERLAY, "true")
-    assert "exclude_overlay_from_capture" not in runner_module._computer_kwargs(
-        parse_request(_valid_request()), deadline=1.0, cancellation=object(), api_key="k"
-    )
 
 
 def test_child_environment_forwards_the_recordable_overlay_switch(monkeypatch):
     monkeypatch.delenv(runner_module.ENV_RECORDABLE_OVERLAY, raising=False)
     assert runner_module.ENV_RECORDABLE_OVERLAY not in supervisor._child_environment("k")
-    monkeypatch.setenv(runner_module.ENV_RECORDABLE_OVERLAY, "1")
-    assert supervisor._child_environment("k")[runner_module.ENV_RECORDABLE_OVERLAY] == "1"
+    monkeypatch.setenv(runner_module.ENV_RECORDABLE_OVERLAY, "0")
+    assert supervisor._child_environment("k")[runner_module.ENV_RECORDABLE_OVERLAY] == "0"
 
 
 def test_computer_kwargs_can_disable_local_shell():


### PR DESCRIPTION
Replaces #297, which GitHub closed when its stacked base branch was deleted.

## What

Foreground runs now keep the reasoning overlay in screen recordings and screen shares by default. With yutori 0.9.19 the model still never sees it: the overlay host takes the model's desktop frames itself with its own windows filtered out (verified by the start-of-session probe), so there is no hide/reveal fade either.

`YUTORI_RECORDABLE_OVERLAY=0` opts out and restores the previous behaviour, where the overlay opts out of screen capture altogether (`sharingType = .none`) and is invisible to recorders too. Window scope is unaffected (no full-screen overlay).

## Fallback

On a Mac where the host's filtered capture fails or leaks the probe, the SDK falls back to the driver's capture with the overlay hidden around each frame (the old fade) and reports it in the presentation telemetry (`capture_exclusion`, `capture_source`). Default runs never lose overlay exclusion from the model's frames.

## Tests

`pytest`: 476 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default desktop capture/overlay behavior for all foreground runs; mis-set env or SDK capture fallback could affect demos vs. model observations, but scope is limited to overlay recording semantics.
> 
> **Overview**
> **Foreground computer-use runs now keep the reasoning overlay visible in screen recordings and shares by default**, while the SDK still excludes it from frames sent to the model (`exclude_overlay_from_capture=False` unless opted out).
> 
> The runner **always sets** `exclude_overlay_from_capture` for foreground mode (not only when an env var was `"1"`). **`YUTORI_RECORDABLE_OVERLAY=0`** restores the old behavior (overlay opts out of capture entirely). Background/window scope is unchanged and does not pass this flag.
> 
> Comments in `constants.py` and tests were updated to document the inverted opt-out semantics and assert the new default kwargs shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ed63b376f6cbe7a86876fdd3057659b608ecf84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->