### PR TITLE
chore(release): 0.5.22 with yutori 0.9.20

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.21"
+version = "0.5.22"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"
@@ -30,11 +30,9 @@ dependencies = [
     # breaks the install as soon as 2.x resolves.
     "mcp>=1.0.0,<2.0.0",
     "pydantic>=2.0.0",
-    # SDK 0.9.18 lets clicks through the activity window: its body ignores the
-    # mouse, so a click there reaches the app behind it instead of the
-    # transcript, and only the grip strip (drag, close) takes the mouse; model
-    # input on that grip is refused the way input on the Stop item is.
-    "yutori==0.9.19",
+    # SDK 0.9.20 bundles the protocol-v4 navigator overlay from yutori#13269
+    # and presents terminal commands beside the cursor capsule.
+    "yutori==0.9.20",
 ]
 
 [project.optional-dependencies]

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -33,12 +33,12 @@ DELIVERY_MODES = (DELIVERY_MODE_FOREGROUND, DELIVERY_MODE_BACKGROUND)
 # also hides it from recorders. Read by the runner; the supervisor forwards it to the runner's
 # environment.
 ENV_RECORDABLE_OVERLAY = "YUTORI_RECORDABLE_OVERLAY"
-SDK_VERSION = "0.9.19"
+SDK_VERSION = "0.9.20"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.
-SDK_ARTIFACT_SHA256 = "30d6b51398788fc74cee83732b2608440b8ab5779fae57b727d8bc858bcdd556"
-SDK_INSTALLATION_SHA256 = "6848a2c28aabfc4ea97c51affee9f223a17985b1cee32d3e7e6200d6e067fa9f"
-SDK_PROVENANCE_SHA256 = "7cab595d2f00e1a9ab5cd121204fbd6dd4c24163ead3eb76f76eef7fba495fc4"
+SDK_ARTIFACT_SHA256 = "e267c85de2cfa0aae8c044b0629a50c2d0781b0d0f44eb400c9d300cf833d92c"
+SDK_INSTALLATION_SHA256 = "b5c8e019c8a4c7c6564f3833870d941af8c37d4fb35465bd67ebd7b14adc6cab"
+SDK_PROVENANCE_SHA256 = "cacc3ed5af3d6c5c8daeef60be4aa63e0af25b1d51770ef54d6a8f9db6811cee"
 
 # The cua-driver release that implements this tool contract, and the checksum
 # of its installer script. Both are hard gates.

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -871,9 +871,9 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 
 def test_runtime_constants_select_latest_python_surface():
     assert TOOL_SET == "computer_use_tools-20260830"
-    assert SDK_VERSION == "0.9.19"
+    assert SDK_VERSION == "0.9.20"
     assert all(len(digest) == 64 for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256))
-    assert '"yutori==0.9.19"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
+    assert '"yutori==0.9.20"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
 
 
 def test_installed_sdk_matches_the_published_artifact():

--- a/uv.lock
+++ b/uv.lock
@@ -260,7 +260,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -294,8 +294,8 @@ name = "httpcore2"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
-    { name = "truststore", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "h11" },
+    { name = "truststore" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
@@ -1359,8 +1359,8 @@ name = "uvicorn"
 version = "0.52.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
-    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "click" },
+    { name = "h11" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
@@ -1370,7 +1370,7 @@ wheels = [
 
 [[package]]
 name = "yutori"
-version = "0.9.19"
+version = "0.9.20"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1379,14 +1379,14 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b3/88/ca1dfe15836c1d8eabd5d93368cc55ba6495be72390668e3ec7651bc1de3/yutori-0.9.19.tar.gz", hash = "sha256:6f970c1e73717920b2392df30c41bc0766a002cb11c9c5e7baf505e94e2517f3", size = 477083, upload-time = "2026-09-09T21:46:25.076Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/9d/04700b36c39a1cb25a96e22d92dcf282b388e37d588ce8481c338ca86af7/yutori-0.9.20.tar.gz", hash = "sha256:7f000163813b676c8440c2d1895188f0902891a5b0bebe6a12394f7fdfb62e52", size = 482885, upload-time = "2026-09-09T23:46:58.34Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/57/82/b3c0aa1af08c223eab88dbe7d3a79615c69ad5389e07d69f4bb9171a19e1/yutori-0.9.19-py3-none-any.whl", hash = "sha256:30d6b51398788fc74cee83732b2608440b8ab5779fae57b727d8bc858bcdd556", size = 333746, upload-time = "2026-09-09T21:46:23.407Z" },
+    { url = "https://files.pythonhosted.org/packages/76/62/b97c90bfbb29ea2eafa6f7567dbc54049803bbcc7445a2c8428b7e70f712/yutori-0.9.20-py3-none-any.whl", hash = "sha256:e267c85de2cfa0aae8c044b0629a50c2d0781b0d0f44eb400c9d300cf833d92c", size = 337983, upload-time = "2026-09-09T23:46:56.404Z" },
 ]
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.21"
+version = "0.5.22"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -1406,6 +1406,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "yutori", specifier = "==0.9.19" },
+    { name = "yutori", specifier = "==0.9.20" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
## What

- Bumps `yutori-mcp` to `0.5.22`.
- Pins `yutori==0.9.20`, which bundles `yutori-navigator-overlay-runtime==0.5.0` from yutori-ai/yutori#13269 and integrates the cursor-attached terminal command overlay from yutori-ai/yutori-sdk-python#418.
- Updates the wheel, installed-distribution, and runtime provenance integrity hashes from the exact published SDK artifact.
- Refreshes `uv.lock`.

## Verified

- `YUTORI_MCP_VERIFY_PUBLISHED_ARTIFACT=1 uv run --extra dev pytest -q`: 477 passed.
- `uv build`
- `uvx twine check dist/*`
- Published SDK wheel hash matches its GitHub release provenance and PyPI metadata.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version pin and integrity-hash updates only; runtime behavior changes come from the upstream SDK overlay release, not new MCP logic.
> 
> **Overview**
> Releases **yutori-mcp 0.5.22** by pinning **`yutori==0.9.20`** (replacing 0.9.19) and aligning `SDK_VERSION` plus artifact/installation/provenance SHA256 digests in computer-use constants so doctor/preflight still hard-gate the exact published wheel.
> 
> The `pyproject.toml` dependency comment now notes SDK 0.9.20’s protocol-v4 navigator overlay and cursor-adjacent terminal command UI; tests that assert the pinned SDK string and `uv.lock` are updated accordingly (including incidental lockfile dependency marker simplifications).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2b46e8858cef50b3ec3dd6bb2c579719e7cd804. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->