### PR TITLE
refactor(computer-use): finish routing the startup event's elapsed_ms through elapsed_ms_since()

### DIFF
--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -235,7 +235,7 @@ def _event_printer(
             _print_milestone(paint, "runner process ready", started_at, clock=clock)
             return
         if event.get("type") == "startup":
-            observed = {**event, "elapsed_ms": max(0, round((clock() - started_at) * 1000))}
+            observed = {**event, "elapsed_ms": elapsed_ms_since(started_at, clock=clock)}
             line = format_startup_line(observed, app=app)
             if event.get("phase") == "computer" and app is None:
                 line = line.replace("computer session ready", f"ready to drive {surface}", 1)


### PR DESCRIPTION
## What
Yesterday's #295 extracted `elapsed_ms_since()` into `result.py` to consolidate the `max(0, round((now - start) * 1000))` duration formula, and routed the CLI's "runner process ready" and "preflight ready" milestone prints through it. It missed one more inline copy of the exact same formula: `computer_use/cli.py::_event_printer`'s `"startup"` event branch still computed `max(0, round((clock() - started_at) * 1000))` by hand.

This PR routes that last remaining call site through the already-extracted `elapsed_ms_since()` helper, so the formula has exactly one implementation across the runner/CLI boundary instead of two.

## Why it's safe
- **No behavior change**: same single `clock()` read per event, same formula, same output. Verified against the existing iterator-based fake-clock test (`test_cli_startup_printer_shows_phase_and_cumulative_timers`), which asserts exact millisecond values and would fail on any extra/missing `clock()` call.
- **No tool-contract changes**: this is internal CLI console-output plumbing, not part of any MCP tool schema.
- Considered (and rejected) generalizing the sibling duplicate in `runner.py::StartupReporter.mark()` too — it computes `duration_ms`/`elapsed_ms` from one shared `now = self._clock()` snapshot, so routing both through `elapsed_ms_since()` would call `self._clock()` twice instead of once, which breaks `test_startup_reporter_emits_each_phase_and_only_the_first_model_request`'s one-shot iterator clock. Left it as its own single-read formula rather than force a mismatched abstraction.

## Verification
- `uv run --extra dev pytest -q` → 476 passed / 1 skipped (matches documented baseline).
- `uv run ruff check .` → clean.
- `uv run ruff format --check src/yutori_mcp/computer_use/cli.py` still flags this file, but that's pre-existing on `main` before this change (confirmed via `git stash`) — the repo has no `[tool.ruff]` config or CI lint/format gate, matching prior audits' conclusion that this isn't actionable here.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyTFq6DbUvMn1wSy9Bgms8

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyTFq6DbUvMn1wSy9Bgms8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal CLI formatting refactor with identical timing semantics; no MCP contracts or auth/data paths touched.
> 
> **Overview**
> Completes consolidation of startup timing math in the computer-use CLI by replacing the last hand-rolled `max(0, round((clock() - started_at) * 1000))` in `_event_printer`'s `"startup"` branch with the shared **`elapsed_ms_since()`** helper from `result.py` (introduced in #295 for other milestone paths).
> 
> **No user-visible change** — same single `clock()` read per event and the same millisecond values on the console; this only removes duplicate formula code at the runner/CLI boundary.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 28f351bccfcdef401b8994ef2522e7212d5cd2fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->