### PR TITLE
refactor(computer-use): route StartupReporter.mark() through elapsed_ms_since()

### DIFF
--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -480,13 +480,17 @@ class StartupReporter:
         self._model_started = False
 
     def mark(self, phase: str) -> None:
+        # One real clock() read, frozen behind a `lambda: now` clock for both
+        # elapsed_ms_since() calls: this is the same duration formula PR #295/#300
+        # already consolidated for the CLI's milestone prints and ActionReporter,
+        # left inline here since #293 introduced it before that cleanup landed.
         now = self._clock()
         self._emitter.emit(
             {
                 "type": "startup",
                 "phase": phase,
-                "duration_ms": max(0, round((now - self._phase_start) * 1000)),
-                "elapsed_ms": max(0, round((now - self._run_start) * 1000)),
+                "duration_ms": elapsed_ms_since(self._phase_start, clock=lambda: now),
+                "elapsed_ms": elapsed_ms_since(self._run_start, clock=lambda: now),
             }
         )
         self._phase_start = now


### PR DESCRIPTION
@juanpin PR #295 extracted `elapsed_ms_since()` into `result.py` and routed the CLI milestone prints and `ActionReporter`'s per-action timings through it, but `StartupReporter.mark()` (introduced by perf(computer-use) PR #293) still carried its own two inline copies of the identical `max(0, round((now - start) * 1000))` formula for `duration_ms` and `elapsed_ms`. #300 closed a similar gap left in `cli.py`'s `_event_printer`; this closes the last one in `runner.py`, so the formula now has exactly one implementation across the module.

`mark()` reads the clock once per call and freezes it behind a `lambda: now` clock argument for both `elapsed_ms_since()` calls, rather than letting `elapsed_ms_since()` re-read the real clock twice. This preserves both existing invariants:
- the single `clock()` read per `mark()` call that `test_startup_reporter_emits_each_phase_and_only_the_first_model_request` pins with a 3-value fake-clock iterator (one value per `mark()` call) — reusing `elapsed_ms_since()` naively (each call reading the real clock) would have doubled that to 6 reads and broken the test
- `duration_ms`/`elapsed_ms` being computed from the exact same instant rather than two independent `monotonic()` reads a few nanoseconds apart

No behavior change: full suite passes unmodified (476 passed, 1 pre-existing skip), including the fake-clock `StartupReporter` test asserting the literal `duration_ms`/`elapsed_ms` sequence byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVBN51EQUugFhBPpMfAVvq)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal timing refactor with no intended behavior change; startup event payloads should remain byte-identical per existing tests.
> 
> **Overview**
> **StartupReporter** startup milestone timings now use the shared `elapsed_ms_since()` helper instead of duplicating the `max(0, round((now - start) * 1000))` logic in `mark()`.
> 
> `mark()` still performs **one** `clock()` read per call and passes `lambda: now` into both `elapsed_ms_since()` invocations so `duration_ms` and `elapsed_ms` share the same instant and fake-clock tests keep their expected read count—matching the pattern already used for CLI milestones and `ActionReporter`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c307e6ab8cac573206390c8e5a9882c66263986. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->