### PR TITLE
docs(README): document YUTORI_RECORDABLE_OVERLAY foreground default

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,11 @@ working; leave that window alone. Some apps accept background clicks but not typ
 (Calculator, for one), and the run reports the refusal rather than typing blind — add
 `--allow-foreground-fallback` for typing-heavy background tasks.
 
+During a foreground run, the overlay (cursor, click pulses, shell rail, activity window) stays
+visible in screen recordings, screen shares, and VNC by default — only the model's own frames
+exclude it. Set `YUTORI_RECORDABLE_OVERLAY=0` to make the overlay leave screen capture
+altogether instead, hidden from recorders around every capture as before.
+
 `uvx yutori-mcp computer-use stop` ends the active run from another terminal (background runs
 have no on-screen Stop button). `uvx yutori-mcp computer-use smoke` is an end-to-end check: it
 types into Calculator to confirm the permissions took effect, then has the agent compute 9 * 9.


### PR DESCRIPTION
## Summary

PR #298 (merged 2026-09-09) made the computer-use overlay recordable by default during foreground runs: it now stays visible in screen recordings, screen shares, and VNC unless `YUTORI_RECORDABLE_OVERLAY=0` is set to opt back into the previous hide-from-capture behavior.

That PR added the env var and default to `constants.py`/`runner.py` with test coverage in `tests/test_computer_use.py`, but `README.md`'s "macOS computer use" section — which already documents the analogous `NO_COLOR`/`FORCE_COLOR` env-var toggles inline — never mentioned it, so the documented behavior drifted from what actually ships.

## What changed

- Added a short paragraph to `README.md` right after the Foreground/Background description, documenting the new default and the `YUTORI_RECORDABLE_OVERLAY=0` opt-out.

No code changes; documentation only, aligned to the existing shipped behavior.

## Test plan

- [x] Confirmed `ENV_RECORDABLE_OVERLAY` / default behavior by reading `src/yutori_mcp/computer_use/constants.py` and `runner.py::_computer_kwargs`
- [x] Doc-only change; no build/test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L273y4xYCyc3LrBJhKTGQd

---
_Generated by [Claude Code](https://claude.ai/code/session_01L273y4xYCyc3LrBJhKTGQd)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only change with no code or configuration impact.
> 
> **Overview**
> Adds a short paragraph to the **macOS computer use** section of `README.md`, right after the foreground/background explanation.
> 
> It documents that during **foreground** runs the on-screen overlay (cursor, click pulses, shell rail, activity window) is **visible in screen recordings, shares, and VNC by default**, while frames sent to the model still exclude it. It also documents **`YUTORI_RECORDABLE_OVERLAY=0`** to restore the older behavior where the overlay is hidden from capture entirely.
> 
> **Documentation only** — no runtime changes; aligns the README with behavior already shipped in `runner.py` / `constants.py`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54561f371be70b43710e0155c4b1969c272716bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->