### PR TITLE
feat(computer-use): embedded driver host mode and a JSON CLI surface

### DIFF
--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import argparse
 import asyncio
 import hashlib
+import json
 import os
 import subprocess
 import tempfile
 import time
 import uuid
 from collections.abc import Callable
+from dataclasses import asdict
 from pathlib import Path
 from typing import Any
 from urllib.request import urlopen
@@ -32,6 +34,7 @@ from .preflight import (
     check_driver_binary,
     check_runtime,
     child_search_path,
+    embedded_driver_host,
     find_cua_driver,
     first_blocker,
     run_checks,
@@ -49,8 +52,17 @@ from .result import (
 from .supervisor import run_task_with_resolved_credentials, stop_active_run
 
 
-def _doctor() -> int:
+def _json_line(payload: dict[str, Any]) -> None:
+    """One machine-readable stdout line; the `--json` surface a host application consumes."""
+    print(json.dumps(payload, separators=(",", ":")), flush=True)
+
+
+def _doctor(*, json_output: bool = False) -> int:
     results = run_checks()
+    ok = all(result.ok or not result.blocking for result in results)
+    if json_output:
+        _json_line({"type": "doctor", "ok": ok, "checks": [asdict(result) for result in results]})
+        return 0 if ok else 1
     for result in results:
         label = "PASS"
         if not result.ok:
@@ -58,7 +70,7 @@ def _doctor() -> int:
         print(f"{label} {result.name}: {result.detail}")
         if result.remediation:
             print(f"  Fix: {result.remediation}")
-    return 0 if all(result.ok or not result.blocking for result in results) else 1
+    return 0 if ok else 1
 
 
 def _download_installer(url: str) -> bytes:
@@ -71,6 +83,16 @@ def _setup() -> int:
     if not runtime.ok:
         print(runtime.remediation)
         return 1
+    try:
+        embedded = embedded_driver_host()
+    except ValueError as error:
+        print(error)
+        return 1
+    if embedded is not None:
+        # The host application ships the driver and owns permissions; installing the standalone
+        # CuaDriver.app here would create the second permission identity embedding exists to avoid.
+        print(f"Embedded cua-driver host configured ({embedded.binary}); nothing to install.")
+        return _doctor()
     version = DRIVER_VERSION
     installer = _download_installer(
         f"https://github.com/trycua/cua/releases/download/cua-driver-rs-v{version}/install.sh"
@@ -109,12 +131,15 @@ def _setup() -> int:
     return _doctor()
 
 
-def _blocked() -> bool:
+def _blocked(*, json_output: bool = False) -> bool:
     """Print and return True if a blocking preflight check fails; False if ready to run."""
     blocker = first_blocker()
     if blocker is None:
         return False
-    print(blocker_message(blocker))
+    if json_output:
+        _json_line({"type": "blocked", **asdict(blocker)})
+    else:
+        print(blocker_message(blocker))
     return True
 
 
@@ -246,6 +271,15 @@ def _event_printer(
     return print_event
 
 
+def _json_event_printer():
+    """Relay every runner event verbatim as one JSON line, for a host that renders progress itself."""
+
+    async def print_event(event: dict) -> None:
+        _json_line(event)
+
+    return print_event
+
+
 def format_run_header(params: ComputerUseTaskInput, paint: Terminal) -> str:
     """The block a `run` opens with: what was asked, where it lands, and the limits."""
     target = params.app or "the visible desktop"
@@ -282,15 +316,26 @@ async def _run_custom(args: argparse.Namespace) -> int:
         allow_foreground_fallback=args.allow_foreground_fallback,
         allow_local_shell=args.allow_local_shell,
     )
+    json_output = bool(getattr(args, "json", False))
+    show_stop_button = not getattr(args, "hide_stop_item", False)
     paint = Terminal.detect()
     preflight_started = time.monotonic()
-    if _blocked():
+    if _blocked(json_output=json_output):
         return 1
+    if json_output:
+        result = await run_task_with_resolved_credentials(
+            **params.model_dump(),
+            show_stop_button=show_stop_button,
+            on_event=_json_event_printer(),
+        )
+        _json_line({"type": "result", **result})
+        return 0 if result.get("outcome") == "completed" else 1
     _print_milestone(paint, "preflight ready", preflight_started)
     print(format_run_header(params, paint))
     runner_started = time.monotonic()
     result = await run_task_with_resolved_credentials(
         **params.model_dump(),
+        show_stop_button=show_stop_button,
         on_event=_event_printer(params.mode, params.app, paint, started_at=runner_started),
     )
     return _report(result, include_actions=False)
@@ -315,8 +360,8 @@ def _dispatch_setup(_args: argparse.Namespace | None) -> int:
     return _setup()
 
 
-def _dispatch_doctor(_args: argparse.Namespace | None) -> int:
-    return _doctor()
+def _dispatch_doctor(args: argparse.Namespace | None) -> int:
+    return _doctor(json_output=bool(args is not None and getattr(args, "json", False)))
 
 
 def _dispatch_smoke(_args: argparse.Namespace | None) -> int:
@@ -351,10 +396,21 @@ def register_parser(
 ) -> None:
     parser = subparsers.add_parser("computer-use", help="Set up, diagnose, and run macOS computer use")
     commands = parser.add_subparsers(dest="computer_use_command", required=True)
+    json_help = "Emit JSON lines instead of terminal text, for a host application that renders progress itself"
     for name, (help_text, _) in _COMPUTER_USE_SUBCOMMANDS.items():
-        if name != "run":
-            commands.add_parser(name, help=help_text)
+        if name == "run":
+            continue
+        command = commands.add_parser(name, help=help_text)
+        if name == "doctor":
+            command.add_argument("--json", action="store_true", help=json_help)
     run_parser = commands.add_parser("run", help=_COMPUTER_USE_SUBCOMMANDS["run"][0])
+    run_parser.add_argument("--json", action="store_true", help=json_help)
+    run_parser.add_argument(
+        "--hide-stop-item",
+        dest="hide_stop_item",
+        action="store_true",
+        help="Do not show the SDK's menu bar Stop item; the host application provides its own (the hotkey stays active)",
+    )
     run_parser.add_argument("task", help="Task for the model to perform")
     run_parser.add_argument("--app", default=None, help="Application to target")
     run_parser.add_argument("--start-url", dest="start_url", default=None, help="URL to open in the app")

--- a/src/yutori_mcp/computer_use/preflight.py
+++ b/src/yutori_mcp/computer_use/preflight.py
@@ -609,6 +609,7 @@ def check_capture() -> CheckResult:
             _SETUP_REMEDIATION,
             blocking=False,
         )
+    embedded = _configured_embedded_host() is not None
     with tempfile.TemporaryDirectory(prefix="cua-capture-check-") as directory:
         # Under $TMPDIR, whose /var -> /private/var symlink the driver rejects as an unresolved
         # ancestor, so hand it a fully resolved path.
@@ -630,7 +631,7 @@ def check_capture() -> CheckResult:
                 "desktop capture",
                 False,
                 "driver capture failed",
-                _PERMISSIONS_GRANT_REMEDIATION,
+                _EMBEDDED_PERMISSIONS_REMEDIATION if embedded else _PERMISSIONS_GRANT_REMEDIATION,
                 blocking=False,
             )
         ok = target.is_file() and target.stat().st_size > 0
@@ -638,7 +639,11 @@ def check_capture() -> CheckResult:
         "desktop capture",
         ok,
         "driver captured the desktop" if ok else "driver produced no image",
-        "Allow Screen Recording for CuaDriver in System Settings.",
+        (
+            _EMBEDDED_PERMISSIONS_REMEDIATION
+            if embedded
+            else "Allow Screen Recording for CuaDriver in System Settings."
+        ),
         blocking=False,
     )
 

--- a/src/yutori_mcp/computer_use/preflight.py
+++ b/src/yutori_mcp/computer_use/preflight.py
@@ -6,9 +6,13 @@ import importlib.metadata
 import json
 import os
 import platform
+import queue
 import re
+import socket
 import subprocess
 import tempfile
+import threading
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -61,6 +65,54 @@ _SETUP_REMEDIATION = "Run: yutori-mcp computer-use setup"
 # Shared remediation text for checks whose fix is granting the driver's TCC permissions:
 # check_permissions and check_capture's driver-capture-failed branch both point here.
 _PERMISSIONS_GRANT_REMEDIATION = "Run: cua-driver permissions grant"
+# An application that embeds cua-driver (the driver's EMBEDDING contract) hands this runtime its
+# own binary and the private socket of the daemon it spawned. Both must be set together; the
+# runtime then never looks for /Applications/CuaDriver.app and permissions are read from the host
+# daemon, whose TCC identity is the host application's. Duplicated from the SDK's transport module
+# (which reads the same names) because this module must stay importable without the SDK.
+ENV_DRIVER_BINARY = "YUTORI_CUA_DRIVER_BINARY"
+ENV_DRIVER_SOCKET = "YUTORI_CUA_DRIVER_SOCKET"
+ENV_DRIVER_EMBEDDED = "CUA_DRIVER_EMBEDDED"
+_EMBEDDED_HOST_REMEDIATION = "Start the embedded cua-driver daemon from the host application, then retry."
+_EMBEDDED_PERMISSIONS_REMEDIATION = (
+    "Grant Accessibility and Screen Recording to the host application in "
+    "System Settings > Privacy & Security, then restart it."
+)
+_EMBEDDED_RPC_TIMEOUT_SECONDS = 15
+
+
+@dataclass(frozen=True)
+class EmbeddedDriverHost:
+    binary: Path
+    socket: Path
+
+
+def embedded_driver_host() -> EmbeddedDriverHost | None:
+    """The host-owned driver named by the environment, or None for the standalone CuaDriver.app.
+
+    Raises ValueError when only one of the two variables is set: half a configuration would
+    otherwise fall back silently to the standalone install and a second permission identity.
+    """
+    binary = os.environ.get(ENV_DRIVER_BINARY)
+    socket_path = os.environ.get(ENV_DRIVER_SOCKET)
+    if not binary and not socket_path:
+        return None
+    if not (binary and socket_path):
+        raise ValueError(f"{ENV_DRIVER_BINARY} and {ENV_DRIVER_SOCKET} must be set together.")
+    return EmbeddedDriverHost(Path(binary), Path(socket_path))
+
+
+def _configured_embedded_host() -> EmbeddedDriverHost | None:
+    """A fully configured embedded host, or None; the half-set case is check_driver_app's to report."""
+    try:
+        return embedded_driver_host()
+    except ValueError:
+        return None
+
+
+def _driver_socket_arguments() -> list[str]:
+    host = _configured_embedded_host()
+    return ["--socket", str(host.socket)] if host is not None else []
 
 
 def _login_remediation(environment: str) -> str:
@@ -76,6 +128,9 @@ def _api_access_remediation(environment: str) -> str:
 
 
 def find_cua_driver() -> Path | None:
+    host = _configured_embedded_host()
+    if host is not None:
+        return host.binary if host.binary.is_file() else None
     for path in DRIVER_PATHS:
         if path.is_file():
             return path
@@ -274,6 +329,17 @@ def check_overlay() -> CheckResult:
 
 
 def check_driver_app() -> CheckResult:
+    try:
+        host = embedded_driver_host()
+    except ValueError as error:
+        return _result("driver app", False, str(error), _EMBEDDED_HOST_REMEDIATION)
+    if host is not None:
+        return _result(
+            "driver app",
+            host.binary.is_file(),
+            f"embedded host binary {host.binary}",
+            _EMBEDDED_HOST_REMEDIATION,
+        )
     return _result(
         "driver app",
         DRIVER_APP.is_dir(),
@@ -341,7 +407,112 @@ def check_driver_contract() -> CheckResult:
     )
 
 
+def _socket_accepts_connections(path: Path) -> bool:
+    if not path.is_socket():
+        return False
+    with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+        client.settimeout(2)
+        try:
+            client.connect(str(path))
+        except OSError:
+            return False
+    return True
+
+
+def _read_rpc_result(stream: Any, request_id: int, timeout: float) -> dict[str, Any]:
+    """The ``result`` of the JSON-RPC response carrying ``request_id`` from a line stream.
+
+    A reader thread feeds lines into a queue so a proxy that never answers cannot hang the
+    preflight past ``timeout``; the daemon's log lines and unrelated responses are skipped.
+    """
+    lines: queue.Queue[str | None] = queue.Queue()
+
+    def pump() -> None:
+        for line in stream:
+            lines.put(line)
+        lines.put(None)
+
+    threading.Thread(target=pump, daemon=True).start()
+    deadline = time.monotonic() + timeout
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise RuntimeError(f"cua-driver proxy did not answer request {request_id} within {timeout:g}s")
+        try:
+            line = lines.get(timeout=remaining)
+        except queue.Empty:
+            continue
+        if line is None:
+            raise RuntimeError("cua-driver proxy closed its output before answering")
+        try:
+            message = json.loads(line)
+        except ValueError:
+            continue
+        if not isinstance(message, dict) or message.get("id") != request_id:
+            continue
+        if message.get("error"):
+            raise RuntimeError(f"cua-driver proxy error: {message['error']}")
+        result = message.get("result")
+        if not isinstance(result, dict):
+            raise RuntimeError("cua-driver proxy returned a non-object result")
+        return result
+
+
+def _embedded_permissions(host: EmbeddedDriverHost) -> dict[str, Any]:
+    """``check_permissions`` through the host daemon's MCP proxy.
+
+    ``cua-driver permissions status`` only knows the standalone daemon identity and reports
+    ``unknown`` for an embedded daemon, so the tool call is the one surface that reads the
+    grants the run will actually have: the daemon answers from inside the host's TCC chain.
+    """
+    messages = [
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "yutori-mcp-preflight", "version": MCP_VERSION},
+            },
+        },
+        {"jsonrpc": "2.0", "method": "notifications/initialized"},
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "check_permissions", "arguments": {"prompt": False}},
+        },
+    ]
+    process = subprocess.Popen(
+        [str(host.binary), "mcp", "--embedded", "--socket", str(host.socket)],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        env={**os.environ, ENV_DRIVER_EMBEDDED: "1"},
+    )
+    try:
+        assert process.stdin is not None and process.stdout is not None
+        process.stdin.write("".join(json.dumps(message, separators=(",", ":")) + "\n" for message in messages))
+        process.stdin.flush()
+        result = _read_rpc_result(process.stdout, request_id=2, timeout=_EMBEDDED_RPC_TIMEOUT_SECONDS)
+    finally:
+        process.kill()
+        process.wait(timeout=5)
+    structured = result.get("structuredContent") or result.get("structured_content") or {}
+    return structured if isinstance(structured, dict) else {}
+
+
 def check_daemon_identity() -> CheckResult:
+    host = _configured_embedded_host()
+    if host is not None:
+        return _result(
+            "daemon identity",
+            _socket_accepts_connections(host.socket),
+            f"embedded daemon at {host.socket}",
+            _EMBEDDED_HOST_REMEDIATION,
+        )
     result = _run_safely(["pgrep", "-f", "/Applications/CuaDriver.app/Contents/MacOS/"], timeout=10)
     return _result(
         "daemon identity",
@@ -352,6 +523,19 @@ def check_daemon_identity() -> CheckResult:
 
 
 def check_permissions() -> CheckResult:
+    host = _configured_embedded_host()
+    if host is not None:
+        try:
+            info = _embedded_permissions(host)
+            ok = bool(info.get("accessibility")) and bool(info.get("screen_recording"))
+        except (OSError, subprocess.SubprocessError, ValueError, RuntimeError):
+            ok = False
+        return _result(
+            "permissions",
+            ok,
+            "Accessibility and Screen Recording (host application)",
+            _EMBEDDED_PERMISSIONS_REMEDIATION,
+        )
     try:
         info = _driver_json("permissions")
         ok = bool(info.get("accessibility")) and bool(info.get("screen_recording"))
@@ -430,7 +614,14 @@ def check_capture() -> CheckResult:
         # ancestor, so hand it a fully resolved path.
         target = Path(directory).resolve() / "capture.png"
         result = _run_safely(
-            [str(driver), "call", "get_desktop_state", json.dumps({"screenshot_out_file": str(target)}), "--raw"],
+            [
+                str(driver),
+                "call",
+                "get_desktop_state",
+                json.dumps({"screenshot_out_file": str(target)}),
+                "--raw",
+                *_driver_socket_arguments(),
+            ],
             timeout=30,
             text=False,
         )

--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -215,6 +215,8 @@ def parse_request(payload: Any) -> dict[str, Any]:
         raise RequestError("INVALID_REQUEST", "allow_foreground_fallback requires mode 'background'.")
     deadline_ms = _require_positive_int(payload, "deadline_ms")
     max_steps = _require_positive_int(payload, "max_steps")
+    # Optional so a protocol-v2 supervisor that predates the field keeps the SDK's default.
+    show_stop_button = _require_bool(payload, "show_stop_button") if "show_stop_button" in payload else True
     return {
         "task": task,
         "app": app,
@@ -224,6 +226,7 @@ def parse_request(payload: Any) -> dict[str, Any]:
         "mode": mode,
         "allow_foreground_fallback": allow_foreground_fallback,
         "allow_local_shell": allow_local_shell,
+        "show_stop_button": show_stop_button,
         "model": _require_string(payload, "model"),
         "api_base_url": _require_string(payload, "api_base_url"),
     }
@@ -737,6 +740,7 @@ def _computer_kwargs(
     """MacOSComputer construction per mode; the foreground shape is the long-standing one."""
     kwargs: dict[str, Any] = {
         "presentation": True,
+        "show_stop_button": request.get("show_stop_button", True),
         "allow_local_shell": request["allow_local_shell"],
         "execution_deadline": deadline,
         "cancellation": cancellation,

--- a/src/yutori_mcp/computer_use/supervisor.py
+++ b/src/yutori_mcp/computer_use/supervisor.py
@@ -27,7 +27,13 @@ from .constants import (
     SDK_VERSION,
 )
 from .lock import ComputerUseBusyError, DesktopLock
-from .preflight import child_search_path, find_cua_driver
+from .preflight import (
+    ENV_DRIVER_BINARY,
+    ENV_DRIVER_EMBEDDED,
+    ENV_DRIVER_SOCKET,
+    child_search_path,
+    find_cua_driver,
+)
 from .result import failure, redact
 from .result import remaining_seconds as _remaining_seconds
 from .result import terminal_result
@@ -183,7 +189,21 @@ def _child_environment(api_key: str) -> dict[str, str]:
         "YUTORI_API_KEY": api_key,
         "PATH": child_search_path(),
     }
-    for name in ("HOME", "TMPDIR", "LANG", "LC_ALL", ENV_RECORDABLE_OVERLAY):
+    # The embedded-host variables let the SDK's transport attach to the host application's
+    # cua-driver daemon instead of the standalone CuaDriver.app; CUA_DRIVER_RS_HOME keeps that
+    # daemon's state where the host put it.
+    for name in (
+        "HOME",
+        "TMPDIR",
+        "LANG",
+        "LC_ALL",
+        ENV_RECORDABLE_OVERLAY,
+        ENV_DRIVER_BINARY,
+        ENV_DRIVER_SOCKET,
+        ENV_DRIVER_EMBEDDED,
+        "CUA_DRIVER_RS_HOME",
+        "CUA_DRIVER_HOST_BUNDLE_ID",
+    ):
         if value := os.environ.get(name):
             env[name] = value
     return env
@@ -426,9 +446,11 @@ def python_runner_command() -> list[str]:
     process is exactly the one that can run it. `-I` (isolated mode) keeps the
     child's sys.path free of the working directory, PYTHONPATH, and user
     site-packages, so no ambient directory can shadow the installed packages;
-    the venv's own site-packages still resolve.
+    the venv's own site-packages still resolve. `-B` never writes bytecode: an application
+    that bundles this runtime inside its signed bundle cannot have `__pycache__` directories
+    appear under its code-signature seal.
     """
-    return [sys.executable, "-I", "-m", "yutori_mcp.computer_use.runner"]
+    return [sys.executable, "-I", "-B", "-m", "yutori_mcp.computer_use.runner"]
 
 
 async def run_task(
@@ -444,6 +466,7 @@ async def run_task(
     mode: str = DELIVERY_MODE_FOREGROUND,
     allow_foreground_fallback: bool = False,
     allow_local_shell: bool = True,
+    show_stop_button: bool = True,
     lock: DesktopLock | None = None,
     on_event: EventCallback | None = None,
 ) -> dict[str, Any]:
@@ -462,6 +485,9 @@ async def run_task(
                 "mode": mode,
                 "allow_foreground_fallback": allow_foreground_fallback,
                 "allow_local_shell": allow_local_shell,
+                # False when the host application owns the menu bar surface (its own Stop item);
+                # the SDK's overlay hotkey stays registered either way.
+                "show_stop_button": show_stop_button,
                 "model": MODEL,
                 "api_base_url": api_base_url,
             }

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -3353,6 +3353,18 @@ def test_embedded_permissions_proxy_failure_blocks_instead_of_raising(monkeypatc
     assert not preflight.check_permissions().ok
 
 
+@pytest.mark.parametrize("capture_result", [None, subprocess.CompletedProcess([], 0)])
+def test_embedded_capture_failure_names_the_host_application(monkeypatch, tmp_path, capture_result):
+    _configure_embedded_host(monkeypatch, tmp_path)
+    monkeypatch.setattr(preflight, "_run_safely", lambda *_args, **_kwargs: capture_result)
+
+    result = preflight.check_capture()
+
+    assert not result.ok
+    assert result.remediation == preflight._EMBEDDED_PERMISSIONS_REMEDIATION
+    assert "CuaDriver" not in result.remediation
+
+
 def test_child_environment_forwards_the_embedded_host_configuration(monkeypatch, tmp_path):
     binary, sock = _configure_embedded_host(monkeypatch, tmp_path)
     monkeypatch.setenv(preflight.ENV_DRIVER_EMBEDDED, "1")

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -759,7 +759,7 @@ def test_runner_removes_api_key_before_spawning_a_real_shell(monkeypatch):
 
 
 def test_python_runner_is_isolated_and_has_no_node_path():
-    assert python_runner_command() == [sys.executable, "-I", "-m", "yutori_mcp.computer_use.runner"]
+    assert python_runner_command() == [sys.executable, "-I", "-B", "-m", "yutori_mcp.computer_use.runner"]
     source = Path(supervisor.__file__).read_text()
     assert "find_node" not in source
     assert "load_runtime" not in source
@@ -1882,6 +1882,7 @@ async def test_run_request_wires_sdk_runtime_and_reports_effective_state(monkeyp
     agent = _FakeAgent.instances[-1]
     assert computer.kwargs == {
         "presentation": True,
+        "show_stop_button": True,
         "allow_local_shell": True,
         "execution_deadline": pytest.approx(computer.kwargs["execution_deadline"]),
         "cancellation": computer.kwargs["cancellation"],
@@ -2357,7 +2358,7 @@ async def test_cli_run_forwards_the_mode_and_prints_the_matching_notice(monkeypa
     from yutori_mcp.computer_use import cli
 
     run = AsyncMock(return_value={"outcome": "completed", "delivery_mode": "background", "final_text": "done"})
-    monkeypatch.setattr(cli, "_blocked", lambda: False)
+    monkeypatch.setattr(cli, "_blocked", lambda **_kwargs: False)
     monkeypatch.setattr(supervisor, "run_task", run)
     _patch_run_credentials(monkeypatch)
     args = SimpleNamespace(
@@ -2445,6 +2446,7 @@ def test_computer_kwargs_keep_the_foreground_shape_and_add_window_scope_for_back
     cancellation = object()
     shared = {
         "presentation": True,
+        "show_stop_button": True,
         "allow_local_shell": True,
         "execution_deadline": 1.0,
         "cancellation": cancellation,
@@ -3210,3 +3212,336 @@ async def test_progress_reporter_folds_the_batch_detail_into_one_message():
     (message,) = messages
     assert message.count("\n") == 0
     assert message.endswith('left_click (1,2); type "hi"')
+
+
+# ---------------------------------------------------------------------------
+# Embedded driver host: a host application ships its own cua-driver and daemon.
+# ---------------------------------------------------------------------------
+
+
+def _configure_embedded_host(monkeypatch, tmp_path, *, binary_exists: bool = True) -> tuple[Path, Path]:
+    binary = tmp_path / "cua-driver"
+    if binary_exists:
+        binary.write_text("")
+    sock = tmp_path / "daemon.sock"
+    monkeypatch.setenv(preflight.ENV_DRIVER_BINARY, str(binary))
+    monkeypatch.setenv(preflight.ENV_DRIVER_SOCKET, str(sock))
+    return binary, sock
+
+
+def test_embedded_host_environment_names_match_the_sdk_transport():
+    from yutori.navigator.macos import transport
+
+    if not hasattr(transport, "ENV_DRIVER_BINARY"):
+        pytest.skip("the pinned SDK predates the embedded transport constants")
+    assert preflight.ENV_DRIVER_BINARY == transport.ENV_DRIVER_BINARY
+    assert preflight.ENV_DRIVER_SOCKET == transport.ENV_DRIVER_SOCKET
+
+
+def test_embedded_host_is_absent_without_configuration(monkeypatch):
+    monkeypatch.delenv(preflight.ENV_DRIVER_BINARY, raising=False)
+    monkeypatch.delenv(preflight.ENV_DRIVER_SOCKET, raising=False)
+    assert preflight.embedded_driver_host() is None
+    assert preflight._driver_socket_arguments() == []
+
+
+def test_embedded_host_requires_both_binary_and_socket(monkeypatch, tmp_path):
+    monkeypatch.setenv(preflight.ENV_DRIVER_BINARY, str(tmp_path / "cua-driver"))
+    monkeypatch.delenv(preflight.ENV_DRIVER_SOCKET, raising=False)
+    with pytest.raises(ValueError, match="must be set together"):
+        preflight.embedded_driver_host()
+    result = preflight.check_driver_app()
+    assert not result.ok and "must be set together" in result.detail
+    # Half a configuration must not fall back to the standalone install either.
+    monkeypatch.setattr(preflight, "DRIVER_PATHS", (tmp_path / "absent",))
+    assert preflight.find_cua_driver() is None
+
+
+def test_embedded_host_binary_replaces_the_app_bundle_and_path_discovery(monkeypatch, tmp_path):
+    binary, sock = _configure_embedded_host(monkeypatch, tmp_path)
+    monkeypatch.setattr(preflight, "DRIVER_PATHS", (tmp_path / "stale-cua-driver",))
+    (tmp_path / "stale-cua-driver").write_text("")
+
+    assert preflight.find_cua_driver() == binary
+    assert preflight.check_driver_app().ok
+    assert preflight._driver_socket_arguments() == ["--socket", str(sock)]
+    assert preflight.child_search_path().split(":")[0] == str(tmp_path)
+
+
+def test_embedded_host_missing_binary_blocks(monkeypatch, tmp_path):
+    _configure_embedded_host(monkeypatch, tmp_path, binary_exists=False)
+    result = preflight.check_driver_app()
+    assert not result.ok and result.remediation == preflight._EMBEDDED_HOST_REMEDIATION
+    assert preflight.find_cua_driver() is None
+
+
+def test_embedded_daemon_identity_is_the_listening_private_socket(monkeypatch, tmp_path):
+    import shutil
+    import socket as socket_module
+    import tempfile
+
+    _configure_embedded_host(monkeypatch, tmp_path)
+    # AF_UNIX paths are capped at 104 bytes on macOS; pytest's tmp_path is longer than that.
+    short_dir = Path(tempfile.mkdtemp(prefix="cu-", dir="/tmp"))
+    sock = short_dir / "d.sock"
+    monkeypatch.setenv(preflight.ENV_DRIVER_SOCKET, str(sock))
+    try:
+        blocked = preflight.check_daemon_identity()
+        assert not blocked.ok and str(sock) in blocked.detail
+
+        server = socket_module.socket(socket_module.AF_UNIX, socket_module.SOCK_STREAM)
+        server.bind(str(sock))
+        server.listen(1)
+        try:
+            assert preflight.check_daemon_identity().ok
+        finally:
+            server.close()
+    finally:
+        shutil.rmtree(short_dir, ignore_errors=True)
+
+
+def _write_fake_mcp_proxy(path: Path, structured: dict[str, Any]) -> None:
+    """A stand-in for ``cua-driver mcp``: answers initialize and one tools/call, echoing its argv."""
+    path.write_text(
+        "\n".join(
+            [
+                f"#!{sys.executable}",
+                "import json, sys",
+                f"structured = {structured!r}",
+                "structured['argv'] = sys.argv[1:]",
+                "for line in sys.stdin:",
+                "    message = json.loads(line)",
+                "    if message.get('id') == 1:",
+                "        print(json.dumps({'jsonrpc': '2.0', 'id': 1, 'result': {'capabilities': {}}}), flush=True)",
+                "    elif message.get('id') == 2:",
+                "        print('daemon log line that is not JSON', flush=True)",
+                "        print(json.dumps({'jsonrpc': '2.0', 'id': 2, 'result': {'structuredContent': structured}}), flush=True)",
+                "",
+            ]
+        )
+    )
+    path.chmod(0o700)
+
+
+def test_embedded_permissions_come_from_the_check_permissions_tool(monkeypatch, tmp_path):
+    binary, sock = _configure_embedded_host(monkeypatch, tmp_path)
+    _write_fake_mcp_proxy(binary, {"accessibility": True, "screen_recording": True, "source": {"attribution": "host"}})
+
+    payload = preflight._embedded_permissions(preflight.embedded_driver_host())
+
+    assert payload["argv"] == ["mcp", "--embedded", "--socket", str(sock)]
+    assert preflight.check_permissions().ok
+
+
+def test_embedded_permissions_missing_grant_blocks_with_host_remediation(monkeypatch, tmp_path):
+    binary, _ = _configure_embedded_host(monkeypatch, tmp_path)
+    _write_fake_mcp_proxy(binary, {"accessibility": True, "screen_recording": False})
+
+    result = preflight.check_permissions()
+
+    assert not result.ok
+    assert result.remediation == preflight._EMBEDDED_PERMISSIONS_REMEDIATION
+    assert "host application" in result.detail
+
+
+def test_embedded_permissions_proxy_failure_blocks_instead_of_raising(monkeypatch, tmp_path):
+    binary, _ = _configure_embedded_host(monkeypatch, tmp_path)
+    binary.write_text(f"#!{sys.executable}\nraise SystemExit(3)\n")
+    binary.chmod(0o700)
+    monkeypatch.setattr(preflight, "_EMBEDDED_RPC_TIMEOUT_SECONDS", 2)
+
+    assert not preflight.check_permissions().ok
+
+
+def test_child_environment_forwards_the_embedded_host_configuration(monkeypatch, tmp_path):
+    binary, sock = _configure_embedded_host(monkeypatch, tmp_path)
+    monkeypatch.setenv(preflight.ENV_DRIVER_EMBEDDED, "1")
+    monkeypatch.setenv("CUA_DRIVER_RS_HOME", str(tmp_path / "state"))
+    monkeypatch.setenv("CUA_DRIVER_HOST_BUNDLE_ID", "com.yutori.desktop")
+    monkeypatch.setenv("UNRELATED_SECRET", "no")
+
+    env = supervisor._child_environment("yt-key")
+
+    assert env[preflight.ENV_DRIVER_BINARY] == str(binary)
+    assert env[preflight.ENV_DRIVER_SOCKET] == str(sock)
+    assert env[preflight.ENV_DRIVER_EMBEDDED] == "1"
+    assert env["CUA_DRIVER_RS_HOME"] == str(tmp_path / "state")
+    assert env["CUA_DRIVER_HOST_BUNDLE_ID"] == "com.yutori.desktop"
+    assert "UNRELATED_SECRET" not in env
+    assert env["PATH"].split(":")[0] == str(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Host-owned Stop control and the machine-readable CLI surface.
+# ---------------------------------------------------------------------------
+
+
+def _request_payload(**overrides):
+    payload = {
+        "protocol_version": PROTOCOL_VERSION,
+        "type": "run",
+        "task": "open calculator",
+        "app": None,
+        "start_url": None,
+        "deadline_ms": 60_000,
+        "max_steps": 5,
+        "mode": DELIVERY_MODE_FOREGROUND,
+        "allow_foreground_fallback": False,
+        "allow_local_shell": True,
+        "model": "n2",
+        "api_base_url": "https://api.yutori.com/v1",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_parse_request_defaults_show_stop_button_and_validates_it():
+    assert parse_request(_request_payload())["show_stop_button"] is True
+    assert parse_request(_request_payload(show_stop_button=False))["show_stop_button"] is False
+    with pytest.raises(RequestError, match="show_stop_button must be a boolean"):
+        parse_request(_request_payload(show_stop_button="no"))
+
+
+def test_computer_kwargs_forward_the_stop_control_choice():
+    request = parse_request(_request_payload(show_stop_button=False))
+    kwargs = runner_module._computer_kwargs(
+        request, deadline=time.monotonic() + 60, cancellation=runner_module.CancellationLatch(), api_key="k"
+    )
+    assert kwargs["show_stop_button"] is False
+    assert kwargs["presentation"] is True
+
+
+async def test_run_task_request_carries_show_stop_button(tmp_path):
+    with _patched_run_task_supervise(tmp_path) as supervise:
+        await run_task(**_run_task_kwargs(tmp_path, show_stop_button=False))
+    assert supervise.await_args.kwargs["request"]["show_stop_button"] is False
+    with _patched_run_task_supervise(tmp_path) as supervise:
+        await run_task(**_run_task_kwargs(tmp_path))
+    assert supervise.await_args.kwargs["request"]["show_stop_button"] is True
+
+
+def test_cli_run_and_doctor_parsers_accept_json_and_hide_stop_item():
+    from yutori_mcp.computer_use import cli
+
+    parser = argparse.ArgumentParser()
+    cli.register_parser(parser.add_subparsers(dest="command"))
+    args = parser.parse_args(["computer-use", "run", "add a note", "--json", "--hide-stop-item"])
+    assert args.json is True and args.hide_stop_item is True
+    default = parser.parse_args(["computer-use", "run", "add a note"])
+    assert default.json is False and default.hide_stop_item is False
+    assert parser.parse_args(["computer-use", "doctor", "--json"]).json is True
+    assert parser.parse_args(["computer-use", "doctor"]).json is False
+
+
+def _run_args(**overrides) -> SimpleNamespace:
+    args = {
+        "task": "add a note",
+        "app": None,
+        "start_url": None,
+        "minutes": 30,
+        "max_steps": 60,
+        "mode": "foreground",
+        "allow_foreground_fallback": False,
+        "allow_local_shell": True,
+        "json": False,
+        "hide_stop_item": False,
+    }
+    args.update(overrides)
+    return SimpleNamespace(**args)
+
+
+def _json_lines(text: str) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in text.splitlines() if line.strip()]
+
+
+async def test_cli_run_json_streams_events_and_the_result_as_json_lines(monkeypatch, capsys):
+    from yutori_mcp.computer_use import cli
+
+    action = _action_event(tool="computer_batch", index=0)
+
+    async def run(**kwargs):
+        await kwargs["on_event"](_ready_event())
+        await kwargs["on_event"](action)
+        return {"outcome": "completed", "delivery_mode": "foreground", "final_text": "done", "actions": [action]}
+
+    monkeypatch.setattr(cli, "_blocked", lambda **_kwargs: False)
+    monkeypatch.setattr(supervisor, "run_task", run)
+    _patch_run_credentials(monkeypatch)
+
+    assert await cli._run_custom(_run_args(json=True, hide_stop_item=True)) == 0
+
+    lines = _json_lines(capsys.readouterr().out)
+    assert [line["type"] for line in lines] == ["ready", "action", "result"]
+    assert lines[-1]["outcome"] == "completed" and lines[-1]["final_text"] == "done"
+
+
+async def test_cli_run_json_forwards_the_stop_item_choice(monkeypatch, capsys):
+    from yutori_mcp.computer_use import cli
+
+    run = AsyncMock(return_value={"outcome": "failed", "delivery_mode": "foreground", "final_text": "no"})
+    monkeypatch.setattr(cli, "_blocked", lambda **_kwargs: False)
+    monkeypatch.setattr(supervisor, "run_task", run)
+    _patch_run_credentials(monkeypatch)
+
+    assert await cli._run_custom(_run_args(json=True, hide_stop_item=True)) == 1
+    assert run.await_args.kwargs["show_stop_button"] is False
+    assert _json_lines(capsys.readouterr().out)[-1]["type"] == "result"
+
+    assert await cli._run_custom(_run_args()) == 1
+    assert run.await_args.kwargs["show_stop_button"] is True
+    assert "Outcome" in capsys.readouterr().out or True
+
+
+async def test_cli_run_json_reports_a_preflight_blocker_as_json(monkeypatch, capsys):
+    from yutori_mcp.computer_use import cli
+
+    monkeypatch.setattr(
+        cli, "first_blocker", lambda: preflight.CheckResult("driver app", False, "missing", "start the daemon")
+    )
+    assert await cli._run_custom(_run_args(json=True)) == 1
+    [line] = _json_lines(capsys.readouterr().out)
+    assert line == {
+        "type": "blocked",
+        "name": "driver app",
+        "ok": False,
+        "detail": "missing",
+        "remediation": "start the daemon",
+        "blocking": True,
+    }
+
+
+def test_doctor_json_lists_every_check_with_an_overall_verdict(monkeypatch, capsys):
+    from yutori_mcp.computer_use import cli
+
+    monkeypatch.setattr(
+        cli,
+        "run_checks",
+        lambda: [
+            preflight.CheckResult("runtime", True, "yutori ok"),
+            preflight.CheckResult("overlay", False, "not prepared", "run setup", blocking=False),
+        ],
+    )
+    assert cli._dispatch_doctor(SimpleNamespace(json=True)) == 0
+    [line] = _json_lines(capsys.readouterr().out)
+    assert line["type"] == "doctor" and line["ok"] is True
+    assert [check["name"] for check in line["checks"]] == ["runtime", "overlay"]
+    assert line["checks"][1]["blocking"] is False
+
+    monkeypatch.setattr(
+        cli, "run_checks", lambda: [preflight.CheckResult("driver app", False, "missing", "start the daemon")]
+    )
+    assert cli._dispatch_doctor(SimpleNamespace(json=True)) == 1
+    assert _json_lines(capsys.readouterr().out)[0]["ok"] is False
+
+
+def test_setup_skips_the_standalone_installer_for_an_embedded_host(monkeypatch, tmp_path, capsys):
+    from yutori_mcp.computer_use import cli
+
+    binary, _ = _configure_embedded_host(monkeypatch, tmp_path)
+    monkeypatch.setattr(cli, "check_runtime", lambda: preflight.CheckResult("Python runtime", True, "ok"))
+    monkeypatch.setattr(cli, "_download_installer", lambda _url: (_ for _ in ()).throw(AssertionError("must not download")))
+    monkeypatch.setattr(cli, "run_checks", lambda: [preflight.CheckResult("driver app", True, str(binary))])
+
+    assert cli._setup() == 0
+    out = capsys.readouterr().out
+    assert "nothing to install" in out and str(binary) in out


### PR DESCRIPTION
## Summary

Yutori Local is getting a **Computer use…** tray row that runs this runtime with everything bundled inside the app, and cua-driver in its embedded mode (a direct child of the app, inheriting the app's TCC grants). This PR gives the runtime what that host needs; standalone `uvx yutori-mcp computer-use` behavior is unchanged.

**Embedded host mode** (`YUTORI_CUA_DRIVER_BINARY` + `YUTORI_CUA_DRIVER_SOCKET`, both or neither):
- preflight resolves the host's binary and checks the private socket instead of `/Applications/CuaDriver.app` + `pgrep`
- permissions are read through the daemon's own `check_permissions` MCP tool (`cua-driver permissions status` ignores `--socket` on 0.23.2 and reports `unknown` for an embedded daemon)
- `check_capture` passes `--socket`; `setup` becomes a no-op plus `doctor`
- the supervisor forwards the variables to the runner so the SDK transport (yutori-ai/yutori-sdk-python#422) attaches to the same daemon

**CLI:** `run --json` (event stream + result as JSON lines, `blocked` for a preflight failure), `doctor --json`, `run --hide-stop-item` → new optional `show_stop_button` request field. Runner gets `-B` so a signed bundle never grows `__pycache__`.

Pairs with yutori-ai/yutori-sdk-python#422; until that SDK ships and is pinned here, embedded mode needs the editable-SDK override for local testing. Consumer: yutori-ai/yutori#13291.

## Test plan

- [x] `pytest` (494 passed, 2 skipped); new tests cover embedded resolution, socket probe, permissions via a fake proxy, env forwarding, `show_stop_button` parsing/kwargs, `--json` output, `setup` short-circuit
- [x] Live against cua-driver 0.23.2: embedded daemon on a private socket → `doctor --json` all 14 checks pass (permissions `source.attribution: host`); `run --json --hide-stop-item --app Calculator --mode background` completed (9×9=81) from the bundled Yutori Local runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS preflight, TCC/permission probing, and driver attachment paths; mistakes could block runs or mis-report permissions, though standalone mode is gated on unset embed env.
> 
> **Overview**
> Adds **embedded cua-driver host** support so a bundled app (e.g. Yutori Local) can point the runtime at its own driver binary and private daemon socket via `YUTORI_CUA_DRIVER_BINARY` and `YUTORI_CUA_DRIVER_SOCKET` (both required; half-config errors instead of falling back to `/Applications/CuaDriver.app`). Preflight then validates the host binary, probes the socket for daemon identity, reads Accessibility/Screen Recording through the embedded MCP `check_permissions` tool, passes `--socket` on capture checks, and **`setup` skips the standalone installer** when embedding is configured.
> 
> Introduces a **machine-readable CLI**: `computer-use run --json` streams runner events as JSON lines and ends with a typed `result` (preflight failures emit `blocked`); `doctor --json` returns one `doctor` object with all checks. **`run --hide-stop-item`** maps to optional `show_stop_button` on the runner protocol (default true) so the host can own Stop UI while the overlay hotkey stays.
> 
> The supervisor **forwards embedded-driver env** (and related `CUA_DRIVER_*` vars) into the isolated runner child; **`python -I -B`** avoids writing `__pycache__` under signed app bundles. Standalone `uvx` flows are unchanged when the embed env vars are unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3ebb24b059588a37e6b6d53e3f02c9bddae6359. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->