### PR TITLE
chore(release): 0.5.23 with yutori 0.9.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.22"
+version = "0.5.23"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"
@@ -30,9 +30,9 @@ dependencies = [
     # breaks the install as soon as 2.x resolves.
     "mcp>=1.0.0,<2.0.0",
     "pydantic>=2.0.0",
-    # SDK 0.9.20 bundles the protocol-v4 navigator overlay from yutori#13269
-    # and presents terminal commands beside the cursor capsule.
-    "yutori==0.9.20",
+    # SDK 0.9.21 lets MCP attach to a host-embedded macOS driver daemon while
+    # preserving the standalone CuaDriver transport.
+    "yutori==0.9.21",
 ]
 
 [project.optional-dependencies]

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -33,11 +33,11 @@ DELIVERY_MODES = (DELIVERY_MODE_FOREGROUND, DELIVERY_MODE_BACKGROUND)
 # also hides it from recorders. Read by the runner; the supervisor forwards it to the runner's
 # environment.
 ENV_RECORDABLE_OVERLAY = "YUTORI_RECORDABLE_OVERLAY"
-SDK_VERSION = "0.9.20"
+SDK_VERSION = "0.9.21"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.
-SDK_ARTIFACT_SHA256 = "e267c85de2cfa0aae8c044b0629a50c2d0781b0d0f44eb400c9d300cf833d92c"
-SDK_INSTALLATION_SHA256 = "b5c8e019c8a4c7c6564f3833870d941af8c37d4fb35465bd67ebd7b14adc6cab"
+SDK_ARTIFACT_SHA256 = "f0afd7eefd04a70696360d59e94aa053bd6b7b35a91cc26f182e93f1332e6ddd"
+SDK_INSTALLATION_SHA256 = "12ad93d54d4c6108768745c8f48d4bd421824bc9fc8ba93f8fc7229a401463a1"
 SDK_PROVENANCE_SHA256 = "cacc3ed5af3d6c5c8daeef60be4aa63e0af25b1d51770ef54d6a8f9db6811cee"
 
 # The cua-driver release that implements this tool contract, and the checksum

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -871,9 +871,9 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 
 def test_runtime_constants_select_latest_python_surface():
     assert TOOL_SET == "computer_use_tools-20260830"
-    assert SDK_VERSION == "0.9.20"
+    assert SDK_VERSION == "0.9.21"
     assert all(len(digest) == 64 for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256))
-    assert '"yutori==0.9.20"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
+    assert '"yutori==0.9.21"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
 
 
 def test_installed_sdk_matches_the_published_artifact():

--- a/uv.lock
+++ b/uv.lock
@@ -1370,7 +1370,7 @@ wheels = [
 
 [[package]]
 name = "yutori"
-version = "0.9.20"
+version = "0.9.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1379,14 +1379,14 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/9d/04700b36c39a1cb25a96e22d92dcf282b388e37d588ce8481c338ca86af7/yutori-0.9.20.tar.gz", hash = "sha256:7f000163813b676c8440c2d1895188f0902891a5b0bebe6a12394f7fdfb62e52", size = 482885, upload-time = "2026-09-09T23:46:58.34Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/17/37/f4710bf6079f6a9371e1312f9b21aaa6af3b49f587e0b728d166e0c86c8a/yutori-0.9.21.tar.gz", hash = "sha256:62107cc8db9ca85e7d33ab4301479053e8f898a52f4bfd6efb89bbc6d490d99e", size = 483694, upload-time = "2026-09-10T06:39:20.517Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/62/b97c90bfbb29ea2eafa6f7567dbc54049803bbcc7445a2c8428b7e70f712/yutori-0.9.20-py3-none-any.whl", hash = "sha256:e267c85de2cfa0aae8c044b0629a50c2d0781b0d0f44eb400c9d300cf833d92c", size = 337983, upload-time = "2026-09-09T23:46:56.404Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/cb/4b38788e4bc0c42702e44a3e85f041f7abb4cd3ef48c3cbc686e02f618b4/yutori-0.9.21-py3-none-any.whl", hash = "sha256:f0afd7eefd04a70696360d59e94aa053bd6b7b35a91cc26f182e93f1332e6ddd", size = 338459, upload-time = "2026-09-10T06:39:18.765Z" },
 ]
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.22"
+version = "0.5.23"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -1406,6 +1406,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "yutori", specifier = "==0.9.20" },
+    { name = "yutori", specifier = "==0.9.21" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
Bumps yutori-mcp to 0.5.23 and pins the newly published yutori SDK 0.9.21 for embedded macOS driver-host support. Updates the locked SDK artifacts and the runtime integrity hashes used by doctor/preflight. Validated with 497 tests, the live PyPI artifact check, package builds, and Twine checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and checksum sync only; runtime behavior follows the already-tested yutori 0.9.21 SDK rather than new MCP code paths in this diff.
> 
> **Overview**
> Releases **yutori-mcp 0.5.23** and pins **`yutori==0.9.21`**, called out in `pyproject.toml` for host-embedded macOS driver daemon support while keeping the standalone CuaDriver path.
> 
> The bump refreshes **`SDK_VERSION`**, **PyPI wheel / installation SHA-256** values in `constants.py`, matching **`uv.lock`**, so doctor/preflight and supervisor provenance checks stay aligned with the published SDK artifact. Tests that assert the pinned version and `pyproject.toml` string are updated accordingly.
> 
> No application logic changes beyond dependency and integrity metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e56be9d4ea4fb5ded6b0a7e934403c85eadc21c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->