### PR TITLE
chore(release): 0.5.24 with yutori 0.9.22

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.23"
+version = "0.5.24"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"
@@ -30,9 +30,9 @@ dependencies = [
     # breaks the install as soon as 2.x resolves.
     "mcp>=1.0.0,<2.0.0",
     "pydantic>=2.0.0",
-    # SDK 0.9.21 lets MCP attach to a host-embedded macOS driver daemon while
-    # preserving the standalone CuaDriver transport.
-    "yutori==0.9.21",
+    # SDK 0.9.22 clears completed overlay reasoning while the next model call
+    # is pending, and retains the host-embedded macOS driver transport.
+    "yutori==0.9.22",
 ]
 
 [project.optional-dependencies]

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -33,11 +33,11 @@ DELIVERY_MODES = (DELIVERY_MODE_FOREGROUND, DELIVERY_MODE_BACKGROUND)
 # also hides it from recorders. Read by the runner; the supervisor forwards it to the runner's
 # environment.
 ENV_RECORDABLE_OVERLAY = "YUTORI_RECORDABLE_OVERLAY"
-SDK_VERSION = "0.9.21"
+SDK_VERSION = "0.9.22"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.
-SDK_ARTIFACT_SHA256 = "f0afd7eefd04a70696360d59e94aa053bd6b7b35a91cc26f182e93f1332e6ddd"
-SDK_INSTALLATION_SHA256 = "12ad93d54d4c6108768745c8f48d4bd421824bc9fc8ba93f8fc7229a401463a1"
+SDK_ARTIFACT_SHA256 = "8b331d71b7bc0126f27bcb7f32312231e6189b4eaedbd1d4c35971a0ba31fcfd"
+SDK_INSTALLATION_SHA256 = "d3137ae0095e046df1b7309f719d12ba2642e3840ac5a0080fc5e6cd0122883e"
 SDK_PROVENANCE_SHA256 = "cacc3ed5af3d6c5c8daeef60be4aa63e0af25b1d51770ef54d6a8f9db6811cee"
 
 # The cua-driver release that implements this tool contract, and the checksum

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -871,9 +871,9 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 
 def test_runtime_constants_select_latest_python_surface():
     assert TOOL_SET == "computer_use_tools-20260830"
-    assert SDK_VERSION == "0.9.21"
+    assert SDK_VERSION == "0.9.22"
     assert all(len(digest) == 64 for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256))
-    assert '"yutori==0.9.21"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
+    assert '"yutori==0.9.22"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
 
 
 def test_installed_sdk_matches_the_published_artifact():

--- a/uv.lock
+++ b/uv.lock
@@ -1370,7 +1370,7 @@ wheels = [
 
 [[package]]
 name = "yutori"
-version = "0.9.21"
+version = "0.9.22"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1379,14 +1379,14 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/37/f4710bf6079f6a9371e1312f9b21aaa6af3b49f587e0b728d166e0c86c8a/yutori-0.9.21.tar.gz", hash = "sha256:62107cc8db9ca85e7d33ab4301479053e8f898a52f4bfd6efb89bbc6d490d99e", size = 483694, upload-time = "2026-09-10T06:39:20.517Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/6a/65bd85d8380df9fa6ea117ac2c2a4e9b9e2f2eb69b9c233357530d8c91cb/yutori-0.9.22.tar.gz", hash = "sha256:9b9709d29b94f5d9dd0fa4f8bc2a49e9ddf545ae9e15f9a120a9c31acd2b45a2", size = 483837, upload-time = "2026-09-10T07:27:41.535Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/cb/4b38788e4bc0c42702e44a3e85f041f7abb4cd3ef48c3cbc686e02f618b4/yutori-0.9.21-py3-none-any.whl", hash = "sha256:f0afd7eefd04a70696360d59e94aa053bd6b7b35a91cc26f182e93f1332e6ddd", size = 338459, upload-time = "2026-09-10T06:39:18.765Z" },
+    { url = "https://files.pythonhosted.org/packages/32/b4/302a93ff890e6567822d445d558a9528d32624310102dd73054075352c61/yutori-0.9.22-py3-none-any.whl", hash = "sha256:8b331d71b7bc0126f27bcb7f32312231e6189b4eaedbd1d4c35971a0ba31fcfd", size = 338499, upload-time = "2026-09-10T07:27:39.739Z" },
 ]
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.23"
+version = "0.5.24"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -1406,6 +1406,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "yutori", specifier = "==0.9.21" },
+    { name = "yutori", specifier = "==0.9.22" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
Bumps yutori-mcp to 0.5.24 and pins yutori SDK 0.9.22, which clears completed overlay reasoning at the next model-request boundary. Updates the locked SDK artifacts and exact runtime integrity hashes. Validated with 497 MCP tests, the live published-SDK artifact check, package builds, and Twine checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and version-pin release only; no MCP server or runner logic changes beyond updated SDK checksums and tests.
> 
> **Overview**
> Releases **yutori-mcp 0.5.24** and pins the **`yutori` SDK to 0.9.22** (from 0.9.21). The dependency comment notes that 0.9.22 clears completed overlay reasoning while the next model call is pending; host-embedded macOS driver transport behavior is unchanged.
> 
> **Runtime integrity** is updated in `constants.py`: `SDK_VERSION`, `SDK_ARTIFACT_SHA256`, and `SDK_INSTALLATION_SHA256` match the new PyPI wheel so doctor/preflight still gate installs. **`uv.lock`** and **`test_computer_use.py`** runtime constant assertions are aligned with the new pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cdf2cd45b1c44c38eef26e86471144df9c78792. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->