### PR TITLE
refactor(computer-use): share structured_content() between app.py and preflight.py

### DIFF
--- a/src/yutori_mcp/computer_use/app.py
+++ b/src/yutori_mcp/computer_use/app.py
@@ -13,6 +13,7 @@ from yutori.navigator.macos.transport import (
     CuaDriverUncertainActionError,
 )
 
+from .result import structured_content
 from .targeting import require_frontmost_target
 
 _BUNDLE_ID_PATTERN = re.compile(r"^[A-Za-z0-9-]+(\.[A-Za-z0-9-]+)+$")
@@ -24,17 +25,6 @@ _BACKGROUND_SETTLE_MS = 300
 _WINDOW_POLL_MS = 250
 _WINDOW_POLL_ATTEMPTS = 12
 _MIN_IMMEDIATE_UNTITLED_WINDOW_AREA = 60_000
-
-
-def structured_content(result: dict[str, Any]) -> dict[str, Any]:
-    """The structured payload of a ``_call_tool`` result, tolerating either key casing.
-
-    The driver protocol has used both ``structuredContent`` (MCP-style) and
-    ``structured_content`` across releases; every caller wants "whichever one is present,
-    or an empty dict" rather than caring which.
-    """
-    value = result.get("structuredContent") or result.get("structured_content") or {}
-    return value if isinstance(value, dict) else {}
 
 
 def _windows(payload: dict[str, Any]) -> list[dict[str, Any]]:

--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -48,6 +48,7 @@ from .result import (
     format_runtime_version,
     format_terminal_action,
     format_terminal_result,
+    structured_content,
 )
 from .supervisor import run_task_with_resolved_credentials, stop_active_run
 
@@ -156,7 +157,7 @@ def _report(result: dict[str, Any], *, include_actions: bool = True) -> int:
 async def _mechanical_calculator_check() -> str:
     from yutori.navigator.macos.transport import CuaDriverTransport
 
-    from .app import prepare_app, structured_content
+    from .app import prepare_app
     from .targeting import TargetGuardedMacOSComputer
 
     driver = find_cua_driver()

--- a/src/yutori_mcp/computer_use/preflight.py
+++ b/src/yutori_mcp/computer_use/preflight.py
@@ -31,6 +31,7 @@ from .constants import (
     SDK_VERSION,
     TOOL_SET,
 )
+from .result import structured_content
 
 DRIVER_APP = Path("/Applications/CuaDriver.app")
 DRIVER_PATHS = (
@@ -500,8 +501,7 @@ def _embedded_permissions(host: EmbeddedDriverHost) -> dict[str, Any]:
     finally:
         process.kill()
         process.wait(timeout=5)
-    structured = result.get("structuredContent") or result.get("structured_content") or {}
-    return structured if isinstance(structured, dict) else {}
+    return structured_content(result)
 
 
 def check_daemon_identity() -> CheckResult:

--- a/src/yutori_mcp/computer_use/result.py
+++ b/src/yutori_mcp/computer_use/result.py
@@ -27,6 +27,19 @@ def redact(text: str, secret: str) -> str:
     return text.replace(secret, REDACTED)
 
 
+def structured_content(result: dict[str, Any]) -> dict[str, Any]:
+    """The structured payload of an MCP tool result, tolerating either key casing.
+
+    The driver protocol has used both ``structuredContent`` (MCP-style) and
+    ``structured_content`` across releases; every caller wants "whichever one is present,
+    or an empty dict" rather than caring which. Lives here (not ``app.py``, which owns the
+    SDK-backed ``MacOSComputer`` calls) so ``preflight.py``'s embedded-host MCP proxy call
+    can reuse it without importing the SDK.
+    """
+    value = result.get("structuredContent") or result.get("structured_content") or {}
+    return value if isinstance(value, dict) else {}
+
+
 def remaining_seconds(deadline: float) -> float:
     """Seconds left before ``deadline`` (a ``time.monotonic()`` value).
 


### PR DESCRIPTION
## What

`#303` (embedded driver host mode) added `preflight.py::_embedded_permissions()`, which reads
an MCP tool result through the host daemon's proxy and extracts its structured payload with:

```python
structured = result.get("structuredContent") or result.get("structured_content") or {}
return structured if isinstance(structured, dict) else {}
```

This is byte-for-byte the same key-casing-tolerant extraction that `app.py::structured_content()`
already implements (and documents) for the SDK-backed `_call_tool()` path — it was just
re-derived inline instead of reused.

## Why this is an improvement

- Removes a real, if small, duplicate: the exact same two-line MCP-result-shape workaround
  living in two places with no name at the second site.
- `preflight.py` has an explicit standing invariant ("this module must stay importable
  without the SDK") that blocks it from importing `structured_content` from `app.py`, which
  imports `yutori.navigator.macos`. Moving the helper into `result.py` — already the
  SDK-free module shared across the runner/supervisor/cli boundary — lets `preflight.py`
  reuse it while keeping that invariant intact.
- `cli.py`'s local import of `structured_content` (previously piggybacking on `app.py`'s
  lazy, SDK-triggering import inside `_mechanical_calculator_check`) now comes from the
  already-imported `.result` module at the top of the file, which is slightly more direct
  and no longer implicitly re-exported through `app.py`.

## Why this is safe

- Pure move + call-site update, no behavior change: same two-key fallback, same
  `isinstance(..., dict)` guard.
- No test references `structured_content` by patching `app.structured_content` directly
  (confirmed via grep), so there's nothing to break by relocating it.
- Full test suite: `497 passed, 1 skipped`, exactly matching the pre-change baseline.
- `ruff check .` clean. `ruff format --check` flags these files, but it already did before
  this change (confirmed via `git stash`) — the repo has no `[tool.ruff]` config, no
  pre-commit hook, and no CI lint step, so this isn't a regression.

## Scope

4 files touched, +18/-14. No functional/behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JrjM4EeELNvAohH1n1q6zi


---
_Generated by [Claude Code](https://claude.ai/code/session_01JrjM4EeELNvAohH1n1q6zi)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only relocation with identical fallback and dict guard; no behavior or API surface change.
> 
> **Overview**
> **Centralizes MCP tool-result parsing** by moving `structured_content()` from `app.py` into SDK-free `result.py`, so every caller shares one helper for `structuredContent` vs `structured_content` key casing.
> 
> `preflight.py` drops duplicated inline extraction in `_embedded_permissions()` and imports from `result` instead of `app` (which would pull in the navigator SDK). `app.py` and `cli.py` now import the helper from `result`; the smoke test’s mechanical calculator path no longer reaches it through a lazy `app` import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e03d2367f0a5bdb1ff73980f24216cc0164f8d24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->