### PR TITLE
refactor(computer-use): dedupe the outcome-to-exit-code mapping in cli.py

### DIFF
--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -144,6 +144,11 @@ def _blocked(*, json_output: bool = False) -> bool:
     return True
 
 
+def _exit_code(result: dict[str, Any]) -> int:
+    """The process exit code a run result maps to: 0 only for a completed outcome."""
+    return 0 if result.get("outcome") == "completed" else 1
+
+
 def _report(result: dict[str, Any], *, include_actions: bool = True) -> int:
     """Print the formatted run result and derive the process exit code from its outcome.
 
@@ -151,7 +156,7 @@ def _report(result: dict[str, Any], *, include_actions: bool = True) -> int:
     in progress; `run` turns it off, having already printed each action as it landed.
     """
     print(format_terminal_result(result, Terminal.detect(), include_actions=include_actions))
-    return 0 if result.get("outcome") == "completed" else 1
+    return _exit_code(result)
 
 
 async def _mechanical_calculator_check() -> str:
@@ -330,7 +335,7 @@ async def _run_custom(args: argparse.Namespace) -> int:
             on_event=_json_event_printer(),
         )
         _json_line({"type": "result", **result})
-        return 0 if result.get("outcome") == "completed" else 1
+        return _exit_code(result)
     _print_milestone(paint, "preflight ready", preflight_started)
     print(format_run_header(params, paint))
     runner_started = time.monotonic()

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -2344,6 +2344,14 @@ def test_cli_run_parser_accepts_mode_and_fallback_flags():
         parser.parse_args(["computer-use", "run", "x", "--mode", "sideways"])
 
 
+def test_exit_code_is_zero_only_for_a_completed_outcome():
+    from yutori_mcp.computer_use import cli
+
+    assert cli._exit_code({"outcome": "completed"}) == 0
+    assert cli._exit_code({"outcome": "limit"}) == 1
+    assert cli._exit_code({}) == 1
+
+
 def test_hands_off_notice_depends_on_the_mode():
     from yutori_mcp.computer_use import cli
 


### PR DESCRIPTION
## What

`_run_custom()`'s new `--json` branch (added in #303, embedded driver host mode) reintroduced the identical `0 if result.get("outcome") == "completed" else 1` formula that `_report()` already implements — the exact duplication `#238` originally extracted `_report()` to avoid, now reappearing in the newer JSON code path.

Extracted `_exit_code(result) -> int` in `computer_use/cli.py`; both `_report()` and the `--json` branch of `_run_custom()` now delegate to it. Zero behavior change — same mapping, same call sites' return values.

## Why safe

- Pure extraction, no new call sites, no signature changes.
- 2 files touched (`cli.py` + `tests/test_computer_use.py`), +15/-2.
- Existing tests already exercise both branches end-to-end (`test_cli_run_forwards_the_mode_and_prints_the_matching_notice` for the non-JSON completed=0 path, `test_cli_run_json_streams_events_and_the_result_as_json_lines`/`test_cli_run_json_reports_a_preflight_blocker_as_json` for the JSON completed=0/failed=1 paths) — all pass unchanged.
- Added one direct unit test pinning `_exit_code`'s mapping.

## Verification

- `uv run --extra dev pytest -q` → 498 passed, 1 skipped (baseline 497/1 + 1 new test).
- `uv run ruff check .` clean. (`ruff format --check` pre-existingly flags this file and others on `main`; confirmed via `git stash` this is unrelated to the diff — no CI lint step gates on it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KH1NWgmVUjiUwHg9Z21CTZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01KH1NWgmVUjiUwHg9Z21CTZ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure extraction with existing end-to-end tests; only affects CLI exit codes, unchanged mapping logic.
> 
> **Overview**
> **Deduplicates** how the computer-use CLI turns a run `result` dict into a process exit code after the `--json` path reintroduced the same inline rule `_report()` already used.
> 
> Adds **`_exit_code(result)`** in `computer_use/cli.py` (exit **0** only when `outcome == "completed"`). **`_report()`** and the **`--json`** branch of **`_run_custom()`** both return through it—**no intended behavior change** for terminal or JSON runs.
> 
> Adds **`test_exit_code_is_zero_only_for_a_completed_outcome`** to lock the mapping (`completed` → 0; `limit` or missing outcome → 1).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab2d8952c59e4356accab3eec238a49d43c885eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->