### PR TITLE
chore(release): 0.5.25 with yutori 0.9.23

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.24"
+version = "0.5.25"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"
@@ -30,9 +30,10 @@ dependencies = [
     # breaks the install as soon as 2.x resolves.
     "mcp>=1.0.0,<2.0.0",
     "pydantic>=2.0.0",
-    # SDK 0.9.22 clears completed overlay reasoning while the next model call
-    # is pending, and retains the host-embedded macOS driver transport.
-    "yutori==0.9.22",
+    # SDK 0.9.23 reverts the cursor-anchored run-command panel: the shell rail is
+    # back under the menu bar, the capsule carries "$ <command>" again, and the
+    # bundled overlay runtime is back on renderer protocol 3.
+    "yutori==0.9.23",
 ]
 
 [project.optional-dependencies]

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -33,12 +33,12 @@ DELIVERY_MODES = (DELIVERY_MODE_FOREGROUND, DELIVERY_MODE_BACKGROUND)
 # also hides it from recorders. Read by the runner; the supervisor forwards it to the runner's
 # environment.
 ENV_RECORDABLE_OVERLAY = "YUTORI_RECORDABLE_OVERLAY"
-SDK_VERSION = "0.9.22"
+SDK_VERSION = "0.9.23"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.
-SDK_ARTIFACT_SHA256 = "8b331d71b7bc0126f27bcb7f32312231e6189b4eaedbd1d4c35971a0ba31fcfd"
-SDK_INSTALLATION_SHA256 = "d3137ae0095e046df1b7309f719d12ba2642e3840ac5a0080fc5e6cd0122883e"
-SDK_PROVENANCE_SHA256 = "cacc3ed5af3d6c5c8daeef60be4aa63e0af25b1d51770ef54d6a8f9db6811cee"
+SDK_ARTIFACT_SHA256 = "88f79c54c1a2dc72c47fd79fc31617fd5295b60790be24993b398ca3fd76c890"
+SDK_INSTALLATION_SHA256 = "6ac1ba6b3cf5ad2c00155d0cccd4efec3ef0d7dc83066ce69ce294eaf1b2eb3e"
+SDK_PROVENANCE_SHA256 = "7cab595d2f00e1a9ab5cd121204fbd6dd4c24163ead3eb76f76eef7fba495fc4"
 
 # The cua-driver release that implements this tool contract, and the checksum
 # of its installer script. Both are hard gates.

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -871,9 +871,9 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 
 def test_runtime_constants_select_latest_python_surface():
     assert TOOL_SET == "computer_use_tools-20260830"
-    assert SDK_VERSION == "0.9.22"
+    assert SDK_VERSION == "0.9.23"
     assert all(len(digest) == 64 for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256))
-    assert '"yutori==0.9.22"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
+    assert '"yutori==0.9.23"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
 
 
 def test_installed_sdk_matches_the_published_artifact():

--- a/uv.lock
+++ b/uv.lock
@@ -260,7 +260,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -294,8 +294,8 @@ name = "httpcore2"
 version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
+    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "truststore", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
@@ -1359,8 +1359,8 @@ name = "uvicorn"
 version = "0.52.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "h11" },
+    { name = "click", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
+    { name = "h11", marker = "python_full_version < '3.12' or python_full_version >= '3.14' or sys_platform != 'emscripten'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
@@ -1370,7 +1370,7 @@ wheels = [
 
 [[package]]
 name = "yutori"
-version = "0.9.22"
+version = "0.9.23"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1379,14 +1379,14 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c9/6a/65bd85d8380df9fa6ea117ac2c2a4e9b9e2f2eb69b9c233357530d8c91cb/yutori-0.9.22.tar.gz", hash = "sha256:9b9709d29b94f5d9dd0fa4f8bc2a49e9ddf545ae9e15f9a120a9c31acd2b45a2", size = 483837, upload-time = "2026-09-10T07:27:41.535Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a0/01/55b934255f3401cacb92d0b3d7fcd260c47e21e5b32e86cf6c8c4378f706/yutori-0.9.23.tar.gz", hash = "sha256:45bd281f996cc5cfee5291606e4929424bea5f35bc25c801d45800a52706f169", size = 478327, upload-time = "2026-09-10T16:15:45.358Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/32/b4/302a93ff890e6567822d445d558a9528d32624310102dd73054075352c61/yutori-0.9.22-py3-none-any.whl", hash = "sha256:8b331d71b7bc0126f27bcb7f32312231e6189b4eaedbd1d4c35971a0ba31fcfd", size = 338499, upload-time = "2026-09-10T07:27:39.739Z" },
+    { url = "https://files.pythonhosted.org/packages/db/f8/96f7914298b59f7154e55f695446613709cb4d0ead11ee0e6d707d2ccb65/yutori-0.9.23-py3-none-any.whl", hash = "sha256:88f79c54c1a2dc72c47fd79fc31617fd5295b60790be24993b398ca3fd76c890", size = 334397, upload-time = "2026-09-10T16:15:43.897Z" },
 ]
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.24"
+version = "0.5.25"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -1406,6 +1406,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "yutori", specifier = "==0.9.22" },
+    { name = "yutori", specifier = "==0.9.23" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
Bumps `yutori-mcp` to 0.5.25 and repins the SDK at `yutori==0.9.23`, which reverts the cursor-anchored run-command panel ([SDK #418](https://github.com/yutori-ai/yutori-sdk-python/pull/418), reverted in [#427](https://github.com/yutori-ai/yutori-sdk-python/pull/427)): the shell rail sits under the menu bar again, the capsule carries `$ <command>`, and the bundled overlay runtime is back on renderer protocol 3.

All three SDK integrity digests move with the new wheel — artifact, installed-distribution, and provenance. The provenance digest returns to its pre-#418 value, since the revert restores the protocol-3 `provenance.json` byte for byte.

Verified against the published wheel: `YUTORI_MCP_VERIFY_PUBLISHED_ARTIFACT=1 uv run pytest` — 499 passed, including the PyPI artifact-hash check and the installed-runtime digest check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version pin and checksum updates only; no MCP server logic changes, though users get SDK overlay UI/protocol behavior from the revert.
> 
> **Overview**
> **Release 0.5.25** repins the computer-use runtime on **`yutori==0.9.23`** (from 0.9.22). The dependency comment documents that this SDK release **reverts the cursor-anchored run-command panel**: shell rail under the menu bar again, capsule shows `$ <command>`, overlay back on **renderer protocol 3**.
> 
> `SDK_VERSION` and all three **integrity digests** in `constants.py` (artifact, installation, provenance) are updated to match the published 0.9.23 wheel; doctor/preflight continue to gate runs on those values. Tests that pin `pyproject.toml` and runtime constants are aligned. **`uv.lock`** resolves `yutori` 0.9.23 and includes minor dependency-marker churn unrelated to app logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f0fedeaba690feff3136685b76f66582c0db7a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->