### PR TITLE
ci: update action versions and fix workflow caching

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -16,11 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
+          cache: pip
+          # There is no requirements file to hash, so key the pip download
+          # cache off the only dependency manifest in the repo.
+          cache-dependency-path: pyproject.toml
 
       - name: Install build tools
         run: pip install build twine

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,17 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
-      - uses: astral-sh/setup-uv@v6
+      # No floating major tag is published past v7, so pin the exact release.
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          # Also hands setup-uv the interpreter so the uv cache key is
+          # per-Python; otherwise every matrix leg races on one shared key.
+          python-version: ${{ matrix.python-version }}
+          # `auto` caches on push/pull_request but skips release and tag pushes,
+          # so the publish gate never restores a cache it could be poisoned by.
+          enable-cache: auto
 
       - name: Run tests
         run: uv run --python ${{ matrix.python-version }} --extra dev pytest -q


### PR DESCRIPTION
Bumps `actions/checkout` v5 → v7, `actions/setup-python` v6 → v7, and `astral-sh/setup-uv` v6 → v10.0.1 — the latter SHA-pinned because upstream stopped publishing floating major tags after v7 and this workflow gates the PyPI publish. Both `v7` majors are ESM/dependency migrations, and the one behavioral change in checkout (blocking fork checkouts) applies only to `pull_request_target`/`workflow_run`, which we don't use.

The uv cache was already enabled by default, but all five matrix legs computed the same cache key and raced on a single entry, so four of five saves lost; passing `python-version` to `setup-uv` puts the interpreter in the key so each leg gets its own cache. `enable-cache` stays on `auto` so the release/tag-push path used by the publish gate still skips cache restore.

The publish job additionally caches pip downloads for `build`/`twine`, keyed off `pyproject.toml` since there is no requirements file to hash. `actionlint` is clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes; cache policy explicitly avoids restore on release/tag pushes that gate PyPI publish.
> 
> **Overview**
> **Updates GitHub Actions** in the test and PyPI publish workflows: `actions/checkout` and `actions/setup-python` move to **v7**, and `astral-sh/setup-uv` is bumped to **v10.0.1** with a **SHA pin** (no floating major tag past v7) because this matrix gates publishing.
> 
> **Fixes uv caching** on the multi-Python test matrix by passing `python-version` into `setup-uv` so each leg gets its own cache key instead of racing on one shared entry. **`enable-cache: auto`** is set explicitly so cache restore is skipped on release/tag events used by the publish gate.
> 
> The **publish job** adds **pip download caching** for `build`/`twine`, with `cache-dependency-path` set to `pyproject.toml` because there is no requirements file to hash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b058d3b5c7d6c40eca24c2192aad774c0bdac62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->