### PR TITLE
chore(release): 0.5.26 with yutori 0.9.24

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.25"
+version = "0.5.26"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"
@@ -30,10 +30,10 @@ dependencies = [
     # breaks the install as soon as 2.x resolves.
     "mcp>=1.0.0,<2.0.0",
     "pydantic>=2.0.0",
-    # SDK 0.9.23 reverts the cursor-anchored run-command panel: the shell rail is
-    # back under the menu bar, the capsule carries "$ <command>" again, and the
-    # bundled overlay runtime is back on renderer protocol 3.
-    "yutori==0.9.23",
+    # SDK 0.9.24 re-bundles navigator overlay runtime 0.5.0 (renderer protocol 4),
+    # restoring the shared overlay work the 0.9.23 revert dropped. The rail stays
+    # under the menu bar and the capsule keeps carrying "$ <command>".
+    "yutori==0.9.24",
 ]
 
 [project.optional-dependencies]

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -33,12 +33,12 @@ DELIVERY_MODES = (DELIVERY_MODE_FOREGROUND, DELIVERY_MODE_BACKGROUND)
 # also hides it from recorders. Read by the runner; the supervisor forwards it to the runner's
 # environment.
 ENV_RECORDABLE_OVERLAY = "YUTORI_RECORDABLE_OVERLAY"
-SDK_VERSION = "0.9.23"
+SDK_VERSION = "0.9.24"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.
-SDK_ARTIFACT_SHA256 = "88f79c54c1a2dc72c47fd79fc31617fd5295b60790be24993b398ca3fd76c890"
-SDK_INSTALLATION_SHA256 = "6ac1ba6b3cf5ad2c00155d0cccd4efec3ef0d7dc83066ce69ce294eaf1b2eb3e"
-SDK_PROVENANCE_SHA256 = "7cab595d2f00e1a9ab5cd121204fbd6dd4c24163ead3eb76f76eef7fba495fc4"
+SDK_ARTIFACT_SHA256 = "2b1696edc1d23eec7176de5aba935f623b1962769ae01c24cf93f9b3842cec17"
+SDK_INSTALLATION_SHA256 = "7786d67d6728abe3dcf4bb5bc8f95b125038330185cfa0abb99bebffd42197a4"
+SDK_PROVENANCE_SHA256 = "cacc3ed5af3d6c5c8daeef60be4aa63e0af25b1d51770ef54d6a8f9db6811cee"
 
 # The cua-driver release that implements this tool contract, and the checksum
 # of its installer script. Both are hard gates.

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -871,9 +871,9 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 
 def test_runtime_constants_select_latest_python_surface():
     assert TOOL_SET == "computer_use_tools-20260830"
-    assert SDK_VERSION == "0.9.23"
+    assert SDK_VERSION == "0.9.24"
     assert all(len(digest) == 64 for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256))
-    assert '"yutori==0.9.23"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
+    assert '"yutori==0.9.24"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
 
 
 def test_installed_sdk_matches_the_published_artifact():

--- a/uv.lock
+++ b/uv.lock
@@ -1370,7 +1370,7 @@ wheels = [
 
 [[package]]
 name = "yutori"
-version = "0.9.23"
+version = "0.9.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1379,14 +1379,14 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/01/55b934255f3401cacb92d0b3d7fcd260c47e21e5b32e86cf6c8c4378f706/yutori-0.9.23.tar.gz", hash = "sha256:45bd281f996cc5cfee5291606e4929424bea5f35bc25c801d45800a52706f169", size = 478327, upload-time = "2026-09-10T16:15:45.358Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/83/646e748eb8ccba09903f5132c52cdeb0de1e3519fe3346ec00bf9849c41f/yutori-0.9.24.tar.gz", hash = "sha256:31a7cd725103780bbf3414380ba931eae77db2e764293a83dccc6b2199015da0", size = 480575, upload-time = "2026-09-10T17:02:34.415Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/db/f8/96f7914298b59f7154e55f695446613709cb4d0ead11ee0e6d707d2ccb65/yutori-0.9.23-py3-none-any.whl", hash = "sha256:88f79c54c1a2dc72c47fd79fc31617fd5295b60790be24993b398ca3fd76c890", size = 334397, upload-time = "2026-09-10T16:15:43.897Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d8/74b6a26bb7247ea4008dbf948b5d6c739b0e9f6b35de6e86078994e2f976/yutori-0.9.24-py3-none-any.whl", hash = "sha256:2b1696edc1d23eec7176de5aba935f623b1962769ae01c24cf93f9b3842cec17", size = 336446, upload-time = "2026-09-10T17:02:32.043Z" },
 ]
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.25"
+version = "0.5.26"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -1406,6 +1406,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "yutori", specifier = "==0.9.23" },
+    { name = "yutori", specifier = "==0.9.24" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
Bumps `yutori-mcp` to 0.5.26 and repins the SDK at `yutori==0.9.24`, which re-bundles navigator overlay runtime 0.5.0 ([SDK #430](https://github.com/yutori-ai/yutori-sdk-python/pull/430)) — the shared overlay work from [yutori#13269](https://github.com/yutori-ai/yutori/pull/13269) that reverting SDK #418 had dropped. The run-command rail stays under the menu bar and the capsule keeps carrying `$ <command>`.

Artifact and installed-distribution digests move with the new wheel. The provenance digest returns to `cacc3ed5…6811cee`, the same value 0.5.24 pinned — the restore reproduces the protocol-4 `provenance.json` byte for byte.

Verified against the published wheel: `YUTORI_MCP_VERIFY_PUBLISHED_ARTIFACT=1 uv run pytest` — 499 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and digest-only release with no application logic changes; risk is limited to users needing the new SDK wheel for computer-use preflight to pass.
> 
> **Overview**
> Releases **yutori-mcp 0.5.26** and repins the computer-use runtime to **`yutori==0.9.24`**, moving off 0.9.23. The dependency comment notes 0.9.24 re-bundles **navigator overlay runtime 0.5.0** (renderer **protocol 4**), restoring shared overlay behavior that the 0.9.23 revert had removed, while keeping the run-command rail under the menu bar and the `$ <command>` capsule.
> 
> **`constants.py`** updates `SDK_VERSION` and the artifact, installation, and provenance SHA256 digests so doctor/preflight and the runner’s ready handshake still reject SDK drift. **`uv.lock`**, **`pyproject.toml`**, and **`test_computer_use.py`** assertions are aligned with the new pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0e634d9ffed3648d98888809a7df2b3912c9351. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->