### PR TITLE
chore(release): 0.5.27 with yutori 0.9.25

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.26"
+version = "0.5.27"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"
@@ -30,10 +30,10 @@ dependencies = [
     # breaks the install as soon as 2.x resolves.
     "mcp>=1.0.0,<2.0.0",
     "pydantic>=2.0.0",
-    # SDK 0.9.24 re-bundles navigator overlay runtime 0.5.0 (renderer protocol 4),
-    # restoring the shared overlay work the 0.9.23 revert dropped. The rail stays
-    # under the menu bar and the capsule keeps carrying "$ <command>".
-    "yutori==0.9.24",
+    # SDK 0.9.25 presents a foreground shell command as the renderer's
+    # cursor-attached RUN COMMAND card; the rail under the menu bar now carries
+    # only the commands with no cursor of their own (background, status mode).
+    "yutori==0.9.25",
 ]
 
 [project.optional-dependencies]

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -33,11 +33,11 @@ DELIVERY_MODES = (DELIVERY_MODE_FOREGROUND, DELIVERY_MODE_BACKGROUND)
 # also hides it from recorders. Read by the runner; the supervisor forwards it to the runner's
 # environment.
 ENV_RECORDABLE_OVERLAY = "YUTORI_RECORDABLE_OVERLAY"
-SDK_VERSION = "0.9.24"
+SDK_VERSION = "0.9.25"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.
-SDK_ARTIFACT_SHA256 = "2b1696edc1d23eec7176de5aba935f623b1962769ae01c24cf93f9b3842cec17"
-SDK_INSTALLATION_SHA256 = "7786d67d6728abe3dcf4bb5bc8f95b125038330185cfa0abb99bebffd42197a4"
+SDK_ARTIFACT_SHA256 = "95e27ec2429600ff6339318d35946deb119a4067cf1dc1879d8287751513be56"
+SDK_INSTALLATION_SHA256 = "24b224147a6ffa82675d426f8af063ae127fb966b3502fcac045740e586ba832"
 SDK_PROVENANCE_SHA256 = "cacc3ed5af3d6c5c8daeef60be4aa63e0af25b1d51770ef54d6a8f9db6811cee"
 
 # The cua-driver release that implements this tool contract, and the checksum

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -871,9 +871,9 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 
 def test_runtime_constants_select_latest_python_surface():
     assert TOOL_SET == "computer_use_tools-20260830"
-    assert SDK_VERSION == "0.9.24"
+    assert SDK_VERSION == "0.9.25"
     assert all(len(digest) == 64 for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256))
-    assert '"yutori==0.9.24"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
+    assert '"yutori==0.9.25"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
 
 
 def test_installed_sdk_matches_the_published_artifact():

--- a/uv.lock
+++ b/uv.lock
@@ -1370,7 +1370,7 @@ wheels = [
 
 [[package]]
 name = "yutori"
-version = "0.9.24"
+version = "0.9.25"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1379,14 +1379,14 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/20/83/646e748eb8ccba09903f5132c52cdeb0de1e3519fe3346ec00bf9849c41f/yutori-0.9.24.tar.gz", hash = "sha256:31a7cd725103780bbf3414380ba931eae77db2e764293a83dccc6b2199015da0", size = 480575, upload-time = "2026-09-10T17:02:34.415Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/e3/10bf938f3bfc8c111243d3899c5b8ae7eedcc460db7ae1f142bb56b2d1b2/yutori-0.9.25.tar.gz", hash = "sha256:82f6fe756c0c0faf3d83b4298fbddd6da87ac878fdeeb89768776376e0c1f203", size = 481926, upload-time = "2026-09-10T18:00:51.656Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d8/74b6a26bb7247ea4008dbf948b5d6c739b0e9f6b35de6e86078994e2f976/yutori-0.9.24-py3-none-any.whl", hash = "sha256:2b1696edc1d23eec7176de5aba935f623b1962769ae01c24cf93f9b3842cec17", size = 336446, upload-time = "2026-09-10T17:02:32.043Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/09/2b69deb55509a18de6e0245fb93f3ce268dc972c20d80e12e7c6243a06a9/yutori-0.9.25-py3-none-any.whl", hash = "sha256:95e27ec2429600ff6339318d35946deb119a4067cf1dc1879d8287751513be56", size = 337348, upload-time = "2026-09-10T18:00:49.906Z" },
 ]
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.26"
+version = "0.5.27"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -1406,6 +1406,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "yutori", specifier = "==0.9.24" },
+    { name = "yutori", specifier = "==0.9.25" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
Bumps `yutori-mcp` to 0.5.27 and repins the SDK at `yutori==0.9.25`, which presents a foreground shell command as the renderer's cursor-attached `RUN COMMAND` card ([SDK #432](https://github.com/yutori-ai/yutori-sdk-python/pull/432)) instead of the rail under the menu bar — the presentation [yutori#13269](https://github.com/yutori-ai/yutori/pull/13269) built `showTerminal` for. The rail now carries only the commands with no cursor of their own: background commands and every command in a status-mode run.

Artifact and installed-distribution digests move with the new wheel; the provenance digest is unchanged, since 0.9.25 does not touch the bundled runtime.

Verified on a real foreground desktop run before release, and against the published wheel: `YUTORI_MCP_VERIFY_PUBLISHED_ARTIFACT=1 uv run pytest` — 499 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version pin and digest updates only; behavior change lives in the upstream SDK overlay presentation, with existing preflight checks enforcing the new wheel.
> 
> **Overview**
> Releases **yutori-mcp 0.5.27** and repins the computer-use runtime to **`yutori==0.9.25`**, aligning with the SDK’s updated shell UI: foreground commands show as a cursor-attached **RUN COMMAND** card, while the menu-bar rail is reserved for background and status-mode commands only.
> 
> `pyproject.toml` dependency comments, `SDK_VERSION`, and **wheel/installation SHA256** digests in `constants.py` are updated so doctor/preflight still gate on the published artifact; **provenance** digest is unchanged. Tests and `uv.lock` follow the new pins—no MCP server logic changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1099daca7e9855327b57314ce929a06d49afc7c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->