### PR TITLE
feat(computer-use): stream frames and the transcript to the host; presentation flag

### DIFF
--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -262,6 +262,8 @@ def _event_printer(
     started_at = clock() if started_at is None else started_at
 
     async def print_event(event: dict) -> None:
+        if event.get("type") in _HOST_ONLY_EVENT_TYPES:
+            return
         if event.get("type") == "ready":
             _print_milestone(paint, "runner process ready", started_at, clock=clock)
             return
@@ -275,6 +277,11 @@ def _event_printer(
         print("\n".join(format_terminal_action(event, paint)), flush=True)
 
     return print_event
+
+
+# Streamed for a host application's own rendering (`--json`); the terminal printer and the
+# MCP progress reporter have nothing to show for them.
+_HOST_ONLY_EVENT_TYPES = frozenset({"frame", "activity"})
 
 
 def _json_event_printer():
@@ -324,6 +331,7 @@ async def _run_custom(args: argparse.Namespace) -> int:
     )
     json_output = bool(getattr(args, "json", False))
     show_stop_button = not getattr(args, "hide_stop_item", False)
+    presentation = not getattr(args, "no_presentation", False)
     paint = Terminal.detect()
     preflight_started = time.monotonic()
     if _blocked(json_output=json_output):
@@ -332,6 +340,7 @@ async def _run_custom(args: argparse.Namespace) -> int:
         result = await run_task_with_resolved_credentials(
             **params.model_dump(),
             show_stop_button=show_stop_button,
+            presentation=presentation,
             on_event=_json_event_printer(),
         )
         _json_line({"type": "result", **result})
@@ -342,6 +351,7 @@ async def _run_custom(args: argparse.Namespace) -> int:
     result = await run_task_with_resolved_credentials(
         **params.model_dump(),
         show_stop_button=show_stop_button,
+        presentation=presentation,
         on_event=_event_printer(params.mode, params.app, paint, started_at=runner_started),
     )
     return _report(result, include_actions=False)
@@ -416,6 +426,15 @@ def register_parser(
         dest="hide_stop_item",
         action="store_true",
         help="Do not show the SDK's menu bar Stop item; the host application provides its own (the hotkey stays active)",
+    )
+    run_parser.add_argument(
+        "--no-presentation",
+        dest="no_presentation",
+        action="store_true",
+        help=(
+            "Show none of the SDK's surfaces (overlay, menu bar item, activity window, hotkey); "
+            "the host application renders the run from the --json frame and activity events"
+        ),
     )
     run_parser.add_argument("task", help="Task for the model to perform")
     run_parser.add_argument("--app", default=None, help="Application to target")

--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -332,6 +332,7 @@ async def _run_custom(args: argparse.Namespace) -> int:
     json_output = bool(getattr(args, "json", False))
     show_stop_button = not getattr(args, "hide_stop_item", False)
     presentation = not getattr(args, "no_presentation", False)
+    exclude_capture_window_ids = tuple(getattr(args, "exclude_capture_windows", None) or ())
     paint = Terminal.detect()
     preflight_started = time.monotonic()
     if _blocked(json_output=json_output):
@@ -341,6 +342,7 @@ async def _run_custom(args: argparse.Namespace) -> int:
             **params.model_dump(),
             show_stop_button=show_stop_button,
             presentation=presentation,
+            exclude_capture_window_ids=exclude_capture_window_ids,
             on_event=_json_event_printer(),
         )
         _json_line({"type": "result", **result})
@@ -352,6 +354,7 @@ async def _run_custom(args: argparse.Namespace) -> int:
         **params.model_dump(),
         show_stop_button=show_stop_button,
         presentation=presentation,
+        exclude_capture_window_ids=exclude_capture_window_ids,
         on_event=_event_printer(params.mode, params.app, paint, started_at=runner_started),
     )
     return _report(result, include_actions=False)
@@ -426,6 +429,17 @@ def register_parser(
         dest="hide_stop_item",
         action="store_true",
         help="Do not show the SDK's menu bar Stop item; the host application provides its own (the hotkey stays active)",
+    )
+    run_parser.add_argument(
+        "--exclude-capture-window",
+        dest="exclude_capture_windows",
+        action="append",
+        type=int,
+        metavar="WINDOW_ID",
+        help=(
+            "CGWindowID of a host application window to keep out of the model's desktop frames "
+            "(foreground runs); it stays on screen and in recordings. Repeatable."
+        ),
     )
     run_parser.add_argument(
         "--no-presentation",

--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import inspect
 import json
 import os
@@ -18,12 +19,17 @@ from typing import Any, TextIO
 from yutori import AsyncYutoriClient
 from yutori.navigator import N2ComputerAgent, flatten_batch_member
 from yutori.navigator.macos import (
+    MacOSComputer as _SDKMacOSComputer,
     MacOSPresentationStatus,
     MacOSTargetCrashedError,
     CancellationLatch,
     ShellPresentationEvent,
     sanitize_command_preview,
 )
+# The SDK's own activity-window row shaping, so a host application rendering the `activity`
+# stream shows exactly the conversation the SDK's activity window shows. Private to the SDK,
+# which this package pins by exact version and hash; tests guard the import.
+from yutori.navigator.macos.presentation import _transcript_entry as transcript_entry
 
 from .app import prepare_app
 from .constants import (
@@ -215,8 +221,9 @@ def parse_request(payload: Any) -> dict[str, Any]:
         raise RequestError("INVALID_REQUEST", "allow_foreground_fallback requires mode 'background'.")
     deadline_ms = _require_positive_int(payload, "deadline_ms")
     max_steps = _require_positive_int(payload, "max_steps")
-    # Optional so a protocol-v2 supervisor that predates the field keeps the SDK's default.
+    # Optional so a protocol-v2 supervisor that predates the fields keeps the SDK's defaults.
     show_stop_button = _require_bool(payload, "show_stop_button") if "show_stop_button" in payload else True
+    presentation = _require_bool(payload, "presentation") if "presentation" in payload else True
     return {
         "task": task,
         "app": app,
@@ -227,6 +234,7 @@ def parse_request(payload: Any) -> dict[str, Any]:
         "allow_foreground_fallback": allow_foreground_fallback,
         "allow_local_shell": allow_local_shell,
         "show_stop_button": show_stop_button,
+        "presentation": presentation,
         "model": _require_string(payload, "model"),
         "api_base_url": _require_string(payload, "api_base_url"),
     }
@@ -451,6 +459,92 @@ class ActionReporter:
         )
         self._index += 1
         self.tool_calls += 1
+
+
+class ActivityReporter:
+    """Stream the run's conversation and frames to the host as `activity` and `frame` events.
+
+    Sits between N2ComputerAgent and the SDK's native presentation controller as the agent's
+    presentation sink: every `present()` call is forwarded to the controller unchanged (when
+    there is one) and also shaped with the SDK's own activity-window row conversion into one
+    `activity` event, so a host application renders the same transcript the SDK's activity
+    window shows (task, thinking, actions, shell commands, final answer). Shell commands are
+    picked up from the computer's shell lifecycle so their rows are revised in place as they
+    finish. As an agent callback it also emits one `frame` per new observation, thumbnailed the
+    way the SDK's menu bar item thumbnails them.
+    """
+
+    def __init__(
+        self,
+        emitter: Emitter,
+        computer: MacOSComputer,
+        *,
+        inner: Any = None,
+        thumbnail: Callable[[bytes], bytes] | None = None,
+    ) -> None:
+        self._emitter = emitter
+        self._computer = computer
+        self._inner = inner
+        # The SDK's menu-bar thumbnail shaping (720px long side JPEG), taken from the SDK class
+        # rather than the instance so a stand-in computer in tests needs no such method.
+        self._thumbnail = thumbnail or _SDKMacOSComputer._thumbnail_jpeg
+        self._sequence = 0
+        self._shell_states: dict[str, tuple[str, int | None]] = {}
+        self._last_capture_id: int | None = None
+
+    async def present(self, event: dict[str, Any]) -> None:
+        if self._inner is not None:
+            try:
+                await self._inner.present(event)
+            except Exception:  # noqa: BLE001 - the SDK controller records its own degradation
+                pass
+        self._emit_entry(event)
+        self._emit_shell_updates()
+
+    async def on_computer_call_end(self, _item: dict[str, Any], _result: list[dict[str, Any]]) -> None:
+        self._emit_shell_updates()
+        await self.emit_frame()
+
+    def _emit_entry(self, event: dict[str, Any]) -> None:
+        try:
+            entry = transcript_entry(event, self._sequence)
+        except Exception:  # noqa: BLE001 - a row the SDK cannot shape is not worth the run
+            return
+        if entry is None:
+            return
+        self._sequence += 1
+        self._emitter.emit({"type": "activity", "entry": entry})
+
+    def _emit_shell_updates(self) -> None:
+        for shell_event in self._computer.shell_events:
+            key = (str(shell_event.state), shell_event.exit_code)
+            if self._shell_states.get(shell_event.task_id) == key:
+                continue
+            self._shell_states[shell_event.task_id] = key
+            entry = transcript_entry({"type": "shell", "event": shell_event}, self._sequence)
+            if entry is not None:
+                self._emitter.emit({"type": "activity", "entry": entry})
+
+    async def emit_frame(self) -> None:
+        observation = self._computer.current_observation
+        if observation is None or observation.capture_id == self._last_capture_id:
+            return
+        try:
+            jpeg = await asyncio.to_thread(self._thumbnail, observation.encoded_bytes)
+        except (OSError, ValueError):
+            return
+        self._last_capture_id = observation.capture_id
+        target = self._computer.target_window
+        caption = f"Frame {observation.capture_id}" + (f" of {target.describe()}" if target is not None else "")
+        self._emitter.emit(
+            {
+                "type": "frame",
+                "capture_id": observation.capture_id,
+                "media_type": "image/jpeg",
+                "data": base64.b64encode(jpeg).decode("ascii"),
+                "caption": caption,
+            }
+        )
 
 
 class ApiCounter:
@@ -739,7 +833,9 @@ def _computer_kwargs(
 ) -> dict[str, Any]:
     """MacOSComputer construction per mode; the foreground shape is the long-standing one."""
     kwargs: dict[str, Any] = {
-        "presentation": True,
+        # False lets a host application own every visible surface (no overlay, no status item,
+        # no hotkey); the host then also owns the stop shortcut.
+        "presentation": request.get("presentation", True),
         "show_stop_button": request.get("show_stop_button", True),
         "allow_local_shell": request["allow_local_shell"],
         "execution_deadline": deadline,
@@ -760,7 +856,12 @@ def _computer_kwargs(
 
 
 def _agent_base_kwargs(
-    request: dict[str, Any], *, completions: Any, computer: MacOSComputer, deadline: float
+    request: dict[str, Any],
+    *,
+    completions: Any,
+    computer: MacOSComputer,
+    deadline: float,
+    presentation: Any = None,
 ) -> dict[str, Any]:
     """N2ComputerAgent construction kwargs for the run's single agent lifecycle."""
     return {
@@ -771,7 +872,7 @@ def _agent_base_kwargs(
         "system_prompt": system_context(
             request["mode"], request["app"], request["allow_local_shell"]
         ),
-        "presentation": computer.presentation,
+        "presentation": presentation if presentation is not None else computer.presentation,
         "screenshot_delay": 0,
         "image_format": OBSERVATION_FORMAT,
         "execution_deadline": deadline,
@@ -982,14 +1083,16 @@ async def run_request(
 
                 computer.recover_target = recover_target
 
+            activity = ActivityReporter(emitter, computer, inner=computer.presentation)
             async with N2ComputerAgent(
                 **_agent_base_kwargs(
                     request,
                     completions=completions,
                     computer=computer,
                     deadline=deadline,
+                    presentation=activity,
                 ),
-                callbacks=[guard, reporter, api_counter, chat, startup],
+                callbacks=[guard, reporter, api_counter, chat, startup, activity],
             ) as agent:
                 final_text = await _collect_final_text(agent, request["task"])
                 if guard.limit_reached or guard.deadline_reached:

--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -200,6 +200,16 @@ def _require_bool(request: dict[str, Any], field: str) -> bool:
     return _require_field(request, field, valid=lambda v: isinstance(v, bool), expected="a boolean")
 
 
+def _require_window_ids(request: dict[str, Any], field: str) -> list[int]:
+    return _require_field(
+        request,
+        field,
+        valid=lambda v: isinstance(v, list)
+        and all(isinstance(item, int) and not isinstance(item, bool) and item > 0 for item in v),
+        expected="a list of positive integer window ids",
+    )
+
+
 def parse_request(payload: Any) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise RequestError("INVALID_REQUEST", "Request must be a JSON object.")
@@ -224,6 +234,9 @@ def parse_request(payload: Any) -> dict[str, Any]:
     # Optional so a protocol-v2 supervisor that predates the fields keeps the SDK's defaults.
     show_stop_button = _require_bool(payload, "show_stop_button") if "show_stop_button" in payload else True
     presentation = _require_bool(payload, "presentation") if "presentation" in payload else True
+    exclude_capture_window_ids = (
+        _require_window_ids(payload, "exclude_capture_window_ids") if "exclude_capture_window_ids" in payload else []
+    )
     return {
         "task": task,
         "app": app,
@@ -235,6 +248,7 @@ def parse_request(payload: Any) -> dict[str, Any]:
         "allow_local_shell": allow_local_shell,
         "show_stop_button": show_stop_button,
         "presentation": presentation,
+        "exclude_capture_window_ids": exclude_capture_window_ids,
         "model": _require_string(payload, "model"),
         "api_base_url": _require_string(payload, "api_base_url"),
     }
@@ -818,8 +832,12 @@ def _timings_payload(
 
 def _supports_background_mode() -> bool:
     """Whether the installed SDK's MacOSComputer has window scope (yutori >= 0.9.11)."""
+    return _computer_accepts("scope")
+
+
+def _computer_accepts(parameter: str) -> bool:
     try:
-        return "scope" in inspect.signature(MacOSComputer.__init__).parameters
+        return parameter in inspect.signature(MacOSComputer.__init__).parameters
     except (TypeError, ValueError):
         return False
 
@@ -852,6 +870,11 @@ def _computer_kwargs(
         )
     else:
         kwargs["exclude_overlay_from_capture"] = os.environ.get(ENV_RECORDABLE_OVERLAY) == "0"
+        # A host application's own panels, kept out of the model's desktop frames by the SDK's
+        # capturer while staying on screen and recordable. Only SDKs that know the parameter.
+        window_ids = request.get("exclude_capture_window_ids") or []
+        if window_ids and _computer_accepts("exclude_capture_window_ids"):
+            kwargs["exclude_capture_window_ids"] = tuple(window_ids)
     return kwargs
 
 

--- a/src/yutori_mcp/computer_use/supervisor.py
+++ b/src/yutori_mcp/computer_use/supervisor.py
@@ -9,7 +9,7 @@ import subprocess
 import sys
 import time
 from collections import deque
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from contextlib import suppress
 from pathlib import Path
 from typing import Any
@@ -472,6 +472,7 @@ async def run_task(
     allow_local_shell: bool = True,
     show_stop_button: bool = True,
     presentation: bool = True,
+    exclude_capture_window_ids: Sequence[int] = (),
     lock: DesktopLock | None = None,
     on_event: EventCallback | None = None,
 ) -> dict[str, Any]:
@@ -496,6 +497,9 @@ async def run_task(
                 # False when the host application renders the run itself (from the `frame` and
                 # `activity` events) and wants no SDK overlay, status item, or hotkey.
                 "presentation": presentation,
+                # CGWindowIDs of the host application's own panels to keep out of the model's
+                # desktop frames (foreground runs); they stay on screen and in recordings.
+                "exclude_capture_window_ids": [int(window_id) for window_id in exclude_capture_window_ids],
                 "model": MODEL,
                 "api_base_url": api_base_url,
             }

--- a/src/yutori_mcp/computer_use/supervisor.py
+++ b/src/yutori_mcp/computer_use/supervisor.py
@@ -278,6 +278,10 @@ def _event_shape_error(event: dict[str, Any]) -> str | None:
         }
     elif event_type == "error":
         required = {"code": str, "message": str}
+    elif event_type == "frame":
+        required = {"capture_id": int, "media_type": str, "data": str}
+    elif event_type == "activity":
+        required = {"entry": dict}
     else:
         return None
     invalid = [
@@ -353,7 +357,7 @@ async def _supervise(
             event_type = event.get("type")
             if shape_error := _event_shape_error(event):
                 return protocol_failure(f"emitted malformed {event_type!r} event: {shape_error}.")
-            if event_type in {"action", "startup"}:
+            if event_type in {"action", "startup", "frame", "activity"}:
                 if not ready:
                     return protocol_failure(f"emitted {event_type} before ready.")
                 if event_type == "action":
@@ -467,6 +471,7 @@ async def run_task(
     allow_foreground_fallback: bool = False,
     allow_local_shell: bool = True,
     show_stop_button: bool = True,
+    presentation: bool = True,
     lock: DesktopLock | None = None,
     on_event: EventCallback | None = None,
 ) -> dict[str, Any]:
@@ -488,6 +493,9 @@ async def run_task(
                 # False when the host application owns the menu bar surface (its own Stop item);
                 # the SDK's overlay hotkey stays registered either way.
                 "show_stop_button": show_stop_button,
+                # False when the host application renders the run itself (from the `frame` and
+                # `activity` events) and wants no SDK overlay, status item, or hotkey.
+                "presentation": presentation,
                 "model": MODEL,
                 "api_base_url": api_base_url,
             }

--- a/src/yutori_mcp/server.py
+++ b/src/yutori_mcp/server.py
@@ -615,6 +615,9 @@ def _progress_reporter(
     from .computer_use.result import describe_delivery_surface, format_action_line, format_startup_line
 
     async def on_event(event: dict[str, Any]) -> None:
+        if event.get("type") in {"frame", "activity"}:
+            # Host-rendering streams (thumbnails, transcript rows); not progress.
+            return
         if event.get("type") == "ready":
             surface = describe_delivery_surface(mode, app)
             message = f"Computer-use runner ready; driving {surface} (up to {max_steps} model turns)."

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import asyncio
 import hashlib
 import importlib.metadata
@@ -459,6 +460,22 @@ async def test_supervisor_forwards_ready_and_action_events():
     result = await _run_supervised(process, on_event=on_event)
     assert [event["type"] for event in seen] == ["ready", "startup", "action"]
     assert result["actions"] == [events[2]]
+
+
+async def test_supervisor_forwards_frame_and_activity_events_without_recording_them_as_actions():
+    frame = {"type": "frame", "capture_id": 1, "media_type": "image/jpeg", "data": "AAAA", "caption": "Frame 1"}
+    activity = {"type": "activity", "entry": {"id": "entry-0", "kind": "thinking", "text": "hm"}}
+    events = [_ready_event(reasoning_overlay_requested=True), frame, activity, _action_event(index=1), _result_event()]
+    process = _Process(_stream(*(json.dumps(event) for event in events)), _stream(""))
+    seen: list[dict] = []
+
+    async def on_event(event):
+        seen.append(event)
+
+    result = await _run_supervised(process, on_event=on_event)
+    assert [event["type"] for event in seen] == ["ready", "frame", "activity", "action"]
+    assert result["outcome"] == "completed"
+    assert [action["type"] for action in result["actions"]] == ["action"]
 
 
 async def test_supervisor_does_not_let_a_blocked_progress_callback_stall_protocol_drain(monkeypatch):
@@ -1890,7 +1907,9 @@ async def test_run_request_wires_sdk_runtime_and_reports_effective_state(monkeyp
         "exclude_overlay_from_capture": False,
     }
     assert agent.kwargs["tool_set"] == TOOL_SET
-    assert agent.kwargs["presentation"] is computer.presentation
+    # The agent's sink is the activity tee wrapping the SDK's own controller.
+    assert isinstance(agent.kwargs["presentation"], runner_module.ActivityReporter)
+    assert agent.kwargs["presentation"]._inner is computer.presentation
     assert agent.kwargs["image_format"] == OBSERVATION_FORMAT == "webp"
     assert agent.kwargs["supports_click_modifiers"] is True
     assert "Shell commands run headlessly" in agent.kwargs["system_prompt"]
@@ -2097,7 +2116,8 @@ async def test_run_request_carries_the_chat_id_on_actions_and_the_result(monkeyp
     assert await runner_module.run_request(request, Emitter(stream), "yt-secret") == "completed"
 
     events = [json.loads(line) for line in stream.lines]
-    action, result = events[-2], events[-1]
+    # `activity` and `frame` events interleave with actions, so pick the last action by type.
+    action, result = [event for event in events if event["type"] == "action"][-1], events[-1]
     assert (action["type"], action["chat_id"]) == ("action", "req-first")
     assert (result["type"], result["chat_id"]) == ("result", "req-first")
 
@@ -2581,7 +2601,9 @@ async def test_run_request_background_binds_the_window_and_never_fronts(monkeypa
     assert computer.window_targets == [_FakeWindowTarget(42, 7, app_name="Notes")]
     assert computer.target_pid == 42
     assert agent.kwargs["system_prompt"].startswith("You control exactly one application window: Notes.")
-    assert agent.kwargs["presentation"] is computer.presentation
+    # The agent's sink is the activity tee wrapping the SDK's own controller.
+    assert isinstance(agent.kwargs["presentation"], runner_module.ActivityReporter)
+    assert agent.kwargs["presentation"]._inner is computer.presentation
     result = json.loads(stream.lines[-1])
     assert result["delivery_mode"] == "background"
     assert result["reasoning_overlay_requested"] is True and result["reasoning_overlay_effective"] is True
@@ -3565,3 +3587,219 @@ def test_setup_skips_the_standalone_installer_for_an_embedded_host(monkeypatch, 
     assert cli._setup() == 0
     out = capsys.readouterr().out
     assert "nothing to install" in out and str(binary) in out
+
+
+# ---------------------------------------------------------------------------
+# Host rendering: `activity` transcript rows and `frame` thumbnails; the presentation flag.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeObservation:
+    capture_id: int
+    encoded_bytes: bytes = b"frame-bytes"
+
+
+class _FakeTarget:
+    def describe(self) -> str:
+        return "Calculator (pid 5, window 9)"
+
+
+class _FakeActivityComputer:
+    def __init__(self) -> None:
+        self.current_observation = None
+        self.target_window = None
+        self.shell_events: tuple[ShellPresentationEvent, ...] = ()
+
+    @staticmethod
+    def _thumbnail_jpeg(image_bytes: bytes) -> bytes:
+        return b"thumb:" + image_bytes
+
+
+class _RecordingPresentation:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    async def present(self, event: dict[str, Any]) -> None:
+        self.events.append(event)
+
+
+def _activity_reporter():
+    stream = io.StringIO()
+    computer = _FakeActivityComputer()
+    inner = _RecordingPresentation()
+    reporter = runner_module.ActivityReporter(
+        Emitter(stream), computer, inner=inner, thumbnail=_FakeActivityComputer._thumbnail_jpeg
+    )
+    return reporter, computer, inner, stream
+
+
+def _events(stream: io.StringIO) -> list[dict[str, Any]]:
+    return [json.loads(line) for line in stream.getvalue().splitlines() if line.strip()]
+
+
+async def test_activity_reporter_tees_presentation_events_into_sdk_shaped_rows():
+    reporter, _computer, inner, stream = _activity_reporter()
+    await reporter.present({"type": "task", "text": "Compute 9 * 9"})
+    await reporter.present({"type": "reasoning", "text": "I should open Calculator."})
+    await reporter.present({"type": "action", "name": "left_click", "arguments": {"coordinates": [100, 20]}})
+    await reporter.present({"type": "request"})  # nothing to show
+    await reporter.present({"type": "final", "text": "81"})
+
+    assert [event["type"] for event in inner.events] == ["task", "reasoning", "action", "request", "final"]
+    entries = [event["entry"] for event in _events(stream) if event["type"] == "activity"]
+    assert [entry["kind"] for entry in entries] == ["task", "thinking", "action", "final"]
+    assert entries[0] == {"id": "entry-0", "kind": "task", "text": "Compute 9 * 9"}
+    assert entries[2]["text"] == "left click at (100, 20)" and entries[2]["icon"] == "click"
+    assert entries[3]["text"] == "81"
+
+
+async def test_activity_reporter_forwards_even_when_the_native_controller_fails():
+    class Failing:
+        async def present(self, _event):
+            raise RuntimeError("host gone")
+
+    stream = io.StringIO()
+    reporter = runner_module.ActivityReporter(Emitter(stream), _FakeActivityComputer(), inner=Failing())
+    await reporter.present({"type": "reasoning", "text": "still reported"})
+    assert _events(stream)[0]["entry"]["kind"] == "thinking"
+
+
+async def test_activity_reporter_streams_one_frame_per_new_observation_with_the_sdk_caption():
+    reporter, computer, _inner, stream = _activity_reporter()
+    await reporter.on_computer_call_end({}, [])
+    assert _events(stream) == [], "no observation yet, no frame"
+
+    computer.current_observation = _FakeObservation(capture_id=1)
+    computer.target_window = _FakeTarget()
+    await reporter.on_computer_call_end({}, [])
+    await reporter.on_computer_call_end({}, [])  # same capture: not repeated
+    computer.current_observation = _FakeObservation(capture_id=2, encoded_bytes=b"second")
+    await reporter.on_computer_call_end({}, [])
+
+    frames = [event for event in _events(stream) if event["type"] == "frame"]
+    assert [frame["capture_id"] for frame in frames] == [1, 2]
+    assert frames[0]["caption"] == "Frame 1 of Calculator (pid 5, window 9)"
+    assert frames[0]["media_type"] == "image/jpeg"
+    assert base64.b64decode(frames[1]["data"]) == b"thumb:second"
+
+
+async def test_activity_reporter_revises_shell_rows_in_place_as_commands_finish():
+    reporter, computer, _inner, stream = _activity_reporter()
+    computer.shell_events = (ShellPresentationEvent("t1", "ls ~", False, "running"),)
+    await reporter.on_computer_call_end({}, [])
+    computer.shell_events = (ShellPresentationEvent("t1", "ls ~", False, "completed", 0),)
+    await reporter.present({"type": "request"})
+    await reporter.present({"type": "request"})  # unchanged shell state: not repeated
+
+    rows = [event["entry"] for event in _events(stream) if event["type"] == "activity"]
+    assert [(row["id"], row["state"], row["exitCode"]) for row in rows] == [
+        ("shell-t1", "running", None),
+        ("shell-t1", "completed", 0),
+    ]
+    assert rows[0]["command"] == "ls ~" and rows[0]["kind"] == "shell"
+
+
+def test_parse_request_defaults_presentation_and_validates_it():
+    assert parse_request(_valid_request())["presentation"] is True
+    assert parse_request(_valid_request(presentation=False))["presentation"] is False
+    with pytest.raises(RequestError, match="presentation must be a boolean"):
+        parse_request(_valid_request(presentation="off"))
+
+
+def test_computer_kwargs_forward_the_presentation_choice():
+    request = parse_request(_valid_request(presentation=False))
+    kwargs = runner_module._computer_kwargs(
+        request, deadline=time.monotonic() + 60, cancellation=runner_module.CancellationLatch(), api_key="k"
+    )
+    assert kwargs["presentation"] is False
+
+
+def test_agent_kwargs_route_presentation_through_the_activity_sink():
+    computer = SimpleNamespace(presentation=object())
+    sink = object()
+    request = parse_request(_valid_request())
+    routed = runner_module._agent_base_kwargs(
+        request, completions=None, computer=computer, deadline=1.0, presentation=sink
+    )
+    assert routed["presentation"] is sink
+    default = runner_module._agent_base_kwargs(request, completions=None, computer=computer, deadline=1.0)
+    assert default["presentation"] is computer.presentation
+
+
+@pytest.mark.parametrize(
+    ("event", "ok"),
+    [
+        ({"type": "frame", "capture_id": 1, "media_type": "image/jpeg", "data": "AAAA"}, True),
+        ({"type": "frame", "capture_id": "1", "media_type": "image/jpeg", "data": "AAAA"}, False),
+        ({"type": "frame", "capture_id": 1, "media_type": "image/jpeg"}, False),
+        ({"type": "activity", "entry": {"id": "entry-0", "kind": "thinking", "text": "x"}}, True),
+        ({"type": "activity", "entry": "not a row"}, False),
+    ],
+)
+def test_supervisor_validates_frame_and_activity_event_shapes(event, ok):
+    assert (supervisor._event_shape_error(event) is None) is ok
+
+
+async def test_run_task_request_carries_presentation(tmp_path):
+    with _patched_run_task_supervise(tmp_path) as supervise:
+        await run_task(**_run_task_kwargs(tmp_path, presentation=False))
+    assert supervise.await_args.kwargs["request"]["presentation"] is False
+    with _patched_run_task_supervise(tmp_path) as supervise:
+        await run_task(**_run_task_kwargs(tmp_path))
+    assert supervise.await_args.kwargs["request"]["presentation"] is True
+
+
+def test_cli_run_parser_accepts_no_presentation():
+    from yutori_mcp.computer_use import cli
+
+    parser = argparse.ArgumentParser()
+    cli.register_parser(parser.add_subparsers(dest="command"))
+    assert parser.parse_args(["computer-use", "run", "x", "--no-presentation"]).no_presentation is True
+    assert parser.parse_args(["computer-use", "run", "x"]).no_presentation is False
+
+
+async def test_cli_run_forwards_presentation_and_json_streams_host_only_events(monkeypatch, capsys):
+    from yutori_mcp.computer_use import cli
+
+    frame = {"type": "frame", "capture_id": 1, "media_type": "image/jpeg", "data": "AAAA"}
+
+    async def run(**kwargs):
+        await kwargs["on_event"](frame)
+        await kwargs["on_event"]({"type": "activity", "entry": {"id": "entry-0", "kind": "thinking", "text": "hm"}})
+        return {"outcome": "completed", "delivery_mode": "background", "final_text": "done"}
+
+    monkeypatch.setattr(cli, "_blocked", lambda **_kwargs: False)
+    monkeypatch.setattr(supervisor, "run_task", run)
+    _patch_run_credentials(monkeypatch)
+
+    args = _run_args(json=True, mode="background", app="Notes", no_presentation=True)
+    assert await cli._run_custom(args) == 0
+    lines = _json_lines(capsys.readouterr().out)
+    assert [line["type"] for line in lines] == ["frame", "activity", "result"]
+
+    captured = AsyncMock(return_value={"outcome": "completed", "delivery_mode": "foreground", "final_text": "ok"})
+    monkeypatch.setattr(supervisor, "run_task", captured)
+    assert await cli._run_custom(_run_args(no_presentation=True)) == 0
+    assert captured.await_args.kwargs["presentation"] is False
+    assert "frame" not in capsys.readouterr().out
+
+
+async def test_cli_text_printer_ignores_host_only_events(capsys):
+    from yutori_mcp.computer_use import cli
+
+    printer = cli._event_printer("foreground", None, _PLAIN_TERMINAL, started_at=0.0, clock=lambda: 1.0)
+    await printer({"type": "frame", "capture_id": 1, "media_type": "image/jpeg", "data": "AAAA"})
+    await printer({"type": "activity", "entry": {"id": "entry-0", "kind": "thinking", "text": "hm"}})
+    assert capsys.readouterr().out == ""
+
+
+async def test_progress_reporter_ignores_host_only_events():
+    from yutori_mcp import server
+
+    ctx = SimpleNamespace(report_progress=AsyncMock(), info=AsyncMock())
+    on_event = server._progress_reporter(ctx, 10)
+    await on_event({"type": "frame", "capture_id": 1, "media_type": "image/jpeg", "data": "AAAA"})
+    await on_event({"type": "activity", "entry": {"id": "entry-0", "kind": "thinking", "text": "hm"}})
+    ctx.report_progress.assert_not_awaited()
+    ctx.info.assert_not_awaited()

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -3803,3 +3803,52 @@ async def test_progress_reporter_ignores_host_only_events():
     await on_event({"type": "activity", "entry": {"id": "entry-0", "kind": "thinking", "text": "hm"}})
     ctx.report_progress.assert_not_awaited()
     ctx.info.assert_not_awaited()
+
+
+def test_parse_request_validates_host_window_ids():
+    assert parse_request(_valid_request())["exclude_capture_window_ids"] == []
+    assert parse_request(_valid_request(exclude_capture_window_ids=[101, 202]))["exclude_capture_window_ids"] == [101, 202]
+    for invalid in ("101", [0], [True], [1.5]):
+        with pytest.raises(RequestError, match="exclude_capture_window_ids must be a list of positive integer window ids"):
+            parse_request(_valid_request(exclude_capture_window_ids=invalid))
+
+
+def test_computer_kwargs_pass_host_window_ids_only_to_an_sdk_that_knows_them(monkeypatch):
+    request = parse_request(_valid_request(exclude_capture_window_ids=[101, 202]))
+    common = {"deadline": time.monotonic() + 60, "cancellation": runner_module.CancellationLatch(), "api_key": "k"}
+    monkeypatch.setattr(runner_module, "_computer_accepts", lambda parameter: True)
+    assert runner_module._computer_kwargs(request, **common)["exclude_capture_window_ids"] == (101, 202)
+    monkeypatch.setattr(runner_module, "_computer_accepts", lambda parameter: parameter == "scope")
+    assert "exclude_capture_window_ids" not in runner_module._computer_kwargs(request, **common)
+    background = parse_request(_valid_request(app="Notes", mode="background", exclude_capture_window_ids=[101]))
+    monkeypatch.setattr(runner_module, "_computer_accepts", lambda parameter: True)
+    assert "exclude_capture_window_ids" not in runner_module._computer_kwargs(background, **common), (
+        "window scope captures only the driven window; nothing to exclude"
+    )
+
+
+async def test_run_task_and_cli_carry_host_window_ids(monkeypatch, tmp_path, capsys):
+    with _patched_run_task_supervise(tmp_path) as supervise:
+        await run_task(**_run_task_kwargs(tmp_path, exclude_capture_window_ids=(101, 202)))
+    assert supervise.await_args.kwargs["request"]["exclude_capture_window_ids"] == [101, 202]
+    with _patched_run_task_supervise(tmp_path) as supervise:
+        await run_task(**_run_task_kwargs(tmp_path))
+    assert supervise.await_args.kwargs["request"]["exclude_capture_window_ids"] == []
+
+    from yutori_mcp.computer_use import cli
+
+    parser = argparse.ArgumentParser()
+    cli.register_parser(parser.add_subparsers(dest="command"))
+    parsed = parser.parse_args(
+        ["computer-use", "run", "x", "--exclude-capture-window", "101", "--exclude-capture-window", "202"]
+    )
+    assert parsed.exclude_capture_windows == [101, 202]
+    assert parser.parse_args(["computer-use", "run", "x"]).exclude_capture_windows is None
+
+    captured = AsyncMock(return_value={"outcome": "completed", "delivery_mode": "foreground", "final_text": "ok"})
+    monkeypatch.setattr(cli, "_blocked", lambda **_kwargs: False)
+    monkeypatch.setattr(supervisor, "run_task", captured)
+    _patch_run_credentials(monkeypatch)
+    assert await cli._run_custom(_run_args(json=True, exclude_capture_windows=[101, 202])) == 0
+    assert captured.await_args.kwargs["exclude_capture_window_ids"] == (101, 202)
+    capsys.readouterr()


### PR DESCRIPTION
## Summary

Yutori Local's tray now mirrors the SDK's status item during a run (live frame, caption, Show activity, Stop) and has its own activity window. This gives the runtime the two streams that needs, and a way to turn the SDK's own surfaces off when the host owns them.

- **`frame` events**: the latest observation thumbnailed exactly like the SDK's menu-bar item (`MacOSComputer._thumbnail_jpeg`, 720px long side) with the SDK's caption, once per new capture.
- **`activity` events**: one transcript row per presentation event, shaped by the SDK's own `_transcript_entry` (task / thinking / action+icon / shell revised in place / error / final / system). `ActivityReporter` is the agent's presentation sink; it forwards every event to the native controller unchanged and tees the row to the protocol stream. Shell rows come from `computer.shell_events`.
- **`presentation` request flag** / `run --no-presentation`: `MacOSComputer(presentation=False)`, so a host rendering the run shows no SDK overlay, status item, activity window, or hotkey (the host owns ⇧⌘Esc then).
- Supervisor accepts and forwards `frame`/`activity` (shape-validated); the terminal printer and MCP progress reporter skip them.
- **`exclude_capture_window_ids`** / `run --exclude-capture-window ID` (repeatable): CGWindowIDs of the host's own panels, handed to `MacOSComputer(exclude_capture_window_ids=...)` for foreground runs when the pinned SDK knows the parameter (yutori-ai/yutori-sdk-python#434), so they stay out of the model's frames while remaining on screen and in recordings.

Protocol version stays 2: both fields are optional and the events are additive.

## Test plan

- [x] `pytest` (516 passed, 1 skipped): reporter tee + SDK-shaped rows, frame dedupe by capture id + caption, shell rows revised in place, flag parsing/kwargs/CLI, supervisor validation and forwarding, printer/progress ignore
- [x] Live from Yutori Local's bundled runtime: background Calculator run → tray menu shows title, "Frame 3 of Calculator (pid …)", the live thumbnail, Hide activity, Stop; activity window shows the frame, action rows, and the final answer; run completed (12×12=144)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the live run path (agent presentation sink, desktop capture exclusions, and high-volume frame events on stdout) but changes are additive with defaults preserving prior SDK-visible behavior.
> 
> **Overview**
> Adds **host-owned UI** for computer-use runs: the runner now streams **`frame`** (JPEG thumbnails + captions, deduped by capture id) and **`activity`** (SDK-shaped transcript rows via `ActivityReporter` teeing the agent presentation sink) through the existing JSONL protocol, while the terminal printer and MCP progress path **ignore** those event types.
> 
> **`presentation`** (CLI `--no-presentation`) turns off SDK overlay, menu bar item, activity window, and hotkey so the host renders from the stream. **`exclude_capture_window_ids`** (repeatable `--exclude-capture-window`) keeps host CGWindowIDs out of foreground desktop captures when the pinned SDK supports it.
> 
> Supervisor validates/forwards the new events; CLI and `run_task` wire the new flags through unchanged protocol v2 (optional fields).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 064b583c9b62cee7a200b66fbb3b898e5b9c0fa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

