### PR TITLE
Fix image reads in macOS computer use

### DIFF
--- a/src/yutori_mcp/computer_use/targeting.py
+++ b/src/yutori_mcp/computer_use/targeting.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import suppress
 
 from yutori.navigator.macos import FrontmostApp, MacOSComputer, MacOSFocusChangedError
+from yutori.navigator.sandbox_tools import render_image_result
+
+
+_IMAGE_SUFFIXES = frozenset({".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"})
 
 
 def _target_mismatch_message(
@@ -42,13 +47,32 @@ async def require_frontmost_target(
 
 
 class TargetGuardedMacOSComputer(MacOSComputer):
-    """Require an app-scoped desktop session's target PID before sending keyboard input.
+    """Apply the local harness's macOS-specific guards and file handling.
 
     The SDK's focus guard prevents a change *after* a screenshot. It deliberately accepts
     whichever app that screenshot observed. Once this repository assigns ``target_pid`` for
     an app-scoped foreground run, accepting a different baseline would send text or shortcuts
     to the wrong application, so this stricter guard fails closed instead.
+
+    The SDK's generic n2 loop supports file handlers returning image content, but its macOS
+    adapter in the pinned release still decodes every ``read`` target as UTF-8. Match the
+    sandbox adapter's image behavior here so reading a local image returns a model-visible
+    WebP instead of raising ``UnicodeDecodeError``.
     """
+
+    async def read_file(
+        self, file_path: str, offset: int = 1, limit: int = 2_000
+    ) -> "str | dict[str, str]":
+        self._require_local_shell()
+        if offset < 1:
+            raise ValueError("read.offset must be a positive 1-based line number")
+        path = self._resolve_file_path(file_path)
+        if path.suffix.lower() not in _IMAGE_SUFFIXES:
+            return await super().read_file(file_path, offset=offset, limit=limit)
+
+        data = await asyncio.to_thread(path.read_bytes)
+        self._file_snapshots[path] = ""
+        return render_image_result(file_path, data)
 
     async def _guard_frontmost(self, tool: str) -> None:
         if self.window_mode or not self.verify_focus or self.target_pid is None:

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -22,6 +22,7 @@ from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from PIL import Image
 from pydantic import ValidationError
 from yutori.navigator.macos import (
     FrontmostApp,
@@ -1508,6 +1509,33 @@ async def test_target_guarded_computer_leaves_window_scope_unchanged():
     await computer._guard_frontmost("hotkey")
 
     computer._probe_frontmost.assert_not_awaited()
+
+
+async def test_target_guarded_computer_reads_images_as_model_visible_content(tmp_path):
+    image_path = tmp_path / "example.png"
+    Image.new("RGB", (3, 2), color=(12, 34, 56)).save(image_path)
+    computer = object.__new__(TargetGuardedMacOSComputer)
+    computer.allow_local_shell = True
+    computer._bash_cwd = str(tmp_path)
+    computer._file_snapshots = {}
+
+    result = await computer.read_file("example.png")
+
+    assert result["text"] == "Loaded image example.png (3x2)"
+    assert result["image_url"].startswith("data:image/webp;base64,")
+    assert image_path in computer._file_snapshots
+
+
+async def test_target_guarded_computer_still_reads_text_with_line_numbers(tmp_path):
+    (tmp_path / "example.txt").write_text("first\nsecond\nthird\n", encoding="utf-8")
+    computer = object.__new__(TargetGuardedMacOSComputer)
+    computer.allow_local_shell = True
+    computer._bash_cwd = str(tmp_path)
+    computer._file_snapshots = {}
+
+    result = await computer.read_file("example.txt", offset=2, limit=1)
+
+    assert result == "     2\tsecond"
 
 
 async def test_smoke_reports_preflight_detail_and_fix(monkeypatch, tmp_path, capsys):


### PR DESCRIPTION
Handle PNG, JPEG, GIF, WebP, and BMP files through the model-visible image result path instead of decoding their bytes as UTF-8. Preserve the existing line-numbered behavior for text files. Adds regression coverage for both image and text reads.\n\nTests: `uv run python -m pytest -q` (500 passed, 1 skipped).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized override of read_file on the guarded macOS computer class; text reads unchanged and tests cover both paths.
> 
> **Overview**
> **macOS computer-use** `read_file` no longer treats image bytes as UTF-8 text. **`TargetGuardedMacOSComputer`** now detects common image extensions (PNG, JPEG, GIF, WebP, BMP), reads the file as bytes, and returns the same **model-visible WebP payload** as the sandbox adapter via `render_image_result`—avoiding **`UnicodeDecodeError`** during agent file reads.
> 
> Non-image paths still delegate to the base **`read_file`**, so **line-numbered text reads** are unchanged. The class docstring now documents both the stricter **target-PID focus guard** and this file-handling behavior.
> 
> Regression tests cover an image read (text caption + `data:image/webp;base64,` URL) and a partial text read with line numbers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3373a5d3b9372e7b3707bf427ec0d72685d98921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->