### PR TITLE
refactor(computer-use): extract _readable_computer() test helper

### DIFF
--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -1511,13 +1511,20 @@ async def test_target_guarded_computer_leaves_window_scope_unchanged():
     computer._probe_frontmost.assert_not_awaited()
 
 
-async def test_target_guarded_computer_reads_images_as_model_visible_content(tmp_path):
-    image_path = tmp_path / "example.png"
-    Image.new("RGB", (3, 2), color=(12, 34, 56)).save(image_path)
+def _readable_computer(tmp_path, **overrides):
     computer = object.__new__(TargetGuardedMacOSComputer)
     computer.allow_local_shell = True
     computer._bash_cwd = str(tmp_path)
     computer._file_snapshots = {}
+    for key, value in overrides.items():
+        setattr(computer, key, value)
+    return computer
+
+
+async def test_target_guarded_computer_reads_images_as_model_visible_content(tmp_path):
+    image_path = tmp_path / "example.png"
+    Image.new("RGB", (3, 2), color=(12, 34, 56)).save(image_path)
+    computer = _readable_computer(tmp_path)
 
     result = await computer.read_file("example.png")
 
@@ -1528,10 +1535,7 @@ async def test_target_guarded_computer_reads_images_as_model_visible_content(tmp
 
 async def test_target_guarded_computer_still_reads_text_with_line_numbers(tmp_path):
     (tmp_path / "example.txt").write_text("first\nsecond\nthird\n", encoding="utf-8")
-    computer = object.__new__(TargetGuardedMacOSComputer)
-    computer.allow_local_shell = True
-    computer._bash_cwd = str(tmp_path)
-    computer._file_snapshots = {}
+    computer = _readable_computer(tmp_path)
 
     result = await computer.read_file("example.txt", offset=2, limit=1)
 


### PR DESCRIPTION
## What

The just-landed #313 (image-file reading support) added two new `TargetGuardedMacOSComputer` tests in `tests/test_computer_use.py`:

- `test_target_guarded_computer_reads_images_as_model_visible_content`
- `test_target_guarded_computer_still_reads_text_with_line_numbers`

Each hand-built the identical 3-line setup:

```python
computer = object.__new__(TargetGuardedMacOSComputer)
computer.allow_local_shell = True
computer._bash_cwd = str(tmp_path)
computer._file_snapshots = {}
```

This mirrors the file's established convention of extracting a shared builder whenever a fixture shape is hand-duplicated across sites (`_patch_run_credentials`, `_action_event`, `_PLAIN_TERMINAL`, `_valid_request`, etc. — see the file's many `_foo(**overrides)` factory helpers). Extracted `_readable_computer(tmp_path, **overrides)`; both tests now build from it.

## Why it's safe

- Test-only change, zero production code touched.
- Zero behavior change: both call sites still construct byte-identical `TargetGuardedMacOSComputer` instances with the same three attributes set to the same values — just built once instead of twice.
- Full suite: `uv run pytest -q` → 500 passed / 1 skipped (matches the documented baseline — no coverage lost or added).
- `uv run ruff check .` clean. (`ruff format --check` flags this file, but confirmed via `git stash` that this is pre-existing on `main`, unrelated to this diff — the repo has no format-check CI gate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RLtds38ZnZSb8agGShyYhb

---
_Generated by [Claude Code](https://claude.ai/code/session_01RLtds38ZnZSb8agGShyYhb)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only deduplication with identical instance setup; no production or behavioral changes.
> 
> **Overview**
> Extracts **`_readable_computer(tmp_path, **overrides)`** in `tests/test_computer_use.py` so the two `TargetGuardedMacOSComputer` `read_file` tests no longer duplicate the same `object.__new__` + three-attribute setup.
> 
> Both **`test_target_guarded_computer_reads_images_as_model_visible_content`** and **`test_target_guarded_computer_still_reads_text_with_line_numbers`** now build the computer through that helper, matching the file’s other `**overrides` factory helpers. **Test-only refactor; no production code or runtime behavior change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 213b88b3913ae60cc9d53a27ee4ede4e5a502cef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->