### PR TITLE
chore(release): 0.5.28 with yutori 0.9.26

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.27"
+version = "0.5.28"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"
@@ -30,10 +30,11 @@ dependencies = [
     # breaks the install as soon as 2.x resolves.
     "mcp>=1.0.0,<2.0.0",
     "pydantic>=2.0.0",
-    # SDK 0.9.25 presents a foreground shell command as the renderer's
-    # cursor-attached RUN COMMAND card; the rail under the menu bar now carries
-    # only the commands with no cursor of their own (background, status mode).
-    "yutori==0.9.25",
+    # SDK 0.9.26 streams a running shell command's output into that card instead
+    # of holding a spinner for the command's whole duration, and re-bundles
+    # navigator overlay runtime 0.5.1, which grows the card's output block from
+    # two rendered rows to four.
+    "yutori==0.9.26",
 ]
 
 [project.optional-dependencies]

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -33,12 +33,12 @@ DELIVERY_MODES = (DELIVERY_MODE_FOREGROUND, DELIVERY_MODE_BACKGROUND)
 # also hides it from recorders. Read by the runner; the supervisor forwards it to the runner's
 # environment.
 ENV_RECORDABLE_OVERLAY = "YUTORI_RECORDABLE_OVERLAY"
-SDK_VERSION = "0.9.25"
+SDK_VERSION = "0.9.26"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.
-SDK_ARTIFACT_SHA256 = "95e27ec2429600ff6339318d35946deb119a4067cf1dc1879d8287751513be56"
-SDK_INSTALLATION_SHA256 = "24b224147a6ffa82675d426f8af063ae127fb966b3502fcac045740e586ba832"
-SDK_PROVENANCE_SHA256 = "cacc3ed5af3d6c5c8daeef60be4aa63e0af25b1d51770ef54d6a8f9db6811cee"
+SDK_ARTIFACT_SHA256 = "d4fa68c29d72e26bf470918036c93677e0cfd9a4d699dc900a03f79768997b70"
+SDK_INSTALLATION_SHA256 = "044ba07b30f484f530d516ec0de445a4a42dd791918c2149cf78868ca30fad59"
+SDK_PROVENANCE_SHA256 = "04ccce6bc1c85552bdb9ad68fc3973c88c3b4ddf7e2314e9779fc00a33812c3d"
 
 # The cua-driver release that implements this tool contract, and the checksum
 # of its installer script. Both are hard gates.

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -872,9 +872,9 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 
 def test_runtime_constants_select_latest_python_surface():
     assert TOOL_SET == "computer_use_tools-20260830"
-    assert SDK_VERSION == "0.9.25"
+    assert SDK_VERSION == "0.9.26"
     assert all(len(digest) == 64 for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256))
-    assert '"yutori==0.9.25"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
+    assert '"yutori==0.9.26"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
 
 
 def test_installed_sdk_matches_the_published_artifact():

--- a/uv.lock
+++ b/uv.lock
@@ -1370,7 +1370,7 @@ wheels = [
 
 [[package]]
 name = "yutori"
-version = "0.9.25"
+version = "0.9.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1379,14 +1379,14 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/e3/10bf938f3bfc8c111243d3899c5b8ae7eedcc460db7ae1f142bb56b2d1b2/yutori-0.9.25.tar.gz", hash = "sha256:82f6fe756c0c0faf3d83b4298fbddd6da87ac878fdeeb89768776376e0c1f203", size = 481926, upload-time = "2026-09-10T18:00:51.656Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/1f/7ceb4d0cbf03b0b01323fcd4341da3dace2777cb6fded2d47d369832861d/yutori-0.9.26.tar.gz", hash = "sha256:30be3fe62301ec1183a60b31087ec25f7cb2243ae21de43baaf45c47d8958ef2", size = 489587, upload-time = "2026-09-11T01:03:27.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/09/2b69deb55509a18de6e0245fb93f3ce268dc972c20d80e12e7c6243a06a9/yutori-0.9.25-py3-none-any.whl", hash = "sha256:95e27ec2429600ff6339318d35946deb119a4067cf1dc1879d8287751513be56", size = 337348, upload-time = "2026-09-10T18:00:49.906Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/c4/f0a87acd6f5b7b7e535fb7a10c223ccaeec35d52ef088359aa7a27d9b4b4/yutori-0.9.26-py3-none-any.whl", hash = "sha256:d4fa68c29d72e26bf470918036c93677e0cfd9a4d699dc900a03f79768997b70", size = 342468, upload-time = "2026-09-11T01:03:25.431Z" },
 ]
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.27"
+version = "0.5.28"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -1406,6 +1406,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "yutori", specifier = "==0.9.25" },
+    { name = "yutori", specifier = "==0.9.26" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
Cuts 0.5.28, pinning SDK 0.9.26.

## What 0.9.26 brings

A running shell command's output now **streams into the run-command card** instead of leaving a spinner up for the command's whole duration ([yutori-sdk-python#435](https://github.com/yutori-ai/yutori-sdk-python/pull/435)). `_run_foreground_shell` ended at `process.communicate()`, which returns once at exit — so a 30-second `ping` reported nothing for 30 seconds.

It also re-bundles `yutori-navigator-overlay-runtime==0.5.1` ([yutori#13319](https://github.com/yutori-ai/yutori/pull/13319)), which grows the card's output block from two rendered rows to four.

## Gates

All three doctor gates move this time. The artifact and installed-distribution digests follow the new wheel as usual; **the provenance digest moves too**, which the last few bumps did not — 0.9.26 re-vendors the renderer rather than leaving it alone.

| Gate | Value |
|---|---|
| `SDK_VERSION` | `0.9.26` |
| `SDK_ARTIFACT_SHA256` | `d4fa68c2…` |
| `SDK_INSTALLATION_SHA256` | `044ba07b…` |
| `SDK_PROVENANCE_SHA256` | `04ccce6b…` |

Computed from the published `yutori-0.9.26-py3-none-any.whl` through preflight's own `_stable_distribution_digest` / `_provenance_path`, not by hand. The artifact digest was cross-checked against the convention by confirming 0.5.27's pinned value still matches PyPI's 0.9.25 wheel digest.

## Testing

- `500 passed, 1 skipped`.
- **`computer-use doctor` passes 14/14 against a clean, non-editable install of this branch** — no `YUTORI_MCP_ALLOW_EDITABLE_SDK` override. That is the gate actually accepting the pins rather than being stepped around, and it reports all three digests back verbatim.
- Live-verified upstream on a real Mac: a 20-second `ping` streaming into the four-row card off the published 0.5.1 bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and SHA256 pin updates only; computer-use doctor gates stay the same mechanism with new SDK artifact values.
> 
> **Overview**
> **Release 0.5.28** bumps `yutori-mcp` and pins **`yutori==0.9.26`** in `pyproject.toml`, with matching updates in `uv.lock`.
> 
> Computer-use runtime gates in `constants.py` move to **0.9.26**: `SDK_VERSION` and all three doctor digests (`SDK_ARTIFACT_SHA256`, `SDK_INSTALLATION_SHA256`, `SDK_PROVENANCE_SHA256`). The dependency comment notes **0.9.26** behavior—streaming foreground shell output into the run-command card (instead of a long spinner) and **navigator overlay runtime 0.5.1** (four-row output block).
> 
> Tests in `test_runtime_constants_select_latest_python_surface` assert the new pin and `pyproject.toml` alignment. No application logic changes beyond version and checksum pins.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c3f9a18d7614a4d63b273aeb0868b3e02c1cd42. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->