### PR TITLE
docs: document --json and --hide-stop-item computer-use run flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,8 @@ Write the prompt so the run has a finish line:
 | `--max-steps N` | `60` | Model turns before stopping; one turn can take several actions |
 | `--mode background` | `foreground` | Drives only `--app`'s window, without taking focus. Requires `--app` |
 | `--allow-foreground-fallback` | off | Background only: retry a missed action with the window briefly fronted |
+| `--json` | off | Emit JSON lines instead of terminal text, for a host application that renders progress itself |
+| `--hide-stop-item` | off | Do not show the SDK's menu bar Stop item; the host application provides its own (the hotkey stays active) |
 | `--env dev` | production | Runs against `platform.dev.yutori.com`. Goes before the subcommand: `yutori-mcp --env dev computer-use run "…"` |
 
 **Foreground** (the default) drives the whole visible desktop — don't touch the Mac while it


### PR DESCRIPTION
## What

Daily doc/test-drift audit found the README had fallen out of sync with a commit merged in the last 24 hours.

**#303** (`feat(computer-use): embedded driver host mode and a JSON CLI surface`) added two new flags to `computer-use run` in `src/yutori_mcp/computer_use/cli.py`:
- `--json` — emit JSON lines instead of terminal text, for a host application that renders progress itself
- `--hide-stop-item` — suppress the SDK's menu bar Stop item, for a host application that provides its own (the hotkey stays active)

Neither flag was added to the README's flag reference table, so the documented CLI surface silently fell behind the actual one.

## What changed

Doc-only change to `README.md`: added both flags to the existing flag table, right after `--allow-foreground-fallback` and before `--env dev`, matching the existing table's format and using the same help text as the CLI's own `--help` output.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7W4RiAGTteb3BwH8A5MNE

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7W4RiAGTteb3BwH8A5MNE)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> README-only update; no code or CLI behavior changes.
> 
> **Overview**
> Brings the **computer-use run** flag reference in `README.md` back in line with the CLI after embedded host / JSON output landed in **#303**.
> 
> The table now documents **`--json`** (JSON lines on stdout for a host app to render progress) and **`--hide-stop-item`** (hide the SDK menu bar Stop control while keeping the stop hotkey), inserted after `--allow-foreground-fallback` with wording aligned to `--help`. **Documentation only** — no runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3eb6c49b8b992dd8bca0d2173d939bee604d07ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->