### PR TITLE
refactor(computer-use): share compact_json_line() across the JSONL writers

### DIFF
--- a/src/yutori_mcp/computer_use/cli.py
+++ b/src/yutori_mcp/computer_use/cli.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import asyncio
 import hashlib
-import json
 import os
 import subprocess
 import tempfile
@@ -41,6 +40,7 @@ from .preflight import (
 )
 from .result import (
     Terminal,
+    compact_json_line,
     describe_delivery_surface,
     elapsed_ms_since,
     format_duration,
@@ -55,7 +55,7 @@ from .supervisor import run_task_with_resolved_credentials, stop_active_run
 
 def _json_line(payload: dict[str, Any]) -> None:
     """One machine-readable stdout line; the `--json` surface a host application consumes."""
-    print(json.dumps(payload, separators=(",", ":")), flush=True)
+    print(compact_json_line(payload), flush=True)
 
 
 def _doctor(*, json_output: bool = False) -> int:

--- a/src/yutori_mcp/computer_use/preflight.py
+++ b/src/yutori_mcp/computer_use/preflight.py
@@ -31,7 +31,7 @@ from .constants import (
     SDK_VERSION,
     TOOL_SET,
 )
-from .result import structured_content
+from .result import compact_json_line, structured_content
 
 DRIVER_APP = Path("/Applications/CuaDriver.app")
 DRIVER_PATHS = (
@@ -495,7 +495,7 @@ def _embedded_permissions(host: EmbeddedDriverHost) -> dict[str, Any]:
     )
     try:
         assert process.stdin is not None and process.stdout is not None
-        process.stdin.write("".join(json.dumps(message, separators=(",", ":")) + "\n" for message in messages))
+        process.stdin.write("".join(compact_json_line(message) + "\n" for message in messages))
         process.stdin.flush()
         result = _read_rpc_result(process.stdout, request_id=2, timeout=_EMBEDDED_RPC_TIMEOUT_SECONDS)
     finally:

--- a/src/yutori_mcp/computer_use/result.py
+++ b/src/yutori_mcp/computer_use/result.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import shutil
 import sys
@@ -16,6 +17,21 @@ REDACTED = "[REDACTED]"
 def format_runtime_version(paint: "Terminal") -> str:
     """The exact MCP and SDK packages executing a computer-use run."""
     return f"yutori-mcp {MCP_VERSION}  {paint.glyph('separator')}  yutori {SDK_VERSION}"
+
+
+def compact_json_line(payload: dict[str, Any]) -> str:
+    """Serialize ``payload`` as one compact JSON line, with no trailing newline.
+
+    Single source of truth for the ``separators=(",", ":")`` line-oriented encoding
+    shared by every JSONL protocol boundary in this package: the runner's stdout
+    events (``runner.Emitter.emit``), the supervisor's request write to the runner's
+    stdin (``supervisor._supervise``), the embedded-driver-host RPC messages
+    (``preflight._embedded_permissions``), and the CLI's own ``--json`` output lines
+    (``cli._json_line``). Each independently reconstructed the same ``json.dumps``
+    call before this existed, so the separators argument that keeps every writer
+    compact and newline-safe could drift out of sync across the four call sites.
+    """
+    return json.dumps(payload, separators=(",", ":"))
 
 
 def redact(text: str, secret: str) -> str:

--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -39,7 +39,7 @@ from .constants import (
     SDK_VERSION,
     TOOL_SET,
 )
-from .result import elapsed_ms_since, redact, remaining_seconds
+from .result import compact_json_line, elapsed_ms_since, redact, remaining_seconds
 from .targeting import TargetGuardedMacOSComputer as MacOSComputer
 
 _FOREGROUND_OPENING = "You control the entire macOS screen. "
@@ -237,7 +237,7 @@ class Emitter:
         self._stream = stream
 
     def emit(self, event: dict[str, Any]) -> None:
-        self._stream.write(json.dumps(event, separators=(",", ":")) + "\n")
+        self._stream.write(compact_json_line(event) + "\n")
         self._stream.flush()
 
 

--- a/src/yutori_mcp/computer_use/supervisor.py
+++ b/src/yutori_mcp/computer_use/supervisor.py
@@ -34,7 +34,7 @@ from .preflight import (
     child_search_path,
     find_cua_driver,
 )
-from .result import failure, redact
+from .result import compact_json_line, failure, redact
 from .result import remaining_seconds as _remaining_seconds
 from .result import terminal_result
 
@@ -330,7 +330,7 @@ async def _supervise(
         return failure(f"Computer-use runner {detail}", actions=actions, delivery_mode=mode)
 
     try:
-        process.stdin.write(json.dumps(request, separators=(",", ":")).encode() + b"\n")
+        process.stdin.write(compact_json_line(request).encode() + b"\n")
         await process.stdin.drain()
         process.stdin.close()
         await process.stdin.wait_closed()


### PR DESCRIPTION
## What

`runner.py`, `supervisor.py`, `preflight.py`, and `cli.py` each independently wrote
`json.dumps(payload, separators=(",", ":"))` to produce one compact, newline-safe
JSON line for their own leg of the runner/supervisor JSONL protocol (or the CLI's
`--json` output). Extracted the shared `compact_json_line()` helper into
`result.py` — this package's existing home for other cross-cutting helpers like
`redact()` and `structured_content()` — and pointed all four call sites at it.

## Why it's an improvement

The exact same non-default `separators` argument was hand-copied at four
independent call sites. A future change to the wire encoding (or just fixing a
typo in the separators) would have had to be made in four places at once, with
no compiler or test to catch a spot that was missed. This mirrors the shape of
several prior merged refactors in this repo (e.g. #306's `structured_content()`
extraction, #295's elapsed-ms consolidation).

## Why it's safe

- Purely internal: no MCP tool name, schema, or observable protocol behavior
  changes. `compact_json_line()` calls the exact same `json.dumps(..., separators=(",", ":"))`
  every call site called before, so byte-for-byte output is unchanged.
- Two now-unused `import json` lines were removed (`cli.py`) where nothing else
  in the file used the module anymore; every other file's `import json` is kept
  because it's still used for other `json.loads`/`json.dumps` calls there.
- Full test suite passes (`pytest -q`: 500 passed, 1 skipped, same as before the change).
- `ruff check` passes clean on every changed file.
- Diff is small (5 files, +24/-8) and mechanical enough to verify correctness
  directly from the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016yzkoBD12oG1ZurE188yAs

---
_Generated by [Claude Code](https://claude.ai/code/session_016yzkoBD12oG1ZurE188yAs)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical internal refactor with identical serialization output; no protocol, API, or security surface changes.
> 
> **Overview**
> Introduces **`compact_json_line()`** in `result.py` as the single place that serializes dicts to compact JSON (no spaces after `:`/`,`). **CLI `--json` output**, **runner stdout events**, **supervisor→runner stdin**, and **embedded-driver MCP RPC** in preflight now call this helper instead of duplicating `json.dumps(..., separators=(",", ":"))`.
> 
> Wire format and observable behavior stay the same; **`import json` was dropped from `cli.py`** where it became unused.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10ad65d9e8aee3ed92ab9f50871436c254d9dca0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->