### PR TITLE
refactor(computer-use): extract _prepare_target() for the duplicated launch/bind sequence

### DIFF
--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -789,6 +789,19 @@ async def _bind_window_target(computer: MacOSComputer, target: dict[str, Any]) -
     await computer.set_window_target(MacOSWindowTarget(target["pid"], window_id, app_name=target.get("name")))
 
 
+async def _prepare_target(computer: MacOSComputer, request: dict[str, Any], *, background: bool) -> dict[str, Any]:
+    """Launch/front ``request["app"]`` and, for a background run, bind its window target.
+
+    Shared by the initial prepare and by ``recover_target``'s post-crash re-resolution — both
+    need the identical launch-then-bind sequence, differing only in what they do with the
+    resolved target afterward.
+    """
+    target = await prepare_app(computer, request["app"], request["start_url"], front=not background)
+    if background:
+        await _bind_window_target(computer, target)
+    return target
+
+
 def _action_delivery(computer: MacOSComputer) -> Callable[[], dict[str, Any]]:
     """Delivery facts for one top-level tool call, aggregated over the driver actions it issued.
 
@@ -958,26 +971,12 @@ async def run_request(
                 # A mutating launch/front call invalidates MacOSComputer's cached
                 # pre-launch frame, so there is no need to encode and discard it
                 # before preparing the target.
-                target = await prepare_app(
-                    computer,
-                    request["app"],
-                    request["start_url"],
-                    front=not background,
-                )
+                target = await _prepare_target(computer, request, background=background)
                 computer.target_pid = target["pid"]
-                if background:
-                    await _bind_window_target(computer, target)
                 startup.mark("target")
 
                 async def recover_target() -> int | None:
-                    recovered = await prepare_app(
-                        computer,
-                        request["app"],
-                        request["start_url"],
-                        front=not background,
-                    )
-                    if background:
-                        await _bind_window_target(computer, recovered)
+                    recovered = await _prepare_target(computer, request, background=background)
                     return recovered["pid"]
 
                 computer.recover_target = recover_target

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -2577,6 +2577,29 @@ def test_supports_background_mode_reads_the_sdk_signature(monkeypatch):
     assert runner_module._supports_background_mode() is False
 
 
+async def test_prepare_target_binds_the_window_only_in_background_mode(monkeypatch):
+    prepared = AsyncMock(return_value={"name": "Notes", "pid": 42, "window_id": 7})
+    bind = AsyncMock()
+    monkeypatch.setattr(runner_module, "prepare_app", prepared)
+    monkeypatch.setattr(runner_module, "_bind_window_target", bind)
+    computer = object()
+    request = {"app": "Notes", "start_url": None}
+
+    target = await runner_module._prepare_target(computer, request, background=True)
+
+    assert target == {"name": "Notes", "pid": 42, "window_id": 7}
+    prepared.assert_awaited_once_with(computer, "Notes", None, front=False)
+    bind.assert_awaited_once_with(computer, target)
+
+    prepared.reset_mock()
+    bind.reset_mock()
+    target = await runner_module._prepare_target(computer, request, background=False)
+
+    assert target == {"name": "Notes", "pid": 42, "window_id": 7}
+    prepared.assert_awaited_once_with(computer, "Notes", None, front=True)
+    bind.assert_not_awaited()
+
+
 async def test_run_request_background_binds_the_window_and_never_fronts(monkeypatch):
     _FakeComputer.instances.clear()
     _FakeAgent.instances.clear()


### PR DESCRIPTION
## What

`runner.py::run_request()` prepared an app-scoped target twice: once at startup, and again inside the `recover_target()` closure it hands to the computer for post-crash recovery. Both call sites ran the identical sequence — `prepare_app(computer, request["app"], request["start_url"], front=not background)` followed by a conditional `await _bind_window_target(computer, target)` only when `background` — differing only in what they did with the resolved dict afterward (set `computer.target_pid` vs. return its `pid`).

Extracted `_prepare_target(computer, request, *, background)` next to the `_bind_window_target()` helper it wraps; both call sites now delegate to it.

## Why

This is the same "name a repeated multi-step sequence once its call sites recur" pattern this file already applies elsewhere (`_bind_window_target`, `_result_event`, `_error_event`) — the launch-then-bind sequence is a single conceptual step that had drifted into two copies a future edit (e.g. a new argument to `prepare_app`, or a change to when binding happens) could easily update in one place and miss the other.

## Why it's safe

- Internal-only refactor: no MCP tool contract or schema this server exposes is touched (this repo's macOS `computer_use` runner isn't itself a public MCP tool schema — the tool boundary this instruction cares about — but even so, no argument order, error type, or emitted event shape changed here).
- Strictly behavior-preserving: identical `prepare_app`/`_bind_window_target` calls, same order, same conditionals, at both former call sites.
- The existing end-to-end tests (`test_run_request_background_binds_the_window_and_never_fronts`, `test_run_request_foreground_does_not_encode_the_invalidated_prelaunch_frame`) already exercise both the initial-prepare and `recover_target()` paths through `run_request()` and pass unchanged.
- Added one direct unit test (`test_prepare_target_binds_the_window_only_in_background_mode`) pinning `_prepare_target`'s two branches in isolation.

## Verification

- `uv run --extra dev pytest -q` → **501 passed / 1 skipped** (baseline before this change: 500 passed / 1 skipped, +1 for the new test).
- `uvx ruff check .` → clean.
- `uvx ruff format --check .` → flags the same 16 pre-existing files with or without this diff (confirmed via `git stash`); this repo has no `[tool.ruff]` config and CI's `test.yml` does not run `ruff format`, so this is not a regression.

1 file of production code touched (`src/yutori_mcp/computer_use/runner.py`), plus the test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016eWrWkAAB6YBFKcByLmL4Y


---
_Generated by [Claude Code](https://claude.ai/code/session_016eWrWkAAB6YBFKcByLmL4Y)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor with identical prepare/bind logic; no protocol or MCP contract changes, covered by existing and new tests.
> 
> **Overview**
> **Refactors** the macOS computer-use runner so the duplicated **launch app → optionally bind window** flow lives in one helper, `_prepare_target()`.
> 
> `run_request()` used to inline the same `prepare_app(..., front=not background)` plus background-only `_bind_window_target()` in two places: initial target setup and the `recover_target()` callback after crashes. Both paths now call `_prepare_target(computer, request, background=background)`; behavior and ordering are unchanged.
> 
> A focused unit test asserts background runs bind the window with `front=False`, while foreground runs use `front=True` and skip binding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 395d36682508458c03318fcf50a055735ce2e6e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->