### PR TITLE
refactor(computer-use): share cross-field validation between the schema and runner

### DIFF
--- a/src/yutori_mcp/computer_use/runner.py
+++ b/src/yutori_mcp/computer_use/runner.py
@@ -41,6 +41,7 @@ from .constants import (
 )
 from .result import compact_json_line, elapsed_ms_since, redact, remaining_seconds
 from .targeting import TargetGuardedMacOSComputer as MacOSComputer
+from ..schemas import computer_use_constraint_error
 
 _FOREGROUND_OPENING = "You control the entire macOS screen. "
 _SHARED_CONTEXT = (
@@ -204,15 +205,13 @@ def parse_request(payload: Any) -> dict[str, Any]:
     task = _require_string(payload, "task")
     app = _require_optional_string(payload, "app")
     start_url = _require_optional_string(payload, "start_url")
-    if start_url is not None and app is None:
-        raise RequestError("INVALID_REQUEST", "start_url requires app.")
     mode = _require_mode(payload)
     allow_foreground_fallback = _require_bool(payload, "allow_foreground_fallback")
     allow_local_shell = _require_bool(payload, "allow_local_shell")
-    if mode == DELIVERY_MODE_BACKGROUND and app is None:
-        raise RequestError("INVALID_REQUEST", "mode 'background' requires app.")
-    if allow_foreground_fallback and mode != DELIVERY_MODE_BACKGROUND:
-        raise RequestError("INVALID_REQUEST", "allow_foreground_fallback requires mode 'background'.")
+    if error := computer_use_constraint_error(
+        app=app, start_url=start_url, mode=mode, allow_foreground_fallback=allow_foreground_fallback
+    ):
+        raise RequestError("INVALID_REQUEST", f"{error}.")
     deadline_ms = _require_positive_int(payload, "deadline_ms")
     max_steps = _require_positive_int(payload, "max_steps")
     # Optional so a protocol-v2 supervisor that predates the field keeps the SDK's default.

--- a/src/yutori_mcp/schemas.py
+++ b/src/yutori_mcp/schemas.py
@@ -403,6 +403,30 @@ ComputerUseMode = Literal["foreground", "background"]
 COMPUTER_USE_DEFAULT_MODE: ComputerUseMode = "foreground"
 
 
+def computer_use_constraint_error(
+    *,
+    app: str | None,
+    start_url: str | None,
+    mode: str,
+    allow_foreground_fallback: bool,
+) -> str | None:
+    """The first violated cross-field rule for a computer-use task, or None.
+
+    Shared by ``ComputerUseTaskInput`` below (the MCP tool's client-facing schema) and
+    ``computer_use/runner.py``'s ``parse_request`` (the wire-protocol parser for the JSONL
+    request a validated ``ComputerUseTaskInput.model_dump()`` becomes): both enforce the same
+    three rules on the same fields, so the wording and check order can't drift between the two
+    validation layers.
+    """
+    if start_url is not None and app is None:
+        return "start_url requires app"
+    if mode == "background" and app is None:
+        return "mode='background' requires app"
+    if allow_foreground_fallback and mode != "background":
+        return "allow_foreground_fallback requires mode='background'"
+    return None
+
+
 class ComputerUseTaskInput(ToolInput):
     task: str = Field(..., description="Task to perform on the Mac desktop or in the target app's window")
     app: str | None = Field(default=None, description="Optional application to target")
@@ -444,21 +468,14 @@ class ComputerUseTaskInput(ToolInput):
     )
 
     @model_validator(mode="after")
-    def require_app_for_start_url(self) -> ComputerUseTaskInput:
-        if self.start_url is not None and self.app is None:
-            raise ValueError("start_url requires app")
-        return self
-
-    @model_validator(mode="after")
-    def require_app_for_background(self) -> ComputerUseTaskInput:
-        if self.mode == "background" and self.app is None:
-            raise ValueError("mode='background' requires app")
-        return self
-
-    @model_validator(mode="after")
-    def require_background_for_fallback(self) -> ComputerUseTaskInput:
-        if self.allow_foreground_fallback and self.mode != "background":
-            raise ValueError("allow_foreground_fallback requires mode='background'")
+    def validate_cross_field_constraints(self) -> ComputerUseTaskInput:
+        if error := computer_use_constraint_error(
+            app=self.app,
+            start_url=self.start_url,
+            mode=self.mode,
+            allow_foreground_fallback=self.allow_foreground_fallback,
+        ):
+            raise ValueError(error)
         return self
 
 

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -81,7 +81,13 @@ from yutori_mcp.computer_use.supervisor import (
     python_runner_command,
     run_task,
 )
-from yutori_mcp.schemas import COMPUTER_USE_DEFAULT_MINUTES, COMPUTER_USE_DEFAULT_MODE, ComputerUseMode, ComputerUseTaskInput
+from yutori_mcp.schemas import (
+    COMPUTER_USE_DEFAULT_MINUTES,
+    COMPUTER_USE_DEFAULT_MODE,
+    ComputerUseMode,
+    ComputerUseTaskInput,
+    computer_use_constraint_error,
+)
 
 
 @pytest.mark.parametrize("minutes", [0.9, 60.1])
@@ -2237,6 +2243,32 @@ def test_computer_use_mode_literal_matches_runtime_delivery_modes():
     from typing import get_args
 
     assert set(get_args(ComputerUseMode)) == set(DELIVERY_MODES)
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        (
+            {"app": None, "start_url": "https://x", "mode": "foreground", "allow_foreground_fallback": False},
+            "start_url requires app",
+        ),
+        (
+            {"app": None, "start_url": None, "mode": "background", "allow_foreground_fallback": False},
+            "mode='background' requires app",
+        ),
+        (
+            {"app": "Notes", "start_url": None, "mode": "foreground", "allow_foreground_fallback": True},
+            "allow_foreground_fallback requires mode='background'",
+        ),
+        (
+            {"app": "Notes", "start_url": "https://x", "mode": "background", "allow_foreground_fallback": True},
+            None,
+        ),
+    ],
+)
+def test_computer_use_constraint_error_matches_both_call_sites(kwargs, expected):
+    """ComputerUseTaskInput and runner.parse_request both delegate to this one function."""
+    assert computer_use_constraint_error(**kwargs) == expected
     assert COMPUTER_USE_DEFAULT_MODE == DELIVERY_MODE_FOREGROUND
 
 


### PR DESCRIPTION
## What

`ComputerUseTaskInput` (in `schemas.py`) and `computer_use/runner.py`'s `parse_request()` each independently enforced the same three cross-field rules on the same four fields:

- `start_url` requires `app`
- `mode='background'` requires `app`
- `allow_foreground_fallback` requires `mode='background'`

One expressed them as three separate pydantic `@model_validator(mode="after")` methods; the other as three hand-rolled `if`/`raise RequestError` checks with slightly different message punctuation. Both had to be kept in sync by hand.

Extracted `computer_use_constraint_error()` in `schemas.py` as the single source of truth for the rule text and check order. `ComputerUseTaskInput` now has one validator that raises on the first violation the shared function reports; `parse_request()` calls the same function and wraps its message in a `RequestError`.

## Why it's safe

- Pydantic's chained `@model_validator(mode="after")` methods already stop at the first one that raises (verified locally), so collapsing the three validators into one that raises on the first rule the shared function flags preserves the exact same error surfaced in every existing case.
- `parse_request()`'s tests only assert on the `RequestError.code` ("INVALID_REQUEST"), not exact message text, so reordering the check to run after all four fields are parsed (needed since the shared function takes all four at once) doesn't change any test outcome — verified against every parametrized case in `test_parse_request_rejects_malformed_requests`.
- `computer_use/cli.py` already imports from `..schemas` elsewhere in this package, so `runner.py` importing `computer_use_constraint_error` from `..schemas` adds no new import direction and no circular-import risk (confirmed by importing both modules directly).
- Added a small direct unit test (`test_computer_use_constraint_error_matches_both_call_sites`) pinning the shared function's contract, on top of the existing tests that already exercise it through both `ComputerUseTaskInput` and `parse_request`.

## Verification

- `uv run pytest -q` — 505 passed, 1 skipped (up from 501 passed, 1 skipped on `main`, from the 4 new parametrized cases)
- `uv run ruff check .` — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015od5oiRzaTzBYXv6YbTiG9


---
_Generated by [Claude Code](https://claude.ai/code/session_015od5oiRzaTzBYXv6YbTiG9)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only: same rules and error text, with tests pinning the shared helper; no behavior change beyond unified check ordering after all four fields are parsed in the runner.
> 
> **Overview**
> **Centralizes computer-use cross-field validation** so the MCP schema (`ComputerUseTaskInput`) and the JSONL wire parser (`parse_request` in `runner.py`) cannot drift.
> 
> Adds `computer_use_constraint_error()` in `schemas.py` as the single source of truth for three rules: `start_url` needs `app`, `mode='background'` needs `app`, and `allow_foreground_fallback` only applies in background mode. Pydantic’s three separate `@model_validator` hooks are collapsed into one that raises on the first violation; the runner delegates to the same helper and wraps the message in `RequestError("INVALID_REQUEST", ...)`.
> 
> Adds a parametrized unit test on the shared helper so both validation paths stay aligned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a607edaa5bb87e1ecdf1f7caac152c9df694c87b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->