### PR TITLE
chore(deps): pin cua-driver 0.28.0, release 0.5.29

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.28"
+version = "0.5.29"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"

--- a/skills/06-computer-use/SKILL.md
+++ b/skills/06-computer-use/SKILL.md
@@ -28,7 +28,7 @@ uvx yutori-mcp computer-use smoke
 ```
 
 Requirements: macOS 15+, Python 3.10+, `uvx`, a Yutori API key with computer-use access,
-`CuaDriver.app` / `cua-driver==0.23.2`, and Screen Recording plus Accessibility permissions.
+`CuaDriver.app` / `cua-driver==0.28.0`, and Screen Recording plus Accessibility permissions.
 The optional native reasoning overlay may require Xcode Command Line Tools.
 
 ## Run a Task

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -42,5 +42,5 @@ SDK_PROVENANCE_SHA256 = "04ccce6bc1c85552bdb9ad68fc3973c88c3b4ddf7e2314e9779fc00
 
 # The cua-driver release that implements this tool contract, and the checksum
 # of its installer script. Both are hard gates.
-DRIVER_VERSION = "0.23.2"
+DRIVER_VERSION = "0.28.0"
 DRIVER_INSTALLER_SHA256 = "317ba3a49fdba10f2a7f1b9f392c1bc1b7657f3aae85e1e2e43684cf17a1bf3b"

--- a/uv.lock
+++ b/uv.lock
@@ -1386,7 +1386,7 @@ wheels = [
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.28"
+version = "0.5.29"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },


### PR DESCRIPTION
## Pin cua-driver 0.28.0

Moves `DRIVER_VERSION` from 0.23.2 to 0.28.0, the newest cua-driver release, and cuts yutori-mcp 0.5.29 to carry it.

**Why the two constants next to it do not move**

- `DRIVER_INSTALLER_SHA256` is unchanged: the tag-pinned `install.sh` wrapper is byte-identical from 0.20.0 through 0.28.0.
- The SDK pin stays at `yutori==0.9.26`, which is still the newest release on PyPI, so `SDK_VERSION` and the three SDK digests are untouched.

**Permissions survive the swap.** 0.28.0's `CuaDriver.app` carries the same designated requirement as 0.23.2 (`identifier "com.trycua.driver" ... subject.OU = YCK386LBJ7`), so the 0.22.0+ installer preserves the existing Accessibility and Screen Recording grants rather than forcing a re-grant. Confirmed on a real upgrade — no consent prompt reappeared.

**What we get.** Nothing in 0.24.0–0.28.0 changes the tools this repo drives; the macOS-relevant changes are fixes:

- corrected macOS click delivery and recording evidence ([trycua/cua#2907](https://github.com/trycua/cua/pull/2907))
- persisted macOS direct-capture verification ([#2904](https://github.com/trycua/cua/pull/2904))
- normalized repeated macOS consent labels ([#3706](https://github.com/trycua/cua/pull/3706)), which `computer-use setup` walks the user through
- host identity accepted in the embedded health check ([#2170](https://github.com/trycua/cua/pull/2170)), relevant to the embedded-driver-host path
- `get_window_state` can skip the a11y tree and return capture metadata ([#3516](https://github.com/trycua/cua/pull/3516))

## Verification

On macOS 27 / arm64, after `computer-use setup`:

- `computer-use doctor` — all PASS, `driver contract: 0.28.0`
- `computer-use smoke` — Calculator mechanical and live checks pass on the foreground desktop path
- `computer-use run --app Calculator --mode background` — completes with 0 foreground escalations and 0 background refusals, exercising the window-scoped path where the driver's foreground-focus enforcement lives
- 505 tests pass locally

## Notes

Existing installs: run `yutori-mcp computer-use setup` once. Preflight gates on an exact version match, so doctor reports BLOCKED until the app is upgraded.

yutori SDK 0.9.26 still pins `cua-driver==0.23.2` in its `macos` extra. That does not constrain us — yutori-mcp depends on bare `yutori`, installs the app via `install.sh`, and the SDK has no runtime driver-version gate — but anyone installing `yutori[macos]` will have a 0.23.2 pip package alongside a 0.28.0 app. Worth folding into the SDK's next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency pin and patch release only; installer checksum unchanged and SDK contract unchanged, with upgrade path via existing setup/doctor gates.
> 
> **Overview**
> Bumps the required **cua-driver** / `CuaDriver.app` pin from **0.23.2** to **0.28.0** in `DRIVER_VERSION` and the computer-use skill docs, and releases **yutori-mcp 0.5.29** (`pyproject.toml`, `uv.lock`). The yutori SDK pin (**0.9.26**) and `DRIVER_INSTALLER_SHA256` are unchanged.
> 
> Preflight/doctor still require an exact driver match, so existing Mac installs need **`yutori-mcp computer-use setup`** once to upgrade the app. The PR notes 0.28.0 keeps the same Mac signing identity so Accessibility and Screen Recording grants should carry over without re-consent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52c18850d7531f75fecfd5b5a0259b99b01ad895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->