### PR TITLE
chore(deps): pin yutori 0.9.27, release 0.5.30

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "yutori-mcp"
-version = "0.5.29"
+version = "0.5.30"
 description = "MCP server and workflow skills for building agents with Yutori"
 readme = "README.md"
 license = "Apache-2.0"
@@ -30,11 +30,11 @@ dependencies = [
     # breaks the install as soon as 2.x resolves.
     "mcp>=1.0.0,<2.0.0",
     "pydantic>=2.0.0",
-    # SDK 0.9.26 streams a running shell command's output into that card instead
-    # of holding a spinner for the command's whole duration, and re-bundles
-    # navigator overlay runtime 0.5.1, which grows the card's output block from
-    # two rendered rows to four.
-    "yutori==0.9.26",
+    # SDK 0.9.27 rewrites the three key names n2 spells differently from
+    # cua-driver at the RPC boundary: pageup/pagedown no longer abort a batch
+    # with "Unknown key name", and delete deletes forward instead of erasing
+    # left.
+    "yutori==0.9.27",
 ]
 
 [project.optional-dependencies]

--- a/src/yutori_mcp/computer_use/constants.py
+++ b/src/yutori_mcp/computer_use/constants.py
@@ -33,11 +33,11 @@ DELIVERY_MODES = (DELIVERY_MODE_FOREGROUND, DELIVERY_MODE_BACKGROUND)
 # also hides it from recorders. Read by the runner; the supervisor forwards it to the runner's
 # environment.
 ENV_RECORDABLE_OVERLAY = "YUTORI_RECORDABLE_OVERLAY"
-SDK_VERSION = "0.9.26"
+SDK_VERSION = "0.9.27"
 # The PyPI wheel digest and a digest derived from its stable RECORD entries.
 # Doctor compares the latter with the unpacked installation before any task runs.
-SDK_ARTIFACT_SHA256 = "d4fa68c29d72e26bf470918036c93677e0cfd9a4d699dc900a03f79768997b70"
-SDK_INSTALLATION_SHA256 = "044ba07b30f484f530d516ec0de445a4a42dd791918c2149cf78868ca30fad59"
+SDK_ARTIFACT_SHA256 = "de2408a9c490d34daba53eca0e1eb0d18e680dd71268591d6f52c6dfece35459"
+SDK_INSTALLATION_SHA256 = "f96e99bf98e37e4d86f8421e920826bb846f437bd833caf8e4bd1589f2f75f72"
 SDK_PROVENANCE_SHA256 = "04ccce6bc1c85552bdb9ad68fc3973c88c3b4ddf7e2314e9779fc00a33812c3d"
 
 # The cua-driver release that implements this tool contract, and the checksum

--- a/tests/test_computer_use.py
+++ b/tests/test_computer_use.py
@@ -878,9 +878,9 @@ async def test_server_holds_desktop_lock_across_preflight_and_runner(monkeypatch
 
 def test_runtime_constants_select_latest_python_surface():
     assert TOOL_SET == "computer_use_tools-20260830"
-    assert SDK_VERSION == "0.9.26"
+    assert SDK_VERSION == "0.9.27"
     assert all(len(digest) == 64 for digest in (SDK_ARTIFACT_SHA256, SDK_INSTALLATION_SHA256, SDK_PROVENANCE_SHA256))
-    assert '"yutori==0.9.26"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
+    assert '"yutori==0.9.27"' in Path(__file__).parents[1].joinpath("pyproject.toml").read_text()
 
 
 def test_installed_sdk_matches_the_published_artifact():

--- a/uv.lock
+++ b/uv.lock
@@ -1370,7 +1370,7 @@ wheels = [
 
 [[package]]
 name = "yutori"
-version = "0.9.26"
+version = "0.9.27"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1379,14 +1379,14 @@ dependencies = [
     { name = "rich" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/1f/7ceb4d0cbf03b0b01323fcd4341da3dace2777cb6fded2d47d369832861d/yutori-0.9.26.tar.gz", hash = "sha256:30be3fe62301ec1183a60b31087ec25f7cb2243ae21de43baaf45c47d8958ef2", size = 489587, upload-time = "2026-09-11T01:03:27.196Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/e9/b98c70e89b6b3a84e41ad8d5c75849edd840308ec4c77d59b87e8c009f50/yutori-0.9.27.tar.gz", hash = "sha256:9ad7d3c7e1e343a47066b66144c6d20ca7969cc61377b18dee38c94575cf147c", size = 490242, upload-time = "2026-09-12T00:19:45.011Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/c4/f0a87acd6f5b7b7e535fb7a10c223ccaeec35d52ef088359aa7a27d9b4b4/yutori-0.9.26-py3-none-any.whl", hash = "sha256:d4fa68c29d72e26bf470918036c93677e0cfd9a4d699dc900a03f79768997b70", size = 342468, upload-time = "2026-09-11T01:03:25.431Z" },
+    { url = "https://files.pythonhosted.org/packages/87/de/f59fb0eaf41795d4d62924fde4f5a8d9518bb077125e14b0d7f6485128c1/yutori-0.9.27-py3-none-any.whl", hash = "sha256:de2408a9c490d34daba53eca0e1eb0d18e680dd71268591d6f52c6dfece35459", size = 342817, upload-time = "2026-09-12T00:19:43.139Z" },
 ]
 
 [[package]]
 name = "yutori-mcp"
-version = "0.5.29"
+version = "0.5.30"
 source = { editable = "." }
 dependencies = [
     { name = "mcp" },
@@ -1406,6 +1406,6 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.21.0" },
-    { name = "yutori", specifier = "==0.9.26" },
+    { name = "yutori", specifier = "==0.9.27" },
 ]
 provides-extras = ["dev"]


### PR DESCRIPTION
Picks up SDK [0.9.27](https://github.com/yutori-ai/yutori-sdk-python/releases/tag/v0.9.27), which ships yutori-ai/yutori-sdk-python#440: `key_press` now rewrites the three key names n2 spells differently from cua-driver at the RPC boundary, so `pageup`/`pagedown` no longer abort a batch with "Unknown key name" and `delete` deletes forward instead of erasing left.

- `SDK_VERSION` → 0.9.27, `SDK_ARTIFACT_SHA256` → the published wheel digest, `SDK_INSTALLATION_SHA256` recomputed from a registry install.
- `SDK_PROVENANCE_SHA256` unchanged — `DRIVER_VERSION` stays 0.28.0.
- `yutori==` pin in pyproject (with its comment), the constants test, and uv.lock move together.
- yutori-mcp version → 0.5.30 for the release that follows this merge.

`tests/test_computer_use.py::test_installed_sdk_matches_the_published_artifact` passes against the installed 0.9.27; full suite 505 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical version and checksum alignment with a pinned SDK; main user-visible change is corrected keyboard semantics in computer-use runs, with preflight still enforcing the expected wheel.
> 
> **Overview**
> **Bumps `yutori-mcp` to 0.5.30** and pins **`yutori==0.9.27`**, picking up SDK fixes for `key_press` name mapping at the cua-driver RPC boundary (`pageup`/`pagedown` no longer fail batches; `delete` is forward-delete).
> 
> Runtime provenance moves with the release: `SDK_VERSION`, wheel/installation SHA256 digests in `constants.py`, the `pyproject.toml` pin comment, `test_runtime_constants_select_latest_python_surface`, and `uv.lock`. **`SDK_PROVENANCE_SHA256` and `DRIVER_VERSION` (0.28.0) are unchanged.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f6cf0202c6eb783d442828b0a907ef482daf80c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->